### PR TITLE
Compile with C++11 turned on

### DIFF
--- a/kinematics_base_test/CMakeLists.txt
+++ b/kinematics_base_test/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(kinematics_base_test)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   pluginlib

--- a/kinematics_tests_support/CMakeLists.txt
+++ b/kinematics_tests_support/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(kinematics_tests_support)
 
+add_compile_options(-std=c++11)
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages

--- a/kuka_kr210_manipulator_ik_plugin/CMakeLists.txt
+++ b/kuka_kr210_manipulator_ik_plugin/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(kuka_kr210_manipulator_ik_plugin)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   pluginlib

--- a/motoman_sia20d_ikfast_manipulator_plugin/CMakeLists.txt
+++ b/motoman_sia20d_ikfast_manipulator_plugin/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(motoman_sia20d_ikfast_manipulator_plugin)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   moveit_core
   pluginlib

--- a/test_kuka_kr210_moveit_config/CMakeLists.txt
+++ b/test_kuka_kr210_moveit_config/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(test_kuka_kr210_moveit_config)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED)
 
 catkin_package()

--- a/test_motoman_sia20d_moveit_config/CMakeLists.txt
+++ b/test_motoman_sia20d_moveit_config/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(test_motoman_sia20d_moveit_config)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED)
 
 catkin_package()


### PR DESCRIPTION
This is required now for anything that uses geometric_shapes.

This is only needed for the kinetic-devel branch.
