### PR TITLE
Run clang-format on entire repo

### DIFF
--- a/kinematics_base_test/src/test_kinematics_as_plugin.cpp
+++ b/kinematics_base_test/src/test_kinematics_as_plugin.cpp
@@ -1,62 +1,63 @@
- /*********************************************************************
- * Software License Agreement (BSD License)
- *
- *  Copyright (c) 2008, Willow Garage, Inc.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of Willow Garage nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *********************************************************************/
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
 
 /* Author: Sachin Chitta */
 
-#include <ros/ros.h>
 #include <gtest/gtest.h>
 #include <pluginlib/class_loader.h>
+#include <ros/ros.h>
 
 // MoveIt!
 #include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/rdf_loader/rdf_loader.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
-#include <moveit/rdf_loader/rdf_loader.h>
-#include <urdf/model.h>
 #include <srdfdom/model.h>
+#include <urdf/model.h>
 
 #define IK_NEAR 1e-4
 #define IK_NEAR_TRANSLATE 1e-5
 
 class MyTest
 {
- public:
+public:
   bool initialize()
   {
     double search_discretization;
     ros::NodeHandle nh("~");
-    kinematics_loader_.reset(new pluginlib::ClassLoader<kinematics::KinematicsBase>("moveit_core", "kinematics::KinematicsBase"));
+    kinematics_loader_.reset(new pluginlib::ClassLoader<kinematics::KinematicsBase>("moveit_core", "kinematics::"
+                                                                                                   "KinematicsBase"));
     std::string plugin_name;
     if (!nh.getParam("plugin_name", plugin_name))
     {
@@ -64,12 +65,12 @@ class MyTest
       EXPECT_TRUE(0);
       return false;
     }
-    ROS_INFO("Plugin name: %s",plugin_name.c_str());
+    ROS_INFO("Plugin name: %s", plugin_name.c_str());
     try
     {
       kinematics_solver_ = kinematics_loader_->createInstance(plugin_name);
     }
-    catch(pluginlib::PluginlibException& ex)//handle the class failing to load
+    catch (pluginlib::PluginlibException& ex)  // handle the class failing to load
     {
       ROS_ERROR("The plugin failed to load. Error: %s", ex.what());
       EXPECT_TRUE(0);
@@ -78,7 +79,7 @@ class MyTest
     std::string root_name, tip_name;
     ros::WallTime start_time = ros::WallTime::now();
     bool done = true;
-    while((ros::WallTime::now()-start_time).toSec() <= 5.0)
+    while ((ros::WallTime::now() - start_time).toSec() <= 5.0)
     {
       if (!nh.getParam("root_name", root_name))
       {
@@ -104,30 +105,28 @@ class MyTest
       done = true;
     }
 
-    if(!done)
+    if (!done)
       return false;
 
-    if(kinematics_solver_->initialize("robot_description","right_arm",root_name,tip_name,search_discretization))
+    if (kinematics_solver_->initialize("robot_description", "right_arm", root_name, tip_name, search_discretization))
       return true;
     else
     {
       EXPECT_TRUE(0);
       return false;
     }
-
   };
 
-  void joint_state_callback(const geometry_msgs::Pose &ik_pose,
-                            const std::vector<double> &joint_state,
-                            moveit_msgs::MoveItErrorCodes &error_code)
+  void joint_state_callback(const geometry_msgs::Pose& ik_pose, const std::vector<double>& joint_state,
+                            moveit_msgs::MoveItErrorCodes& error_code)
   {
     std::vector<std::string> link_names;
     link_names.push_back("r_elbow_flex_link");
     std::vector<geometry_msgs::Pose> solutions;
     solutions.resize(1);
-    if(!kinematics_solver_->getPositionFK(link_names,joint_state,solutions))
+    if (!kinematics_solver_->getPositionFK(link_names, joint_state, solutions))
       error_code.val = error_code.PLANNING_FAILED;
-    if(solutions[0].position.z > 0.0)
+    if (solutions[0].position.z > 0.0)
       error_code.val = error_code.SUCCESS;
     else
       error_code.val = error_code.PLANNING_FAILED;
@@ -163,10 +162,11 @@ TEST(ArmIKPlugin, getFK)
 {
   rdf_loader::RDFLoader rdf_loader_;
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_.getSRDF();
+  const boost::shared_ptr<srdf::Model>& srdf = rdf_loader_.getSRDF();
   const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf));
-  robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(my_test.kinematics_solver_->getGroupName());
+  robot_model::JointModelGroup* joint_model_group =
+      kinematic_model->getJointModelGroup(my_test.kinematics_solver_->getGroupName());
 
   std::vector<double> seed, fk_values, solution;
   moveit_msgs::MoveItErrorCodes error_code;
@@ -181,7 +181,7 @@ TEST(ArmIKPlugin, getFK)
   int number_fk_tests;
   nh.param("number_fk_tests", number_fk_tests, 100);
 
-  for(unsigned int i=0; i < (unsigned int) number_fk_tests; ++i)
+  for (unsigned int i = 0; i < (unsigned int)number_fk_tests; ++i)
   {
     seed.resize(my_test.kinematics_solver_->getJointNames().size(), 0.0);
     fk_values.resize(my_test.kinematics_solver_->getJointNames().size(), 0.0);
@@ -200,12 +200,13 @@ TEST(ArmIKPlugin, searchIK)
 {
   rdf_loader::RDFLoader rdf_loader_;
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf_model = rdf_loader_.getSRDF();
+  const boost::shared_ptr<srdf::Model>& srdf_model = rdf_loader_.getSRDF();
   const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
-  robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(my_test.kinematics_solver_->getGroupName());
+  robot_model::JointModelGroup* joint_model_group =
+      kinematic_model->getJointModelGroup(my_test.kinematics_solver_->getGroupName());
 
-  //Test inverse kinematics
+  // Test inverse kinematics
   std::vector<double> seed, fk_values, solution;
   double timeout = 5.0;
   moveit_msgs::MoveItErrorCodes error_code;
@@ -215,7 +216,8 @@ TEST(ArmIKPlugin, searchIK)
   fk_names.push_back(my_test.kinematics_solver_->getTipFrame());
 
   robot_state::RobotState kinematic_state(kinematic_model);
-  //  robot_state::JointStateGroup* joint_state_group = kinematic_state.getJointStateGroup(my_test.kinematics_solver_->getGroupName());
+  //  robot_state::JointStateGroup* joint_state_group =
+  //  kinematic_state.getJointStateGroup(my_test.kinematics_solver_->getGroupName());
 
   ros::NodeHandle nh("~");
   int number_ik_tests;
@@ -223,7 +225,7 @@ TEST(ArmIKPlugin, searchIK)
   unsigned int success = 0;
 
   ros::WallTime start_time = ros::WallTime::now();
-  for(unsigned int i=0; i < (unsigned int) number_ik_tests; ++i)
+  for (unsigned int i = 0; i < (unsigned int)number_ik_tests; ++i)
   {
     seed.resize(my_test.kinematics_solver_->getJointNames().size(), 0.0);
     fk_values.resize(my_test.kinematics_solver_->getJointNames().size(), 0.0);
@@ -237,9 +239,10 @@ TEST(ArmIKPlugin, searchIK)
     ASSERT_TRUE(result_fk);
 
     bool result = my_test.kinematics_solver_->searchPositionIK(poses[0], seed, timeout, solution, error_code);
-    ROS_DEBUG("Pose: %f %f %f",poses[0].position.x, poses[0].position.y, poses[0].position.z);
-    ROS_DEBUG("Orient: %f %f %f %f",poses[0].orientation.x, poses[0].orientation.y, poses[0].orientation.z, poses[0].orientation.w);
-    if(result)
+    ROS_DEBUG("Pose: %f %f %f", poses[0].position.x, poses[0].position.y, poses[0].position.z);
+    ROS_DEBUG("Orient: %f %f %f %f", poses[0].orientation.x, poses[0].orientation.y, poses[0].orientation.z,
+              poses[0].orientation.w);
+    if (result)
     {
       success++;
       result = my_test.kinematics_solver_->getPositionIK(poses[0], solution, solution, error_code);
@@ -259,23 +262,24 @@ TEST(ArmIKPlugin, searchIK)
     EXPECT_NEAR(poses[0].orientation.z, new_poses[0].orientation.z, IK_NEAR);
     EXPECT_NEAR(poses[0].orientation.w, new_poses[0].orientation.w, IK_NEAR);
   }
-  ROS_INFO("Success Rate: %f",(double)success/number_ik_tests);
+  ROS_INFO("Success Rate: %f", (double)success / number_ik_tests);
   bool success_count = (success > 0.99 * number_ik_tests);
   EXPECT_TRUE(success_count);
-  ROS_INFO("Elapsed time: %f", (ros::WallTime::now()-start_time).toSec());
+  ROS_INFO("Elapsed time: %f", (ros::WallTime::now() - start_time).toSec());
 }
 
 TEST(ArmIKPlugin, searchIKWithCallbacks)
 {
   rdf_loader::RDFLoader rdf_loader_;
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader_.getSRDF();
+  const boost::shared_ptr<srdf::Model>& srdf = rdf_loader_.getSRDF();
   const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf));
-  robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(my_test.kinematics_solver_->getGroupName());
+  robot_model::JointModelGroup* joint_model_group =
+      kinematic_model->getJointModelGroup(my_test.kinematics_solver_->getGroupName());
 
-  //Test inverse kinematics
-  std::vector<double> seed,fk_values,solution;
+  // Test inverse kinematics
+  std::vector<double> seed, fk_values, solution;
   double timeout = 5.0;
   moveit_msgs::MoveItErrorCodes error_code;
   solution.resize(my_test.kinematics_solver_->getJointNames().size(), 0.0);
@@ -284,7 +288,8 @@ TEST(ArmIKPlugin, searchIKWithCallbacks)
   fk_names.push_back(my_test.kinematics_solver_->getTipFrame());
 
   robot_state::RobotState kinematic_state(kinematic_model);
-  //  robot_state::JointStateGroup* joint_state_group = kinematic_state.getJointStateGroup(my_test.kinematics_solver_->getGroupName());
+  //  robot_state::JointStateGroup* joint_state_group =
+  //  kinematic_state.getJointStateGroup(my_test.kinematics_solver_->getGroupName());
 
   ros::NodeHandle nh("~");
   int number_ik_tests;
@@ -292,7 +297,7 @@ TEST(ArmIKPlugin, searchIKWithCallbacks)
   unsigned int success = 0;
   unsigned int num_actual_tests = 0;
 
-  for(unsigned int i=0; i < (unsigned int) number_ik_tests; ++i)
+  for (unsigned int i = 0; i < (unsigned int)number_ik_tests; ++i)
   {
     seed.resize(my_test.kinematics_solver_->getJointNames().size(), 0.0);
     fk_values.resize(my_test.kinematics_solver_->getJointNames().size(), 0.0);
@@ -304,14 +309,15 @@ TEST(ArmIKPlugin, searchIKWithCallbacks)
     poses.resize(1);
     bool result_fk = my_test.kinematics_solver_->getPositionFK(fk_names, fk_values, poses);
     ASSERT_TRUE(result_fk);
-    if(poses[0].position.z < 0.0)
+    if (poses[0].position.z < 0.0)
       continue;
 
     num_actual_tests++;
-    bool result = my_test.kinematics_solver_->searchPositionIK(poses[0], seed, timeout, solution,
-                                                              boost::bind(&MyTest::joint_state_callback, &my_test, _1, _2, _3), error_code);
+    bool result = my_test.kinematics_solver_->searchPositionIK(
+        poses[0], seed, timeout, solution, boost::bind(&MyTest::joint_state_callback, &my_test, _1, _2, _3),
+        error_code);
 
-    if(result)
+    if (result)
     {
       success++;
       std::vector<geometry_msgs::Pose> new_poses;
@@ -328,16 +334,15 @@ TEST(ArmIKPlugin, searchIKWithCallbacks)
       EXPECT_NEAR(poses[0].orientation.w, new_poses[0].orientation.w, IK_NEAR);
     }
 
-    if(!ros::ok())
+    if (!ros::ok())
       break;
   }
-  ROS_INFO("Success with callbacks (%%): %f",(double)success/num_actual_tests*100.0);
+  ROS_INFO("Success with callbacks (%%): %f", (double)success / num_actual_tests * 100.0);
 }
 
-
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init (argc, argv, "right_arm_kinematics");
+  ros::init(argc, argv, "right_arm_kinematics");
   return RUN_ALL_TESTS();
 }

--- a/kinematics_base_test/src/test_kinematics_plugin.cpp
+++ b/kinematics_base_test/src/test_kinematics_plugin.cpp
@@ -1,14 +1,14 @@
-#include <ros/ros.h>
 #include <gtest/gtest.h>
 #include <pluginlib/class_loader.h>
+#include <ros/ros.h>
 
 // MoveIt!
 #include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/rdf_loader/rdf_loader.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_state/robot_state.h>
-#include <moveit/rdf_loader/rdf_loader.h>
-#include <urdf/model.h>
 #include <srdfdom/model.h>
+#include <urdf/model.h>
 
 #define IK_NEAR 1e-4
 #define IK_NEAR_TRANSLATE 1e-5
@@ -16,7 +16,7 @@
 typedef pluginlib::ClassLoader<kinematics::KinematicsBase> KinematicsLoader;
 
 const std::string PLUGIN_NAME_PARAM = "ik_plugin_name";
-const std::string GROUP_PARAM  = "group";
+const std::string GROUP_PARAM = "group";
 const std::string TIP_LINK_PARAM = "tip_link";
 const std::string ROOT_LINK_PARAM = "root_link";
 const std::string ROBOT_DESCRIPTION_PARAM = "robot_description";
@@ -30,7 +30,6 @@ const double DEFAULT_SEARCH_DISCRETIZATION = 0.01f;
 class KinematicsTest
 {
 public:
-
   bool initialize()
   {
     ros::NodeHandle ph("~");
@@ -38,33 +37,33 @@ public:
 
     // loading plugin
     kinematics_loader_.reset(new KinematicsLoader("moveit_core", "kinematics::KinematicsBase"));
-    if(ph.getParam(PLUGIN_NAME_PARAM,plugin_name))
+    if (ph.getParam(PLUGIN_NAME_PARAM, plugin_name))
     {
       try
       {
-        ROS_INFO_STREAM("Loading "<<plugin_name);
+        ROS_INFO_STREAM("Loading " << plugin_name);
         kinematics_solver_ = kinematics_loader_->createInstance(plugin_name);
       }
-      catch(pluginlib::PluginlibException& e)
+      catch (pluginlib::PluginlibException& e)
       {
-        ROS_ERROR_STREAM("Plugin failed to load: "<<e.what());
+        ROS_ERROR_STREAM("Plugin failed to load: " << e.what());
         EXPECT_TRUE(false);
         return false;
       }
-
     }
     else
     {
-      ROS_ERROR_STREAM("The plugin "<<plugin_name<<" was not found");
+      ROS_ERROR_STREAM("The plugin " << plugin_name << " was not found");
       EXPECT_TRUE(false);
       return false;
     }
 
     // initializing plugin
-    if(ph.getParam(GROUP_PARAM,group_name_) && ph.getParam(TIP_LINK_PARAM,tip_link_) &&
-        ph.getParam(ROOT_LINK_PARAM,root_link_) && ph.getParam(JOINT_NAMES_PARAM,joints_))
+    if (ph.getParam(GROUP_PARAM, group_name_) && ph.getParam(TIP_LINK_PARAM, tip_link_) &&
+        ph.getParam(ROOT_LINK_PARAM, root_link_) && ph.getParam(JOINT_NAMES_PARAM, joints_))
     {
-      if(kinematics_solver_->initialize(ROBOT_DESCRIPTION_PARAM,group_name_,root_link_,tip_link_,DEFAULT_SEARCH_DISCRETIZATION))
+      if (kinematics_solver_->initialize(ROBOT_DESCRIPTION_PARAM, group_name_, root_link_, tip_link_,
+                                         DEFAULT_SEARCH_DISCRETIZATION))
       {
         ROS_INFO_STREAM("Kinematics Solver plugin initialzed");
       }
@@ -83,10 +82,8 @@ public:
     }
 
     // loading test details parameters
-    if(ph.getParam(NUM_FK_TESTS,num_fk_tests_) &&
-        ph.getParam(NUM_IK_CB_TESTS,num_ik_cb_tests_) &&
-        ph.getParam(NUM_IK_TESTS,num_ik_tests_) &&
-        ph.getParam(NUM_IK_MULTIPLE_TESTS,num_ik_multiple_tests_))
+    if (ph.getParam(NUM_FK_TESTS, num_fk_tests_) && ph.getParam(NUM_IK_CB_TESTS, num_ik_cb_tests_) &&
+        ph.getParam(NUM_IK_TESTS, num_ik_tests_) && ph.getParam(NUM_IK_MULTIPLE_TESTS, num_ik_multiple_tests_))
     {
       ROS_INFO_STREAM("Loaded test parameters");
     }
@@ -99,30 +96,27 @@ public:
     return true;
   }
 
-  void searchIKCallback(const geometry_msgs::Pose &ik_pose,
-                            const std::vector<double> &joint_state,
-                            moveit_msgs::MoveItErrorCodes &error_code)
+  void searchIKCallback(const geometry_msgs::Pose& ik_pose, const std::vector<double>& joint_state,
+                        moveit_msgs::MoveItErrorCodes& error_code)
   {
     std::vector<std::string> link_names;
     link_names.push_back(tip_link_);
     std::vector<geometry_msgs::Pose> solutions;
     solutions.resize(1);
-    if(!kinematics_solver_->getPositionFK(link_names,joint_state,solutions))
+    if (!kinematics_solver_->getPositionFK(link_names, joint_state, solutions))
     {
       error_code.val = error_code.PLANNING_FAILED;
       return;
     }
 
-    EXPECT_GT(solutions[0].position.z,0.0f);
-    if(solutions[0].position.z > 0.0)
+    EXPECT_GT(solutions[0].position.z, 0.0f);
+    if (solutions[0].position.z > 0.0)
       error_code.val = error_code.SUCCESS;
     else
       error_code.val = error_code.PLANNING_FAILED;
   };
 
-
 public:
-
   kinematics::KinematicsBasePtr kinematics_solver_;
   boost::shared_ptr<KinematicsLoader> kinematics_loader_;
   std::string root_link_;
@@ -147,26 +141,26 @@ TEST(IKFastPlugin, initialize)
   std::vector<std::string> joint_names = kinematics_test.kinematics_solver_->getJointNames();
   EXPECT_EQ((int)joint_names.size(), kinematics_test.joints_.size());
 
-  for(unsigned int i = 0;i < joint_names.size();i++)
+  for (unsigned int i = 0; i < joint_names.size(); i++)
   {
-
-    std::vector<std::string>::iterator pos = std::find(kinematics_test.joints_.begin(),kinematics_test.joints_.end(),joint_names[i]);
-    EXPECT_TRUE(pos != kinematics_test.joints_.end()) << "Joint "<<joint_names[i]<<" not found in list";
+    std::vector<std::string>::iterator pos =
+        std::find(kinematics_test.joints_.begin(), kinematics_test.joints_.end(), joint_names[i]);
+    EXPECT_TRUE(pos != kinematics_test.joints_.end()) << "Joint " << joint_names[i] << " not found in list";
   }
 }
-
 
 TEST(IKFastPlugin, getFK)
 {
   // loading robot model
   rdf_loader::RDFLoader rdf_loader(ROBOT_DESCRIPTION_PARAM);
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
+  const boost::shared_ptr<srdf::Model>& srdf = rdf_loader.getSRDF();
   const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf));
 
   // fk solution setup
-  robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(kinematics_test.kinematics_solver_->getGroupName());
+  robot_model::JointModelGroup* joint_model_group =
+      kinematic_model->getJointModelGroup(kinematics_test.kinematics_solver_->getGroupName());
   std::vector<double> seed, fk_values, solution;
   moveit_msgs::MoveItErrorCodes error_code;
   solution.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
@@ -177,7 +171,7 @@ TEST(IKFastPlugin, getFK)
   bool succeeded;
   int success = 0;
   ros::WallTime start_time = ros::WallTime::now();
-  for(unsigned int i=0; i < kinematics_test.num_fk_tests_; ++i)
+  for (unsigned int i = 0; i < kinematics_test.num_fk_tests_; ++i)
   {
     seed.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
     fk_values.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
@@ -186,28 +180,28 @@ TEST(IKFastPlugin, getFK)
     std::vector<geometry_msgs::Pose> poses;
     poses.resize(1);
     succeeded = kinematics_test.kinematics_solver_->getPositionFK(fk_names, fk_values, poses);
-    if(succeeded && (poses.size() == 1))
+    if (succeeded && (poses.size() == 1))
     {
       success++;
     }
   }
 
-  ROS_INFO_STREAM("Success Rate: "<<(double)success/kinematics_test.num_fk_tests_);
-  EXPECT_GT(success , 0.99 * kinematics_test.num_fk_tests_);
-  ROS_INFO_STREAM("Elapsed time: "<< (ros::WallTime::now()-start_time).toSec());
+  ROS_INFO_STREAM("Success Rate: " << (double)success / kinematics_test.num_fk_tests_);
+  EXPECT_GT(success, 0.99 * kinematics_test.num_fk_tests_);
+  ROS_INFO_STREAM("Elapsed time: " << (ros::WallTime::now() - start_time).toSec());
 }
-
 
 TEST(IKFastPlugin, searchIK)
 {
   rdf_loader::RDFLoader rdf_loader_(ROBOT_DESCRIPTION_PARAM);
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf_model = rdf_loader_.getSRDF();
+  const boost::shared_ptr<srdf::Model>& srdf_model = rdf_loader_.getSRDF();
   const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
-  robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(kinematics_test.kinematics_solver_->getGroupName());
+  robot_model::JointModelGroup* joint_model_group =
+      kinematic_model->getJointModelGroup(kinematics_test.kinematics_solver_->getGroupName());
 
-  //Test inverse kinematics
+  // Test inverse kinematics
   std::vector<double> seed, fk_values, solution;
   double timeout = 5.0;
   moveit_msgs::MoveItErrorCodes error_code;
@@ -218,7 +212,7 @@ TEST(IKFastPlugin, searchIK)
 
   unsigned int success = 0;
   ros::WallTime start_time = ros::WallTime::now();
-  for(unsigned int i=0; i < kinematics_test.num_ik_tests_; ++i)
+  for (unsigned int i = 0; i < kinematics_test.num_ik_tests_; ++i)
   {
     seed.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
     fk_values.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
@@ -233,22 +227,23 @@ TEST(IKFastPlugin, searchIK)
     kinematics_test.kinematics_solver_->searchPositionIK(poses[0], seed, timeout, solution, error_code);
     bool result = error_code.val == error_code.SUCCESS;
 
-    ROS_DEBUG("Pose: %f %f %f",poses[0].position.x, poses[0].position.y, poses[0].position.z);
-    ROS_DEBUG("Orient: %f %f %f %f",poses[0].orientation.x, poses[0].orientation.y, poses[0].orientation.z, poses[0].orientation.w);
+    ROS_DEBUG("Pose: %f %f %f", poses[0].position.x, poses[0].position.y, poses[0].position.z);
+    ROS_DEBUG("Orient: %f %f %f %f", poses[0].orientation.x, poses[0].orientation.y, poses[0].orientation.z,
+              poses[0].orientation.w);
 
-    if(result)
+    if (result)
     {
       EXPECT_TRUE(kinematics_test.kinematics_solver_->getPositionIK(poses[0], solution, solution, error_code));
       result = error_code.val == error_code.SUCCESS;
     }
 
-    if(result)
+    if (result)
     {
       success++;
     }
     else
     {
-      ROS_ERROR_STREAM("searchPositionIK failed on test "<<i+1);
+      ROS_ERROR_STREAM("searchPositionIK failed on test " << i + 1);
       continue;
     }
 
@@ -264,22 +259,22 @@ TEST(IKFastPlugin, searchIK)
     EXPECT_NEAR(poses[0].orientation.w, new_poses[0].orientation.w, IK_NEAR);
   }
 
-
-  ROS_INFO_STREAM("Success Rate: "<<(double)success/kinematics_test.num_ik_tests_);
-  EXPECT_GT(success , 0.99 * kinematics_test.num_ik_tests_);
-  ROS_INFO_STREAM("Elapsed time: "<< (ros::WallTime::now()-start_time).toSec());
+  ROS_INFO_STREAM("Success Rate: " << (double)success / kinematics_test.num_ik_tests_);
+  EXPECT_GT(success, 0.99 * kinematics_test.num_ik_tests_);
+  ROS_INFO_STREAM("Elapsed time: " << (ros::WallTime::now() - start_time).toSec());
 }
 
 TEST(IKFastPlugin, searchIKWithCallback)
 {
   rdf_loader::RDFLoader rdf_loader_(ROBOT_DESCRIPTION_PARAM);
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf_model = rdf_loader_.getSRDF();
+  const boost::shared_ptr<srdf::Model>& srdf_model = rdf_loader_.getSRDF();
   const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
-  robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(kinematics_test.kinematics_solver_->getGroupName());
+  robot_model::JointModelGroup* joint_model_group =
+      kinematic_model->getJointModelGroup(kinematics_test.kinematics_solver_->getGroupName());
 
-  //Test inverse kinematics
+  // Test inverse kinematics
   std::vector<double> seed, fk_values, solution;
   double timeout = 5.0;
   moveit_msgs::MoveItErrorCodes error_code;
@@ -290,7 +285,7 @@ TEST(IKFastPlugin, searchIKWithCallback)
 
   unsigned int success = 0;
   ros::WallTime start_time = ros::WallTime::now();
-  for(unsigned int i=0; i < kinematics_test.num_ik_cb_tests_; ++i)
+  for (unsigned int i = 0; i < kinematics_test.num_ik_cb_tests_; ++i)
   {
     seed.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
     fk_values.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
@@ -303,33 +298,34 @@ TEST(IKFastPlugin, searchIKWithCallback)
     ASSERT_TRUE(result_fk);
 
     // check height
-    if(poses[0].position.z <= 0.0f)
+    if (poses[0].position.z <= 0.0f)
     {
       continue;
     }
 
     solution.clear();
-    kinematics_test.kinematics_solver_->searchPositionIK(poses[0], fk_values, timeout, solution,
-                                                                 boost::bind(&KinematicsTest::searchIKCallback,&kinematics_test,
-                                                                             _1,_2,_3),error_code);
+    kinematics_test.kinematics_solver_->searchPositionIK(
+        poses[0], fk_values, timeout, solution,
+        boost::bind(&KinematicsTest::searchIKCallback, &kinematics_test, _1, _2, _3), error_code);
     bool result = error_code.val == error_code.SUCCESS;
 
-    ROS_DEBUG("Pose: %f %f %f",poses[0].position.x, poses[0].position.y, poses[0].position.z);
-    ROS_DEBUG("Orient: %f %f %f %f",poses[0].orientation.x, poses[0].orientation.y, poses[0].orientation.z, poses[0].orientation.w);
+    ROS_DEBUG("Pose: %f %f %f", poses[0].position.x, poses[0].position.y, poses[0].position.z);
+    ROS_DEBUG("Orient: %f %f %f %f", poses[0].orientation.x, poses[0].orientation.y, poses[0].orientation.z,
+              poses[0].orientation.w);
 
-    if(result)
+    if (result)
     {
       EXPECT_TRUE(kinematics_test.kinematics_solver_->getPositionIK(poses[0], solution, solution, error_code));
       result = error_code.val == error_code.SUCCESS;
     }
 
-    if(result)
+    if (result)
     {
       success++;
     }
     else
     {
-      ROS_ERROR_STREAM("searchPositionIK failed on test "<<i+1);
+      ROS_ERROR_STREAM("searchPositionIK failed on test " << i + 1);
       continue;
     }
 
@@ -345,23 +341,22 @@ TEST(IKFastPlugin, searchIKWithCallback)
     EXPECT_NEAR(poses[0].orientation.w, new_poses[0].orientation.w, IK_NEAR);
   }
 
-
-  ROS_INFO_STREAM("Success Rate: "<<(double)success/kinematics_test.num_ik_cb_tests_);
-  EXPECT_GT(success , 0.99 * kinematics_test.num_ik_cb_tests_);
-  ROS_INFO_STREAM("Elapsed time: "<< (ros::WallTime::now()-start_time).toSec());
+  ROS_INFO_STREAM("Success Rate: " << (double)success / kinematics_test.num_ik_cb_tests_);
+  EXPECT_GT(success, 0.99 * kinematics_test.num_ik_cb_tests_);
+  ROS_INFO_STREAM("Elapsed time: " << (ros::WallTime::now() - start_time).toSec());
 }
-
 
 TEST(IKFastPlugin, getIK)
 {
   rdf_loader::RDFLoader rdf_loader_(ROBOT_DESCRIPTION_PARAM);
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf_model = rdf_loader_.getSRDF();
+  const boost::shared_ptr<srdf::Model>& srdf_model = rdf_loader_.getSRDF();
   const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
-  robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(kinematics_test.kinematics_solver_->getGroupName());
+  robot_model::JointModelGroup* joint_model_group =
+      kinematic_model->getJointModelGroup(kinematics_test.kinematics_solver_->getGroupName());
 
-  //Test inverse kinematics
+  // Test inverse kinematics
   std::vector<double> seed, fk_values, solution;
   double timeout = 5.0;
   moveit_msgs::MoveItErrorCodes error_code;
@@ -372,7 +367,7 @@ TEST(IKFastPlugin, getIK)
 
   unsigned int success = 0;
   ros::WallTime start_time = ros::WallTime::now();
-  for(unsigned int i=0; i < kinematics_test.num_ik_tests_; ++i)
+  for (unsigned int i = 0; i < kinematics_test.num_ik_tests_; ++i)
   {
     seed.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
     fk_values.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
@@ -386,16 +381,18 @@ TEST(IKFastPlugin, getIK)
     solution.clear();
 
     kinematics_test.kinematics_solver_->getPositionIK(poses[0], fk_values, solution, error_code);
-    ROS_DEBUG("Pose: %f %f %f",poses[0].position.x, poses[0].position.y, poses[0].position.z);
-    ROS_DEBUG("Orient: %f %f %f %f",poses[0].orientation.x, poses[0].orientation.y, poses[0].orientation.z, poses[0].orientation.w);
+    ROS_DEBUG("Pose: %f %f %f", poses[0].position.x, poses[0].position.y, poses[0].position.z);
+    ROS_DEBUG("Orient: %f %f %f %f", poses[0].orientation.x, poses[0].orientation.y, poses[0].orientation.z,
+              poses[0].orientation.w);
 
-    if(error_code.val == error_code.SUCCESS)
+    if (error_code.val == error_code.SUCCESS)
     {
       success++;
     }
     else
     {
-      ROS_ERROR_STREAM("getPositionIK failed on test "<<i+1<<" for group " <<kinematics_test.kinematics_solver_->getGroupName());
+      ROS_ERROR_STREAM("getPositionIK failed on test " << i + 1 << " for group "
+                                                       << kinematics_test.kinematics_solver_->getGroupName());
       continue;
     }
 
@@ -411,24 +408,24 @@ TEST(IKFastPlugin, getIK)
     EXPECT_NEAR(poses[0].orientation.w, new_poses[0].orientation.w, IK_NEAR);
   }
 
-
-  ROS_INFO_STREAM("Success Rate: "<<(double)success/kinematics_test.num_ik_tests_);
-  EXPECT_GT(success , 0.99 * kinematics_test.num_ik_tests_);
-  ROS_INFO_STREAM("Elapsed time: "<< (ros::WallTime::now()-start_time).toSec());
+  ROS_INFO_STREAM("Success Rate: " << (double)success / kinematics_test.num_ik_tests_);
+  EXPECT_GT(success, 0.99 * kinematics_test.num_ik_tests_);
+  ROS_INFO_STREAM("Elapsed time: " << (ros::WallTime::now() - start_time).toSec());
 }
 
 TEST(IKFastPlugin, getIKMultipleSolutions)
 {
   rdf_loader::RDFLoader rdf_loader_(ROBOT_DESCRIPTION_PARAM);
   robot_model::RobotModelPtr kinematic_model;
-  const boost::shared_ptr<srdf::Model> &srdf_model = rdf_loader_.getSRDF();
+  const boost::shared_ptr<srdf::Model>& srdf_model = rdf_loader_.getSRDF();
   const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader_.getURDF();
   kinematic_model.reset(new robot_model::RobotModel(urdf_model, srdf_model));
-  robot_model::JointModelGroup* joint_model_group = kinematic_model->getJointModelGroup(kinematics_test.kinematics_solver_->getGroupName());
+  robot_model::JointModelGroup* joint_model_group =
+      kinematic_model->getJointModelGroup(kinematics_test.kinematics_solver_->getGroupName());
 
-  //Test inverse kinematics
+  // Test inverse kinematics
   std::vector<double> seed, fk_values;
-  std::vector< std::vector<double> > solutions;
+  std::vector<std::vector<double> > solutions;
   double timeout = 5.0;
   kinematics::KinematicsQueryOptions options;
   kinematics::KinematicsResult result;
@@ -440,7 +437,7 @@ TEST(IKFastPlugin, getIKMultipleSolutions)
   unsigned int success = 0;
   unsigned int num_ik_solutions = 0;
   ros::WallTime start_time = ros::WallTime::now();
-  for(unsigned int i=0; i < kinematics_test.num_ik_multiple_tests_; ++i)
+  for (unsigned int i = 0; i < kinematics_test.num_ik_multiple_tests_; ++i)
   {
     seed.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
     fk_values.resize(kinematics_test.kinematics_solver_->getJointNames().size(), 0.0);
@@ -452,26 +449,28 @@ TEST(IKFastPlugin, getIKMultipleSolutions)
     ASSERT_TRUE(kinematics_test.kinematics_solver_->getPositionFK(fk_names, fk_values, poses));
 
     solutions.clear();
-    kinematics_test.kinematics_solver_->getPositionIK(poses,fk_values, solutions, result,options);
-    ROS_DEBUG("Pose: %f %f %f",poses[0].position.x, poses[0].position.y, poses[0].position.z);
-    ROS_DEBUG("Orient: %f %f %f %f",poses[0].orientation.x, poses[0].orientation.y, poses[0].orientation.z, poses[0].orientation.w);
+    kinematics_test.kinematics_solver_->getPositionIK(poses, fk_values, solutions, result, options);
+    ROS_DEBUG("Pose: %f %f %f", poses[0].position.x, poses[0].position.y, poses[0].position.z);
+    ROS_DEBUG("Orient: %f %f %f %f", poses[0].orientation.x, poses[0].orientation.y, poses[0].orientation.z,
+              poses[0].orientation.w);
 
-    if(result.kinematic_error == kinematics::KinematicErrors::OK)
+    if (result.kinematic_error == kinematics::KinematicErrors::OK)
     {
-      EXPECT_GT(solutions.size(),0)<<"Found "<<solutions.size()<<" ik solutions.";
+      EXPECT_GT(solutions.size(), 0) << "Found " << solutions.size() << " ik solutions.";
       success = solutions.empty() ? success : success + 1;
-      num_ik_solutions+=solutions.size();
+      num_ik_solutions += solutions.size();
     }
     else
     {
-      ROS_ERROR_STREAM("getPositionIK with multiple solutions failed on test "<<i+1<<" for group " <<kinematics_test.kinematics_solver_->getGroupName());
+      ROS_ERROR_STREAM("getPositionIK with multiple solutions failed on test "
+                       << i + 1 << " for group " << kinematics_test.kinematics_solver_->getGroupName());
       continue;
     }
 
     std::vector<geometry_msgs::Pose> new_poses;
     new_poses.resize(1);
 
-    for(unsigned int i = 0; i < solutions.size();i++)
+    for (unsigned int i = 0; i < solutions.size(); i++)
     {
       std::vector<double>& solution = solutions[i];
       EXPECT_TRUE(kinematics_test.kinematics_solver_->getPositionFK(fk_names, solution, new_poses));
@@ -483,23 +482,18 @@ TEST(IKFastPlugin, getIKMultipleSolutions)
       EXPECT_NEAR(poses[0].orientation.z, new_poses[0].orientation.z, IK_NEAR);
       EXPECT_NEAR(poses[0].orientation.w, new_poses[0].orientation.w, IK_NEAR);
     }
-
-
   }
 
-
-  ROS_INFO_STREAM("Success Rate: "<<(double)success/kinematics_test.num_ik_multiple_tests_);
-  EXPECT_GT(success , 0.99 * kinematics_test.num_ik_multiple_tests_)<<"A total of "<<num_ik_solutions <<" ik solutions were found out of "
-      <<kinematics_test.num_ik_multiple_tests_<<" tests.";
-  ROS_INFO_STREAM("Elapsed time: "<< (ros::WallTime::now()-start_time).toSec());
+  ROS_INFO_STREAM("Success Rate: " << (double)success / kinematics_test.num_ik_multiple_tests_);
+  EXPECT_GT(success, 0.99 * kinematics_test.num_ik_multiple_tests_)
+      << "A total of " << num_ik_solutions << " ik solutions were found out of "
+      << kinematics_test.num_ik_multiple_tests_ << " tests.";
+  ROS_INFO_STREAM("Elapsed time: " << (ros::WallTime::now() - start_time).toSec());
 }
 
-
-
-
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init (argc, argv, "kinematics_plugin_test");
+  ros::init(argc, argv, "kinematics_plugin_test");
   return RUN_ALL_TESTS();
 }

--- a/kuka_kr210_manipulator_ik_plugin/include/ikfast.h
+++ b/kuka_kr210_manipulator_ik_plugin/include/ikfast.h
@@ -17,7 +17,8 @@
 
     The file is divided into two sections:
     - <b>Common</b> - the abstract classes section that all ikfast share regardless of their settings
-    - <b>Library Specific</b> - the library-specific definitions, which depends on the precision/settings that the library was compiled with
+    - <b>Library Specific</b> - the library-specific definitions, which depends on the precision/settings that the
+   library was compiled with
 
     The defines are as follows, they are also used for the ikfast C++ class:
 
@@ -25,14 +26,15 @@
    - IKFAST_HAS_LIBRARY - if defined, will include library-specific functions. by default this is off
    - IKFAST_CLIBRARY - Define this linking statically or dynamically to get correct visibility.
    - IKFAST_NO_MAIN - Remove the ``main`` function, usually used with IKFAST_CLIBRARY
-   - IKFAST_ASSERT - Define in order to get a custom assert called when NaNs, divides by zero, and other invalid conditions are detected.
+   - IKFAST_ASSERT - Define in order to get a custom assert called when NaNs, divides by zero, and other invalid
+   conditions are detected.
    - IKFAST_REAL - Use to force a custom real number type for IkReal.
    - IKFAST_NAMESPACE - Enclose all functions and classes in this namespace, the ``main`` function is excluded.
 
  */
-#include <vector>
 #include <list>
 #include <stdexcept>
+#include <vector>
 
 #ifndef IKFAST_HEADER_COMMON
 #define IKFAST_HEADER_COMMON
@@ -40,52 +42,57 @@
 /// should be the same as ikfast.__version__
 #define IKFAST_VERSION 61
 
-namespace ikfast {
-
+namespace ikfast
+{
 /// \brief holds the solution for a single dof
 template <typename T>
 class IkSingleDOFSolutionBase
 {
 public:
-    IkSingleDOFSolutionBase() : fmul(0), foffset(0), freeind(-1), maxsolutions(1) {
-        indices[0] = indices[1] = indices[2] = indices[3] = indices[4] = -1;
-    }
-    T fmul, foffset; ///< joint value is fmul*sol[freeind]+foffset
-    signed char freeind; ///< if >= 0, mimics another joint
-    unsigned char jointtype; ///< joint type, 0x01 is revolute, 0x11 is slider
-    unsigned char maxsolutions; ///< max possible indices, 0 if controlled by free index or a free joint itself
-    unsigned char indices[5]; ///< unique index of the solution used to keep track on what part it came from. sometimes a solution can be repeated for different indices. store at least another repeated root
+  IkSingleDOFSolutionBase() : fmul(0), foffset(0), freeind(-1), maxsolutions(1)
+  {
+    indices[0] = indices[1] = indices[2] = indices[3] = indices[4] = -1;
+  }
+  T fmul, foffset;             ///< joint value is fmul*sol[freeind]+foffset
+  signed char freeind;         ///< if >= 0, mimics another joint
+  unsigned char jointtype;     ///< joint type, 0x01 is revolute, 0x11 is slider
+  unsigned char maxsolutions;  ///< max possible indices, 0 if controlled by free index or a free joint itself
+  unsigned char indices[5];  ///< unique index of the solution used to keep track on what part it came from. sometimes a
+                             /// solution can be repeated for different indices. store at least another repeated root
 };
 
 /// \brief The discrete solutions are returned in this structure.
 ///
 /// Sometimes the joint axes of the robot can align allowing an infinite number of solutions.
-/// Stores all these solutions in the form of free variables that the user has to set when querying the solution. Its prototype is:
+/// Stores all these solutions in the form of free variables that the user has to set when querying the solution. Its
+/// prototype is:
 template <typename T>
 class IkSolutionBase
 {
 public:
-    virtual ~IkSolutionBase() {
-    }
-    /// \brief gets a concrete solution
-    ///
-    /// \param[out] solution the result
-    /// \param[in] freevalues values for the free parameters \se GetFree
-    virtual void GetSolution(T* solution, const T* freevalues) const = 0;
+  virtual ~IkSolutionBase()
+  {
+  }
+  /// \brief gets a concrete solution
+  ///
+  /// \param[out] solution the result
+  /// \param[in] freevalues values for the free parameters \se GetFree
+  virtual void GetSolution(T* solution, const T* freevalues) const = 0;
 
-    /// \brief std::vector version of \ref GetSolution
-    virtual void GetSolution(std::vector<T>& solution, const std::vector<T>& freevalues) const {
-        solution.resize(GetDOF());
-        GetSolution(&solution.at(0), freevalues.size() > 0 ? &freevalues.at(0) : NULL);
-    }
+  /// \brief std::vector version of \ref GetSolution
+  virtual void GetSolution(std::vector<T>& solution, const std::vector<T>& freevalues) const
+  {
+    solution.resize(GetDOF());
+    GetSolution(&solution.at(0), freevalues.size() > 0 ? &freevalues.at(0) : NULL);
+  }
 
-    /// \brief Gets the indices of the configuration space that have to be preset before a full solution can be returned
-    ///
-    /// \return vector of indices indicating the free parameters
-    virtual const std::vector<int>& GetFree() const = 0;
+  /// \brief Gets the indices of the configuration space that have to be preset before a full solution can be returned
+  ///
+  /// \return vector of indices indicating the free parameters
+  virtual const std::vector<int>& GetFree() const = 0;
 
-    /// \brief the dof of the solution
-    virtual const int GetDOF() const = 0;
+  /// \brief the dof of the solution
+  virtual const int GetDOF() const = 0;
 };
 
 /// \brief manages all the solutions
@@ -93,23 +100,26 @@ template <typename T>
 class IkSolutionListBase
 {
 public:
-    virtual ~IkSolutionListBase() {
-    }
+  virtual ~IkSolutionListBase()
+  {
+  }
 
-    /// \brief add one solution and return its index for later retrieval
-    ///
-    /// \param vinfos Solution data for each degree of freedom of the manipulator
-    /// \param vfree If the solution represents an infinite space, holds free parameters of the solution that users can freely set.
-    virtual size_t AddSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree) = 0;
+  /// \brief add one solution and return its index for later retrieval
+  ///
+  /// \param vinfos Solution data for each degree of freedom of the manipulator
+  /// \param vfree If the solution represents an infinite space, holds free parameters of the solution that users can
+  /// freely set.
+  virtual size_t AddSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree) = 0;
 
-    /// \brief returns the solution pointer
-    virtual const IkSolutionBase<T>& GetSolution(size_t index) const = 0;
+  /// \brief returns the solution pointer
+  virtual const IkSolutionBase<T>& GetSolution(size_t index) const = 0;
 
-    /// \brief returns the number of solutions stored
-    virtual size_t GetNumSolutions() const = 0;
+  /// \brief returns the number of solutions stored
+  virtual size_t GetNumSolutions() const = 0;
 
-    /// \brief clears all current solutions, note that any memory addresses returned from \ref GetSolution will be invalidated.
-    virtual void Clear() = 0;
+  /// \brief clears all current solutions, note that any memory addresses returned from \ref GetSolution will be
+  /// invalidated.
+  virtual void Clear() = 0;
 };
 
 /// \brief holds function pointers for all the exported functions of ikfast
@@ -117,28 +127,39 @@ template <typename T>
 class IkFastFunctions
 {
 public:
-    IkFastFunctions() : _ComputeIk(NULL), _ComputeFk(NULL), _GetNumFreeParameters(NULL), _GetFreeParameters(NULL), _GetNumJoints(NULL), _GetIkRealSize(NULL), _GetIkFastVersion(NULL), _GetIkType(NULL), _GetKinematicsHash(NULL) {
-    }
-    virtual ~IkFastFunctions() {
-    }
-    typedef bool (*ComputeIkFn)(const T*, const T*, const T*, IkSolutionListBase<T>&);
-    ComputeIkFn _ComputeIk;
-    typedef void (*ComputeFkFn)(const T*, T*, T*);
-    ComputeFkFn _ComputeFk;
-    typedef int (*GetNumFreeParametersFn)();
-    GetNumFreeParametersFn _GetNumFreeParameters;
-    typedef int* (*GetFreeParametersFn)();
-    GetFreeParametersFn _GetFreeParameters;
-    typedef int (*GetNumJointsFn)();
-    GetNumJointsFn _GetNumJoints;
-    typedef int (*GetIkRealSizeFn)();
-    GetIkRealSizeFn _GetIkRealSize;
-    typedef const char* (*GetIkFastVersionFn)();
-    GetIkFastVersionFn _GetIkFastVersion;
-    typedef int (*GetIkTypeFn)();
-    GetIkTypeFn _GetIkType;
-    typedef const char* (*GetKinematicsHashFn)();
-    GetKinematicsHashFn _GetKinematicsHash;
+  IkFastFunctions()
+    : _ComputeIk(NULL)
+    , _ComputeFk(NULL)
+    , _GetNumFreeParameters(NULL)
+    , _GetFreeParameters(NULL)
+    , _GetNumJoints(NULL)
+    , _GetIkRealSize(NULL)
+    , _GetIkFastVersion(NULL)
+    , _GetIkType(NULL)
+    , _GetKinematicsHash(NULL)
+  {
+  }
+  virtual ~IkFastFunctions()
+  {
+  }
+  typedef bool (*ComputeIkFn)(const T*, const T*, const T*, IkSolutionListBase<T>&);
+  ComputeIkFn _ComputeIk;
+  typedef void (*ComputeFkFn)(const T*, T*, T*);
+  ComputeFkFn _ComputeFk;
+  typedef int (*GetNumFreeParametersFn)();
+  GetNumFreeParametersFn _GetNumFreeParameters;
+  typedef int* (*GetFreeParametersFn)();
+  GetFreeParametersFn _GetFreeParameters;
+  typedef int (*GetNumJointsFn)();
+  GetNumJointsFn _GetNumJoints;
+  typedef int (*GetIkRealSizeFn)();
+  GetIkRealSizeFn _GetIkRealSize;
+  typedef const char* (*GetIkFastVersionFn)();
+  GetIkFastVersionFn _GetIkFastVersion;
+  typedef int (*GetIkTypeFn)();
+  GetIkTypeFn _GetIkType;
+  typedef const char* (*GetKinematicsHashFn)();
+  GetKinematicsHashFn _GetKinematicsHash;
 };
 
 // Implementations of the abstract classes, user doesn't need to use them
@@ -148,80 +169,103 @@ template <typename T>
 class IkSolution : public IkSolutionBase<T>
 {
 public:
-    IkSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree) {
-        _vbasesol = vinfos;
-        _vfree = vfree;
-    }
+  IkSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree)
+  {
+    _vbasesol = vinfos;
+    _vfree = vfree;
+  }
 
-    virtual void GetSolution(T* solution, const T* freevalues) const {
-        for(std::size_t i = 0; i < _vbasesol.size(); ++i) {
-            if( _vbasesol[i].freeind < 0 )
-                solution[i] = _vbasesol[i].foffset;
-            else {
-                solution[i] = freevalues[_vbasesol[i].freeind]*_vbasesol[i].fmul + _vbasesol[i].foffset;
-                if( solution[i] > T(3.14159265358979) ) {
-                    solution[i] -= T(6.28318530717959);
-                }
-                else if( solution[i] < T(-3.14159265358979) ) {
-                    solution[i] += T(6.28318530717959);
-                }
-            }
+  virtual void GetSolution(T* solution, const T* freevalues) const
+  {
+    for (std::size_t i = 0; i < _vbasesol.size(); ++i)
+    {
+      if (_vbasesol[i].freeind < 0)
+        solution[i] = _vbasesol[i].foffset;
+      else
+      {
+        solution[i] = freevalues[_vbasesol[i].freeind] * _vbasesol[i].fmul + _vbasesol[i].foffset;
+        if (solution[i] > T(3.14159265358979))
+        {
+          solution[i] -= T(6.28318530717959);
         }
-    }
-
-    virtual void GetSolution(std::vector<T>& solution, const std::vector<T>& freevalues) const {
-        solution.resize(GetDOF());
-        GetSolution(&solution.at(0), freevalues.size() > 0 ? &freevalues.at(0) : NULL);
-    }
-
-    virtual const std::vector<int>& GetFree() const {
-        return _vfree;
-    }
-    virtual const int GetDOF() const {
-        return static_cast<int>(_vbasesol.size());
-    }
-
-    virtual void Validate() const {
-        for(size_t i = 0; i < _vbasesol.size(); ++i) {
-            if( _vbasesol[i].maxsolutions == (unsigned char)-1) {
-                throw std::runtime_error("max solutions for joint not initialized");
-            }
-            if( _vbasesol[i].maxsolutions > 0 ) {
-                if( _vbasesol[i].indices[0] >= _vbasesol[i].maxsolutions ) {
-                    throw std::runtime_error("index >= max solutions for joint");
-                }
-                if( _vbasesol[i].indices[1] != (unsigned char)-1 && _vbasesol[i].indices[1] >= _vbasesol[i].maxsolutions ) {
-                    throw std::runtime_error("2nd index >= max solutions for joint");
-                }
-            }
+        else if (solution[i] < T(-3.14159265358979))
+        {
+          solution[i] += T(6.28318530717959);
         }
+      }
     }
+  }
 
-    virtual void GetSolutionIndices(std::vector<unsigned int>& v) const {
-        v.resize(0);
-        v.push_back(0);
-        for(int i = (int)_vbasesol.size()-1; i >= 0; --i) {
-            if( _vbasesol[i].maxsolutions != (unsigned char)-1 && _vbasesol[i].maxsolutions > 1 ) {
-                for(size_t j = 0; j < v.size(); ++j) {
-                    v[j] *= _vbasesol[i].maxsolutions;
-                }
-                size_t orgsize=v.size();
-                if( _vbasesol[i].indices[1] != (unsigned char)-1 ) {
-                    for(size_t j = 0; j < orgsize; ++j) {
-                        v.push_back(v[j]+_vbasesol[i].indices[1]);
-                    }
-                }
-                if( _vbasesol[i].indices[0] != (unsigned char)-1 ) {
-                    for(size_t j = 0; j < orgsize; ++j) {
-                        v[j] += _vbasesol[i].indices[0];
-                    }
-                }
-            }
+  virtual void GetSolution(std::vector<T>& solution, const std::vector<T>& freevalues) const
+  {
+    solution.resize(GetDOF());
+    GetSolution(&solution.at(0), freevalues.size() > 0 ? &freevalues.at(0) : NULL);
+  }
+
+  virtual const std::vector<int>& GetFree() const
+  {
+    return _vfree;
+  }
+  virtual const int GetDOF() const
+  {
+    return static_cast<int>(_vbasesol.size());
+  }
+
+  virtual void Validate() const
+  {
+    for (size_t i = 0; i < _vbasesol.size(); ++i)
+    {
+      if (_vbasesol[i].maxsolutions == (unsigned char)-1)
+      {
+        throw std::runtime_error("max solutions for joint not initialized");
+      }
+      if (_vbasesol[i].maxsolutions > 0)
+      {
+        if (_vbasesol[i].indices[0] >= _vbasesol[i].maxsolutions)
+        {
+          throw std::runtime_error("index >= max solutions for joint");
         }
+        if (_vbasesol[i].indices[1] != (unsigned char)-1 && _vbasesol[i].indices[1] >= _vbasesol[i].maxsolutions)
+        {
+          throw std::runtime_error("2nd index >= max solutions for joint");
+        }
+      }
     }
+  }
 
-    std::vector< IkSingleDOFSolutionBase<T> > _vbasesol;       ///< solution and their offsets if joints are mimiced
-    std::vector<int> _vfree;
+  virtual void GetSolutionIndices(std::vector<unsigned int>& v) const
+  {
+    v.resize(0);
+    v.push_back(0);
+    for (int i = (int)_vbasesol.size() - 1; i >= 0; --i)
+    {
+      if (_vbasesol[i].maxsolutions != (unsigned char)-1 && _vbasesol[i].maxsolutions > 1)
+      {
+        for (size_t j = 0; j < v.size(); ++j)
+        {
+          v[j] *= _vbasesol[i].maxsolutions;
+        }
+        size_t orgsize = v.size();
+        if (_vbasesol[i].indices[1] != (unsigned char)-1)
+        {
+          for (size_t j = 0; j < orgsize; ++j)
+          {
+            v.push_back(v[j] + _vbasesol[i].indices[1]);
+          }
+        }
+        if (_vbasesol[i].indices[0] != (unsigned char)-1)
+        {
+          for (size_t j = 0; j < orgsize; ++j)
+          {
+            v[j] += _vbasesol[i].indices[0];
+          }
+        }
+      }
+    }
+  }
+
+  std::vector<IkSingleDOFSolutionBase<T> > _vbasesol;  ///< solution and their offsets if joints are mimiced
+  std::vector<int> _vfree;
 };
 
 /// \brief Default implementation of \ref IkSolutionListBase
@@ -229,38 +273,40 @@ template <typename T>
 class IkSolutionList : public IkSolutionListBase<T>
 {
 public:
-    virtual size_t AddSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree)
+  virtual size_t AddSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree)
+  {
+    size_t index = _listsolutions.size();
+    _listsolutions.push_back(IkSolution<T>(vinfos, vfree));
+    return index;
+  }
+
+  virtual const IkSolutionBase<T>& GetSolution(size_t index) const
+  {
+    if (index >= _listsolutions.size())
     {
-        size_t index = _listsolutions.size();
-        _listsolutions.push_back(IkSolution<T>(vinfos,vfree));
-        return index;
+      throw std::runtime_error("GetSolution index is invalid");
     }
+    typename std::list<IkSolution<T> >::const_iterator it = _listsolutions.begin();
+    std::advance(it, index);
+    return *it;
+  }
 
-    virtual const IkSolutionBase<T>& GetSolution(size_t index) const
-    {
-        if( index >= _listsolutions.size() ) {
-            throw std::runtime_error("GetSolution index is invalid");
-        }
-        typename std::list< IkSolution<T> >::const_iterator it = _listsolutions.begin();
-        std::advance(it,index);
-        return *it;
-    }
+  virtual size_t GetNumSolutions() const
+  {
+    return _listsolutions.size();
+  }
 
-    virtual size_t GetNumSolutions() const {
-        return _listsolutions.size();
-    }
-
-    virtual void Clear() {
-        _listsolutions.clear();
-    }
+  virtual void Clear()
+  {
+    _listsolutions.clear();
+  }
 
 protected:
-    std::list< IkSolution<T> > _listsolutions;
+  std::list<IkSolution<T> > _listsolutions;
 };
-
 }
 
-#endif // OPENRAVE_IKFAST_HEADER
+#endif  // OPENRAVE_IKFAST_HEADER
 
 // The following code is dependent on the C++ library linking with.
 #ifdef IKFAST_HAS_LIBRARY
@@ -277,7 +323,8 @@ protected:
 #endif
 
 #ifdef IKFAST_NAMESPACE
-namespace IKFAST_NAMESPACE {
+namespace IKFAST_NAMESPACE
+{
 #endif
 
 #ifdef IKFAST_REAL
@@ -292,10 +339,13 @@ typedef double IkReal;
    - ``eerot``
    - For **Transform6D** it is 9 values for the 3x3 rotation matrix.
    - For **Direction3D**, **Ray4D**, and **TranslationDirection5D**, the first 3 values represent the target direction.
-   - For **TranslationXAxisAngle4D**, **TranslationYAxisAngle4D**, and **TranslationZAxisAngle4D** the first value represents the angle.
-   - For **TranslationLocalGlobal6D**, the diagonal elements ([0],[4],[8]) are the local translation inside the end effector coordinate system.
+   - For **TranslationXAxisAngle4D**, **TranslationYAxisAngle4D**, and **TranslationZAxisAngle4D** the first value
+   represents the angle.
+   - For **TranslationLocalGlobal6D**, the diagonal elements ([0],[4],[8]) are the local translation inside the end
+   effector coordinate system.
  */
-IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, ikfast::IkSolutionListBase<IkReal>& solutions);
+IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree,
+                          ikfast::IkSolutionListBase<IkReal>& solutions);
 
 /// \brief Computes the end effector coordinates given the joint values. This function is used to double check ik.
 IKFAST_API void ComputeFk(const IkReal* joints, IkReal* eetrans, IkReal* eerot);
@@ -325,4 +375,4 @@ IKFAST_API const char* GetKinematicsHash();
 }
 #endif
 
-#endif // IKFAST_HAS_LIBRARY
+#endif  // IKFAST_HAS_LIBRARY

--- a/kuka_kr210_manipulator_ik_plugin/kuka_kr210_ikfast_manipulator.cpp
+++ b/kuka_kr210_manipulator_ik_plugin/kuka_kr210_ikfast_manipulator.cpp
@@ -5,7 +5,7 @@
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///     http://www.apache.org/licenses/LICENSE-2.0
-/// 
+///
 /// Unless required by applicable law or agreed to in writing, software
 /// distributed under the License is distributed on an "AS IS" BASIS,
 /// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,26 +18,26 @@
 /// To compile without any main function as a shared object (might need -llapack):
 ///     gcc -fPIC -lstdc++ -DIKFAST_NO_MAIN -DIKFAST_CLIBRARY -shared -Wl,-soname,libik.so -o libik.so ik.cpp
 #define IKFAST_HAS_LIBRARY
-#include "ikfast.h" // found inside share/openrave-X.Y/python/ikfast.h
+#include "ikfast.h"  // found inside share/openrave-X.Y/python/ikfast.h
 using namespace ikfast;
 
 // check if the included ikfast version matches what this file was compiled with
 #define IKFAST_COMPILE_ASSERT(x) extern int __dummy[(int)x]
-IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
+IKFAST_COMPILE_ASSERT(IKFAST_VERSION == 61);
 
-#include <cmath>
-#include <vector>
-#include <limits>
 #include <algorithm>
+#include <cmath>
 #include <complex>
+#include <limits>
+#include <vector>
 
 #define IKFAST_STRINGIZE2(s) #s
 #define IKFAST_STRINGIZE(s) IKFAST_STRINGIZE2(s)
 
 #ifndef IKFAST_ASSERT
-#include <stdexcept>
-#include <sstream>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 
 #ifdef _MSC_VER
 #ifndef __PRETTY_FUNCTION__
@@ -49,7 +49,16 @@ IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
 #define __PRETTY_FUNCTION__ __func__
 #endif
 
-#define IKFAST_ASSERT(b) { if( !(b) ) { std::stringstream ss; ss << "ikfast exception: " << __FILE__ << ":" << __LINE__ << ": " <<__PRETTY_FUNCTION__ << ": Assertion '" << #b << "' failed"; throw std::runtime_error(ss.str()); } }
+#define IKFAST_ASSERT(b)                                                                                               \
+  {                                                                                                                    \
+    if (!(b))                                                                                                          \
+    {                                                                                                                  \
+      std::stringstream ss;                                                                                            \
+      ss << "ikfast exception: " << __FILE__ << ":" << __LINE__ << ": " << __PRETTY_FUNCTION__ << ": Assertion '"      \
+         << #b << "' failed";                                                                                          \
+      throw std::runtime_error(ss.str());                                                                              \
+    }                                                                                                                  \
+  }
 
 #endif
 
@@ -59,40 +68,61 @@ IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
 #define IKFAST_ALIGNED16(x) x __attribute((aligned(16)))
 #endif
 
-#define IK2PI  ((IkReal)6.28318530717959)
-#define IKPI  ((IkReal)3.14159265358979)
-#define IKPI_2  ((IkReal)1.57079632679490)
+#define IK2PI ((IkReal)6.28318530717959)
+#define IKPI ((IkReal)3.14159265358979)
+#define IKPI_2 ((IkReal)1.57079632679490)
 
 #ifdef _MSC_VER
 #ifndef isnan
 #define isnan _isnan
 #endif
-#endif // _MSC_VER
+#endif  // _MSC_VER
 
 // lapack routines
 extern "C" {
-  void dgetrf_ (const int* m, const int* n, double* a, const int* lda, int* ipiv, int* info);
-  void zgetrf_ (const int* m, const int* n, std::complex<double>* a, const int* lda, int* ipiv, int* info);
-  void dgetri_(const int* n, const double* a, const int* lda, int* ipiv, double* work, const int* lwork, int* info);
-  void dgesv_ (const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b, const int* ldb, int* info);
-  void dgetrs_(const char *trans, const int *n, const int *nrhs, double *a, const int *lda, int *ipiv, double *b, const int *ldb, int *info);
-  void dgeev_(const char *jobvl, const char *jobvr, const int *n, double *a, const int *lda, double *wr, double *wi,double *vl, const int *ldvl, double *vr, const int *ldvr, double *work, const int *lwork, int *info);
+void dgetrf_(const int* m, const int* n, double* a, const int* lda, int* ipiv, int* info);
+void zgetrf_(const int* m, const int* n, std::complex<double>* a, const int* lda, int* ipiv, int* info);
+void dgetri_(const int* n, const double* a, const int* lda, int* ipiv, double* work, const int* lwork, int* info);
+void dgesv_(const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b, const int* ldb, int* info);
+void dgetrs_(const char* trans, const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b,
+             const int* ldb, int* info);
+void dgeev_(const char* jobvl, const char* jobvr, const int* n, double* a, const int* lda, double* wr, double* wi,
+            double* vl, const int* ldvl, double* vr, const int* ldvr, double* work, const int* lwork, int* info);
 }
 
-using namespace std; // necessary to get std math routines
+using namespace std;  // necessary to get std math routines
 
 #ifdef IKFAST_NAMESPACE
-namespace IKFAST_NAMESPACE {
+namespace IKFAST_NAMESPACE
+{
 #endif
 
-inline float IKabs(float f) { return fabsf(f); }
-inline double IKabs(double f) { return fabs(f); }
+inline float IKabs(float f)
+{
+  return fabsf(f);
+}
+inline double IKabs(double f)
+{
+  return fabs(f);
+}
 
-inline float IKsqr(float f) { return f*f; }
-inline double IKsqr(double f) { return f*f; }
+inline float IKsqr(float f)
+{
+  return f * f;
+}
+inline double IKsqr(double f)
+{
+  return f * f;
+}
 
-inline float IKlog(float f) { return logf(f); }
-inline double IKlog(double f) { return log(f); }
+inline float IKlog(float f)
+{
+  return logf(f);
+}
+inline double IKlog(double f)
+{
+  return log(f);
+}
 
 // allows asin and acos to exceed 1
 #ifndef IKFAST_SINCOS_THRESH
@@ -111,2706 +141,3668 @@ inline double IKlog(double f) { return log(f); }
 
 inline float IKasin(float f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return float(-IKPI_2);
-else if( f >= 1 ) return float(IKPI_2);
-return asinf(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return float(-IKPI_2);
+  else if (f >= 1)
+    return float(IKPI_2);
+  return asinf(f);
 }
 inline double IKasin(double f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return -IKPI_2;
-else if( f >= 1 ) return IKPI_2;
-return asin(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return -IKPI_2;
+  else if (f >= 1)
+    return IKPI_2;
+  return asin(f);
 }
 
 // return positive value in [0,y)
 inline float IKfmod(float x, float y)
 {
-    while(x < 0) {
-        x += y;
-    }
-    return fmodf(x,y);
+  while (x < 0)
+  {
+    x += y;
+  }
+  return fmodf(x, y);
 }
 
 // return positive value in [0,y)
 inline double IKfmod(double x, double y)
 {
-    while(x < 0) {
-        x += y;
-    }
-    return fmod(x,y);
+  while (x < 0)
+  {
+    x += y;
+  }
+  return fmod(x, y);
 }
 
 inline float IKacos(float f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return float(IKPI);
-else if( f >= 1 ) return float(0);
-return acosf(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return float(IKPI);
+  else if (f >= 1)
+    return float(0);
+  return acosf(f);
 }
 inline double IKacos(double f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return IKPI;
-else if( f >= 1 ) return 0;
-return acos(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return IKPI;
+  else if (f >= 1)
+    return 0;
+  return acos(f);
 }
-inline float IKsin(float f) { return sinf(f); }
-inline double IKsin(double f) { return sin(f); }
-inline float IKcos(float f) { return cosf(f); }
-inline double IKcos(double f) { return cos(f); }
-inline float IKtan(float f) { return tanf(f); }
-inline double IKtan(double f) { return tan(f); }
-inline float IKsqrt(float f) { if( f <= 0.0f ) return 0.0f; return sqrtf(f); }
-inline double IKsqrt(double f) { if( f <= 0.0 ) return 0.0; return sqrt(f); }
-inline float IKatan2(float fy, float fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
-        return float(IKPI_2);
-    }
-    else if( isnan(fx) ) {
-        return 0;
-    }
-    return atan2f(fy,fx);
+inline float IKsin(float f)
+{
+  return sinf(f);
 }
-inline double IKatan2(double fy, double fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
-        return IKPI_2;
-    }
-    else if( isnan(fx) ) {
-        return 0;
-    }
-    return atan2(fy,fx);
+inline double IKsin(double f)
+{
+  return sin(f);
+}
+inline float IKcos(float f)
+{
+  return cosf(f);
+}
+inline double IKcos(double f)
+{
+  return cos(f);
+}
+inline float IKtan(float f)
+{
+  return tanf(f);
+}
+inline double IKtan(double f)
+{
+  return tan(f);
+}
+inline float IKsqrt(float f)
+{
+  if (f <= 0.0f)
+    return 0.0f;
+  return sqrtf(f);
+}
+inline double IKsqrt(double f)
+{
+  if (f <= 0.0)
+    return 0.0;
+  return sqrt(f);
+}
+inline float IKatan2(float fy, float fx)
+{
+  if (isnan(fy))
+  {
+    IKFAST_ASSERT(!isnan(fx));  // if both are nan, probably wrong value will be returned
+    return float(IKPI_2);
+  }
+  else if (isnan(fx))
+  {
+    return 0;
+  }
+  return atan2f(fy, fx);
+}
+inline double IKatan2(double fy, double fx)
+{
+  if (isnan(fy))
+  {
+    IKFAST_ASSERT(!isnan(fx));  // if both are nan, probably wrong value will be returned
+    return IKPI_2;
+  }
+  else if (isnan(fx))
+  {
+    return 0;
+  }
+  return atan2(fy, fx);
 }
 
-inline float IKsign(float f) {
-    if( f > 0 ) {
-        return float(1);
-    }
-    else if( f < 0 ) {
-        return float(-1);
-    }
-    return 0;
+inline float IKsign(float f)
+{
+  if (f > 0)
+  {
+    return float(1);
+  }
+  else if (f < 0)
+  {
+    return float(-1);
+  }
+  return 0;
 }
 
-inline double IKsign(double f) {
-    if( f > 0 ) {
-        return 1.0;
-    }
-    else if( f < 0 ) {
-        return -1.0;
-    }
-    return 0;
+inline double IKsign(double f)
+{
+  if (f > 0)
+  {
+    return 1.0;
+  }
+  else if (f < 0)
+  {
+    return -1.0;
+  }
+  return 0;
 }
 
 /// solves the forward kinematics equations.
 /// \param pfree is an array specifying the free joints of the chain.
-IKFAST_API void ComputeFk(const IkReal* j, IkReal* eetrans, IkReal* eerot) {
-IkReal x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59;
-x0=IKcos(j[0]);
-x1=IKcos(j[1]);
-x2=IKsin(j[2]);
-x3=IKcos(j[2]);
-x4=IKsin(j[1]);
-x5=IKcos(j[4]);
-x6=IKsin(j[4]);
-x7=IKsin(j[3]);
-x8=IKcos(j[3]);
-x9=IKsin(j[0]);
-x10=IKcos(j[5]);
-x11=IKsin(j[5]);
-x12=((IkReal(1.49995000000000))*(x9));
-x13=((IkReal(1.00000000000000))*(x5));
-x14=((IkReal(0.000240000000000000))*(x8));
-x15=((IkReal(0.230000000000000))*(x0));
-x16=((IkReal(0.000100000000000000))*(x1));
-x17=((IkReal(0.230000000000000))*(x8));
-x18=((IkReal(1.00000000000000))*(x9));
-x19=((IkReal(0.000240000000000000))*(x5));
-x20=((IkReal(0.0550600000000000))*(x3));
-x21=((IkReal(1.00000000000000))*(x3));
-x22=((IkReal(1.49995000000000))*(x0));
-x23=((IkReal(1.00000000000000))*(x0));
-x24=((IkReal(0.230000000000000))*(x9));
-x25=((IkReal(1.00000000000000))*(x6));
-x26=((IkReal(0.000240000000000000))*(x6));
-x27=((x1)*(x3));
-x28=((x11)*(x7));
-x29=((x2)*(x4));
-x30=((x1)*(x2));
-x31=((x4)*(x9));
-x32=((x0)*(x4));
-x33=((x7)*(x9));
-x34=((x3)*(x4));
-x35=((x6)*(x8));
-x36=((x18)*(x8));
-x37=((x1)*(x21));
-x38=((x23)*(x29));
-x39=((x18)*(x29));
-x40=((((IkReal(-1.00000000000000))*(x37)))+(x29));
-x41=((((x21)*(x4)))+(((IkReal(1.00000000000000))*(x30))));
-x42=((x40)*(x8));
-x43=((x41)*(x6));
-x44=((((IkReal(-1.00000000000000))*(x0)*(x37)))+(x38));
-x45=((((IkReal(-1.00000000000000))*(x18)*(x27)))+(x39));
-x46=((((x23)*(x30)))+(((x21)*(x32))));
-x47=((IkReal(-1.00000000000000))*(x46));
-x48=((x18)*(((x30)+(x34))));
-x49=((IkReal(-1.00000000000000))*(x48));
-x50=((x47)*(x8));
-x51=((x49)*(x8));
-x52=((x48)*(x7));
-x53=((x46)*(x7));
-x54=((((IkReal(-1.00000000000000))*(x18)*(x7)))+(x50));
-x55=((((x0)*(x7)))+(x51));
-x56=((x5)*(x55));
-x57=((((IkReal(-1.00000000000000))*(x25)*(x41)))+(((IkReal(-1.00000000000000))*(x13)*(x42))));
-x58=((((IkReal(-1.00000000000000))*(x25)*(x44)))+(((IkReal(-1.00000000000000))*(x13)*(x54))));
-x59=((((IkReal(-1.00000000000000))*(x25)*(x45)))+(((IkReal(-1.00000000000000))*(x13)*(x55))));
-eerot[0]=((((x5)*(((((IkReal(-1.00000000000000))*(x38)))+(((x0)*(x27)))))))+(((x54)*(x6))));
-eerot[1]=((((x11)*(x58)))+(((x10)*(((((IkReal(-1.00000000000000))*(x36)))+(x53))))));
-eerot[2]=((((x11)*(((x36)+(((IkReal(-1.00000000000000))*(x53)))))))+(((x10)*(x58))));
-IkReal x60=((IkReal(1.00000000000000))*(x29));
-eetrans[0]=((IkReal(-0.00262000000000000))+(((IkReal(0.000980000000000000))*(x9)))+(((x22)*(x27)))+(((IkReal(-1.00000000000000))*(x20)*(x32)))+(((x5)*(((((IkReal(-1.00000000000000))*(x15)*(x60)))+(((x15)*(x27)))))))+(((IkReal(-1.00000000000000))*(x0)*(x16)))+(((IkReal(-0.0550600000000000))*(x0)*(x30)))+(((x11)*(((((IkReal(-1.00000000000000))*(x14)*(x9)))+(((IkReal(0.000240000000000000))*(x53)))))))+(((IkReal(0.352770000000000))*(x0)))+(((IkReal(1.24990000000000))*(x32)))+(((x6)*(((((x17)*(x47)))+(((IkReal(-1.00000000000000))*(x24)*(x7)))))))+(((IkReal(-1.00000000000000))*(x22)*(x60)))+(((x10)*(((((x26)*(x44)))+(((x19)*(((((IkReal(-1.00000000000000))*(x33)))+(x50))))))))));
-eerot[3]=((((x5)*(((((IkReal(-1.00000000000000))*(x39)))+(((x27)*(x9)))))))+(((x55)*(x6))));
-eerot[4]=((((x11)*(x59)))+(((x10)*(((((x0)*(x8)))+(x52))))));
-eerot[5]=((((x10)*(x59)))+(((x11)*(((((IkReal(-1.00000000000000))*(x23)*(x8)))+(((IkReal(-1.00000000000000))*(x52))))))));
-IkReal x61=((IkReal(1.00000000000000))*(x29));
-eetrans[1]=((IkReal(0.000980000000000000))+(((x6)*(((((x17)*(x49)))+(((x15)*(x7)))))))+(((x5)*(((((IkReal(-1.00000000000000))*(x24)*(x61)))+(((x24)*(x27)))))))+(((x10)*(((((x26)*(x45)))+(((x19)*(x55)))))))+(((IkReal(-0.0550600000000000))*(x30)*(x9)))+(((IkReal(-1.00000000000000))*(x20)*(x31)))+(((IkReal(-0.000980000000000000))*(x0)))+(((IkReal(-1.00000000000000))*(x12)*(x61)))+(((IkReal(-1.00000000000000))*(x16)*(x9)))+(((x11)*(((((x0)*(x14)))+(((IkReal(0.000240000000000000))*(x52)))))))+(((IkReal(0.352770000000000))*(x9)))+(((IkReal(1.24990000000000))*(x31)))+(((x12)*(x27))));
-eerot[6]=((((x35)*(x40)))+(((IkReal(-1.00000000000000))*(x41)*(x5))));
-eerot[7]=((((x10)*(x7)*(((((IkReal(-1.00000000000000))*(x29)))+(x37)))))+(((x11)*(x57))));
-eerot[8]=((((x28)*(x40)))+(((x10)*(x57))));
-eetrans[2]=((IkReal(0.750190000000000))+(((IkReal(0.000100000000000000))*(x4)))+(((x5)*(((((IkReal(-0.230000000000000))*(x30)))+(((IkReal(-0.230000000000000))*(x34)))))))+(((IkReal(-1.49995000000000))*(x30)))+(((IkReal(-1.49995000000000))*(x34)))+(((IkReal(1.24990000000000))*(x1)))+(((IkReal(-1.00000000000000))*(x1)*(x20)))+(((x28)*(((((IkReal(0.000240000000000000))*(x27)))+(((IkReal(-0.000240000000000000))*(x29)))))))+(((x35)*(((((IkReal(0.230000000000000))*(x29)))+(((IkReal(-0.230000000000000))*(x27)))))))+(((x10)*(((((x26)*(x41)))+(((x14)*(x40)*(x5)))))))+(((IkReal(0.0550600000000000))*(x29))));
+IKFAST_API void ComputeFk(const IkReal* j, IkReal* eetrans, IkReal* eerot)
+{
+  IkReal x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23,
+      x24, x25, x26, x27, x28, x29, x30, x31, x32, x33, x34, x35, x36, x37, x38, x39, x40, x41, x42, x43, x44, x45, x46,
+      x47, x48, x49, x50, x51, x52, x53, x54, x55, x56, x57, x58, x59;
+  x0 = IKcos(j[0]);
+  x1 = IKcos(j[1]);
+  x2 = IKsin(j[2]);
+  x3 = IKcos(j[2]);
+  x4 = IKsin(j[1]);
+  x5 = IKcos(j[4]);
+  x6 = IKsin(j[4]);
+  x7 = IKsin(j[3]);
+  x8 = IKcos(j[3]);
+  x9 = IKsin(j[0]);
+  x10 = IKcos(j[5]);
+  x11 = IKsin(j[5]);
+  x12 = ((IkReal(1.49995000000000)) * (x9));
+  x13 = ((IkReal(1.00000000000000)) * (x5));
+  x14 = ((IkReal(0.000240000000000000)) * (x8));
+  x15 = ((IkReal(0.230000000000000)) * (x0));
+  x16 = ((IkReal(0.000100000000000000)) * (x1));
+  x17 = ((IkReal(0.230000000000000)) * (x8));
+  x18 = ((IkReal(1.00000000000000)) * (x9));
+  x19 = ((IkReal(0.000240000000000000)) * (x5));
+  x20 = ((IkReal(0.0550600000000000)) * (x3));
+  x21 = ((IkReal(1.00000000000000)) * (x3));
+  x22 = ((IkReal(1.49995000000000)) * (x0));
+  x23 = ((IkReal(1.00000000000000)) * (x0));
+  x24 = ((IkReal(0.230000000000000)) * (x9));
+  x25 = ((IkReal(1.00000000000000)) * (x6));
+  x26 = ((IkReal(0.000240000000000000)) * (x6));
+  x27 = ((x1) * (x3));
+  x28 = ((x11) * (x7));
+  x29 = ((x2) * (x4));
+  x30 = ((x1) * (x2));
+  x31 = ((x4) * (x9));
+  x32 = ((x0) * (x4));
+  x33 = ((x7) * (x9));
+  x34 = ((x3) * (x4));
+  x35 = ((x6) * (x8));
+  x36 = ((x18) * (x8));
+  x37 = ((x1) * (x21));
+  x38 = ((x23) * (x29));
+  x39 = ((x18) * (x29));
+  x40 = ((((IkReal(-1.00000000000000)) * (x37))) + (x29));
+  x41 = ((((x21) * (x4))) + (((IkReal(1.00000000000000)) * (x30))));
+  x42 = ((x40) * (x8));
+  x43 = ((x41) * (x6));
+  x44 = ((((IkReal(-1.00000000000000)) * (x0) * (x37))) + (x38));
+  x45 = ((((IkReal(-1.00000000000000)) * (x18) * (x27))) + (x39));
+  x46 = ((((x23) * (x30))) + (((x21) * (x32))));
+  x47 = ((IkReal(-1.00000000000000)) * (x46));
+  x48 = ((x18) * (((x30) + (x34))));
+  x49 = ((IkReal(-1.00000000000000)) * (x48));
+  x50 = ((x47) * (x8));
+  x51 = ((x49) * (x8));
+  x52 = ((x48) * (x7));
+  x53 = ((x46) * (x7));
+  x54 = ((((IkReal(-1.00000000000000)) * (x18) * (x7))) + (x50));
+  x55 = ((((x0) * (x7))) + (x51));
+  x56 = ((x5) * (x55));
+  x57 = ((((IkReal(-1.00000000000000)) * (x25) * (x41))) + (((IkReal(-1.00000000000000)) * (x13) * (x42))));
+  x58 = ((((IkReal(-1.00000000000000)) * (x25) * (x44))) + (((IkReal(-1.00000000000000)) * (x13) * (x54))));
+  x59 = ((((IkReal(-1.00000000000000)) * (x25) * (x45))) + (((IkReal(-1.00000000000000)) * (x13) * (x55))));
+  eerot[0] = ((((x5) * (((((IkReal(-1.00000000000000)) * (x38))) + (((x0) * (x27))))))) + (((x54) * (x6))));
+  eerot[1] = ((((x11) * (x58))) + (((x10) * (((((IkReal(-1.00000000000000)) * (x36))) + (x53))))));
+  eerot[2] = ((((x11) * (((x36) + (((IkReal(-1.00000000000000)) * (x53))))))) + (((x10) * (x58))));
+  IkReal x60 = ((IkReal(1.00000000000000)) * (x29));
+  eetrans[0] =
+      ((IkReal(-0.00262000000000000)) + (((IkReal(0.000980000000000000)) * (x9))) + (((x22) * (x27))) +
+       (((IkReal(-1.00000000000000)) * (x20) * (x32))) +
+       (((x5) * (((((IkReal(-1.00000000000000)) * (x15) * (x60))) + (((x15) * (x27))))))) +
+       (((IkReal(-1.00000000000000)) * (x0) * (x16))) + (((IkReal(-0.0550600000000000)) * (x0) * (x30))) +
+       (((x11) * (((((IkReal(-1.00000000000000)) * (x14) * (x9))) + (((IkReal(0.000240000000000000)) * (x53))))))) +
+       (((IkReal(0.352770000000000)) * (x0))) + (((IkReal(1.24990000000000)) * (x32))) +
+       (((x6) * (((((x17) * (x47))) + (((IkReal(-1.00000000000000)) * (x24) * (x7))))))) +
+       (((IkReal(-1.00000000000000)) * (x22) * (x60))) +
+       (((x10) * (((((x26) * (x44))) + (((x19) * (((((IkReal(-1.00000000000000)) * (x33))) + (x50))))))))));
+  eerot[3] = ((((x5) * (((((IkReal(-1.00000000000000)) * (x39))) + (((x27) * (x9))))))) + (((x55) * (x6))));
+  eerot[4] = ((((x11) * (x59))) + (((x10) * (((((x0) * (x8))) + (x52))))));
+  eerot[5] = ((((x10) * (x59))) +
+              (((x11) * (((((IkReal(-1.00000000000000)) * (x23) * (x8))) + (((IkReal(-1.00000000000000)) * (x52))))))));
+  IkReal x61 = ((IkReal(1.00000000000000)) * (x29));
+  eetrans[1] =
+      ((IkReal(0.000980000000000000)) + (((x6) * (((((x17) * (x49))) + (((x15) * (x7))))))) +
+       (((x5) * (((((IkReal(-1.00000000000000)) * (x24) * (x61))) + (((x24) * (x27))))))) +
+       (((x10) * (((((x26) * (x45))) + (((x19) * (x55))))))) + (((IkReal(-0.0550600000000000)) * (x30) * (x9))) +
+       (((IkReal(-1.00000000000000)) * (x20) * (x31))) + (((IkReal(-0.000980000000000000)) * (x0))) +
+       (((IkReal(-1.00000000000000)) * (x12) * (x61))) + (((IkReal(-1.00000000000000)) * (x16) * (x9))) +
+       (((x11) * (((((x0) * (x14))) + (((IkReal(0.000240000000000000)) * (x52))))))) +
+       (((IkReal(0.352770000000000)) * (x9))) + (((IkReal(1.24990000000000)) * (x31))) + (((x12) * (x27))));
+  eerot[6] = ((((x35) * (x40))) + (((IkReal(-1.00000000000000)) * (x41) * (x5))));
+  eerot[7] = ((((x10) * (x7) * (((((IkReal(-1.00000000000000)) * (x29))) + (x37))))) + (((x11) * (x57))));
+  eerot[8] = ((((x28) * (x40))) + (((x10) * (x57))));
+  eetrans[2] =
+      ((IkReal(0.750190000000000)) + (((IkReal(0.000100000000000000)) * (x4))) +
+       (((x5) * (((((IkReal(-0.230000000000000)) * (x30))) + (((IkReal(-0.230000000000000)) * (x34))))))) +
+       (((IkReal(-1.49995000000000)) * (x30))) + (((IkReal(-1.49995000000000)) * (x34))) +
+       (((IkReal(1.24990000000000)) * (x1))) + (((IkReal(-1.00000000000000)) * (x1) * (x20))) +
+       (((x28) * (((((IkReal(0.000240000000000000)) * (x27))) + (((IkReal(-0.000240000000000000)) * (x29))))))) +
+       (((x35) * (((((IkReal(0.230000000000000)) * (x29))) + (((IkReal(-0.230000000000000)) * (x27))))))) +
+       (((x10) * (((((x26) * (x41))) + (((x14) * (x40) * (x5))))))) + (((IkReal(0.0550600000000000)) * (x29))));
 }
 
-IKFAST_API int GetNumFreeParameters() { return 0; }
-IKFAST_API int* GetFreeParameters() { return NULL; }
-IKFAST_API int GetNumJoints() { return 6; }
+IKFAST_API int GetNumFreeParameters()
+{
+  return 0;
+}
+IKFAST_API int* GetFreeParameters()
+{
+  return NULL;
+}
+IKFAST_API int GetNumJoints()
+{
+  return 6;
+}
 
-IKFAST_API int GetIkRealSize() { return sizeof(IkReal); }
+IKFAST_API int GetIkRealSize()
+{
+  return sizeof(IkReal);
+}
 
-IKFAST_API int GetIkType() { return 0x67000001; }
+IKFAST_API int GetIkType()
+{
+  return 0x67000001;
+}
 
-class IKSolver {
+class IKSolver
+{
 public:
-IkReal j0,cj0,sj0,htj0,j1,cj1,sj1,htj1,j2,cj2,sj2,htj2,j3,cj3,sj3,htj3,j4,cj4,sj4,htj4,j5,cj5,sj5,htj5,new_r00,r00,rxp0_0,new_r01,r01,rxp0_1,new_r02,r02,rxp0_2,new_r10,r10,rxp1_0,new_r11,r11,rxp1_1,new_r12,r12,rxp1_2,new_r20,r20,rxp2_0,new_r21,r21,rxp2_1,new_r22,r22,rxp2_2,new_px,px,npx,new_py,py,npy,new_pz,pz,npz,pp;
-unsigned char _ij0[2], _nj0,_ij1[2], _nj1,_ij2[2], _nj2,_ij3[2], _nj3,_ij4[2], _nj4,_ij5[2], _nj5;
-
-bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions) {
-j0=numeric_limits<IkReal>::quiet_NaN(); _ij0[0] = -1; _ij0[1] = -1; _nj0 = -1; j1=numeric_limits<IkReal>::quiet_NaN(); _ij1[0] = -1; _ij1[1] = -1; _nj1 = -1; j2=numeric_limits<IkReal>::quiet_NaN(); _ij2[0] = -1; _ij2[1] = -1; _nj2 = -1; j3=numeric_limits<IkReal>::quiet_NaN(); _ij3[0] = -1; _ij3[1] = -1; _nj3 = -1; j4=numeric_limits<IkReal>::quiet_NaN(); _ij4[0] = -1; _ij4[1] = -1; _nj4 = -1; j5=numeric_limits<IkReal>::quiet_NaN(); _ij5[0] = -1; _ij5[1] = -1; _nj5 = -1; 
-for(int dummyiter = 0; dummyiter < 1; ++dummyiter) {
-    solutions.Clear();
-r00 = eerot[0*3+0];
-r01 = eerot[0*3+1];
-r02 = eerot[0*3+2];
-r10 = eerot[1*3+0];
-r11 = eerot[1*3+1];
-r12 = eerot[1*3+2];
-r20 = eerot[2*3+0];
-r21 = eerot[2*3+1];
-r22 = eerot[2*3+2];
-px = eetrans[0]; py = eetrans[1]; pz = eetrans[2];
-
-new_r00=((IkReal(-1.00000000000000))*(r02));
-new_r01=r01;
-new_r02=r00;
-new_px=((IkReal(0.00262000000000000))+(((IkReal(-0.230000000000000))*(r00)))+(px)+(((IkReal(0.000240000000000000))*(r02))));
-new_r10=((IkReal(-1.00000000000000))*(r12));
-new_r11=r11;
-new_r12=r10;
-new_py=((IkReal(-0.000980000000000000))+(((IkReal(-0.230000000000000))*(r10)))+(py)+(((IkReal(0.000240000000000000))*(r12))));
-new_r20=((IkReal(-1.00000000000000))*(r22));
-new_r21=r21;
-new_r22=r20;
-new_pz=((IkReal(-0.750190000000000))+(pz)+(((IkReal(0.000240000000000000))*(r22)))+(((IkReal(-0.230000000000000))*(r20))));
-r00 = new_r00; r01 = new_r01; r02 = new_r02; r10 = new_r10; r11 = new_r11; r12 = new_r12; r20 = new_r20; r21 = new_r21; r22 = new_r22; px = new_px; py = new_py; pz = new_pz;
-pp=(((px)*(px))+((py)*(py))+((pz)*(pz)));
-npx=((((px)*(r00)))+(((py)*(r10)))+(((pz)*(r20))));
-npy=((((px)*(r01)))+(((py)*(r11)))+(((pz)*(r21))));
-npz=((((px)*(r02)))+(((py)*(r12)))+(((pz)*(r22))));
-rxp0_0=((((IkReal(-1.00000000000000))*(py)*(r20)))+(((pz)*(r10))));
-rxp0_1=((((px)*(r20)))+(((IkReal(-1.00000000000000))*(pz)*(r00))));
-rxp0_2=((((IkReal(-1.00000000000000))*(px)*(r10)))+(((py)*(r00))));
-rxp1_0=((((IkReal(-1.00000000000000))*(py)*(r21)))+(((pz)*(r11))));
-rxp1_1=((((px)*(r21)))+(((IkReal(-1.00000000000000))*(pz)*(r01))));
-rxp1_2=((((IkReal(-1.00000000000000))*(px)*(r11)))+(((py)*(r01))));
-rxp2_0=((((IkReal(-1.00000000000000))*(py)*(r22)))+(((pz)*(r12))));
-rxp2_1=((((px)*(r22)))+(((IkReal(-1.00000000000000))*(pz)*(r02))));
-rxp2_2=((((IkReal(-1.00000000000000))*(px)*(r12)))+(((py)*(r02))));
-{
-IkReal dummyeval[1];
-dummyeval[0]=(((px)*(px))+((py)*(py)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=(((px)*(px))+((py)*(py)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j0array[2], cj0array[2], sj0array[2];
-bool j0valid[2]={false};
-_nj0 = 2;
-if( IKabs(((IkReal(-1.00000000000000))*(py))) < IKFAST_ATAN2_MAGTHRESH && IKabs(px) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x62=((IkReal(1.00000000000000))*(IKatan2(((IkReal(-1.00000000000000))*(py)), px)));
-if( ((((px)*(px))+((py)*(py)))) < (IkReal)-0.00001 )
-    continue;
-if( (((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30)))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30)))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x63=IKasin(((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30))));
-j0array[0]=((x63)+(((IkReal(-1.00000000000000))*(x62))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-j0array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x62)))+(((IkReal(-1.00000000000000))*(x63))));
-sj0array[1]=IKsin(j0array[1]);
-cj0array[1]=IKcos(j0array[1]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-if( j0array[1] > IKPI )
-{
-    j0array[1]-=IK2PI;
-}
-else if( j0array[1] < -IKPI )
-{    j0array[1]+=IK2PI;
-}
-j0valid[1] = true;
-for(int ij0 = 0; ij0 < 2; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 2; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-
-{
-IkReal j2array[2], cj2array[2], sj2array[2];
-bool j2valid[2]={false};
-_nj2 = 2;
-if( (((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0))))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0))))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x64=IKasin(((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0)))));
-j2array[0]=((IkReal(3.10482123119329))+(((IkReal(-1.00000000000000))*(x64))));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-j2array[1]=((IkReal(6.24641388478308))+(x64));
-sj2array[1]=IKsin(j2array[1]);
-cj2array[1]=IKcos(j2array[1]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-if( j2array[1] > IKPI )
-{
-    j2array[1]-=IK2PI;
-}
-else if( j2array[1] < -IKPI )
-{    j2array[1]+=IK2PI;
-}
-j2valid[1] = true;
-for(int ij2 = 0; ij2 < 2; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 2; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-
-{
-IkReal dummyeval[1];
-IkReal gconst0;
-IkReal x65=((py)*(sj0));
-IkReal x66=((IkReal(1.49995000000000))*(sj2));
-IkReal x67=((cj0)*(px));
-IkReal x68=((IkReal(0.0550600000000000))*(cj2));
-gconst0=IKsign(((IkReal(0.440927223000000))+(((IkReal(-1.24990000000000))*(x65)))+(((IkReal(-1.24990000000000))*(x67)))+(((IkReal(0.0550600000000000))*(pz)*(sj2)))+(((x67)*(x68)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((IkReal(-1.49995000000000))*(cj2)*(pz)))+(((x66)*(x67)))+(((IkReal(0.000100000000000000))*(pz)))+(((IkReal(-0.529137361500000))*(sj2)))+(((x65)*(x68)))+(((x65)*(x66)))));
-IkReal x69=((cj0)*(px));
-IkReal x70=((py)*(sj0));
-IkReal x71=((IkReal(550.600000000000))*(cj2));
-IkReal x72=((IkReal(14999.5000000000))*(sj2));
-dummyeval[0]=((IkReal(4409.27223000000))+(((IkReal(-12499.0000000000))*(x69)))+(((IkReal(-5291.37361500000))*(sj2)))+(((IkReal(-194.235162000000))*(cj2)))+(((x69)*(x72)))+(((x69)*(x71)))+(pz)+(((x70)*(x71)))+(((x70)*(x72)))+(((IkReal(-14999.5000000000))*(cj2)*(pz)))+(((IkReal(-12499.0000000000))*(x70)))+(((IkReal(550.600000000000))*(pz)*(sj2))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst1;
-IkReal x73=((cj0)*(px));
-IkReal x74=((py)*(sj0));
-gconst1=IKsign(((IkReal(-0.124446672900000))+(((IkReal(-1.00000000000000))*((x74)*(x74))))+(((IkReal(-2.00000000000000))*(x73)*(x74)))+(((IkReal(-1.00000000000000))*((pz)*(pz))))+(((IkReal(-1.00000000000000))*((x73)*(x73))))+(((IkReal(0.705540000000000))*(x73)))+(((IkReal(0.705540000000000))*(x74)))));
-IkReal x75=((py)*(sj0));
-IkReal x76=((cj0)*(px));
-dummyeval[0]=((IkReal(-1.00000000000000))+(((IkReal(-8.03557039088990))*((x76)*(x76))))+(((IkReal(5.66941633358846))*(x75)))+(((IkReal(5.66941633358846))*(x76)))+(((IkReal(-8.03557039088990))*((pz)*(pz))))+(((IkReal(-8.03557039088990))*((x75)*(x75))))+(((IkReal(-16.0711407817798))*(x75)*(x76))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j1array[1], cj1array[1], sj1array[1];
-bool j1valid[1]={false};
-_nj1 = 1;
-IkReal x77=((py)*(sj0));
-IkReal x78=((IkReal(1.49995000000000))*(pz));
-IkReal x79=((IkReal(0.0550600000000000))*(cj2));
-IkReal x80=((cj0)*(px));
-IkReal x81=((IkReal(0.0550600000000000))*(sj2));
-IkReal x82=((IkReal(1.49995000000000))*(x77));
-IkReal x83=((IkReal(0.0550600000000000))*(x80));
-if( IKabs(((gconst1)*(((IkReal(0.440927223000000))+(((sj2)*(x82)))+(((x79)*(x80)))+(((IkReal(1.49995000000000))*(sj2)*(x80)))+(((IkReal(-1.24990000000000))*(x77)))+(((IkReal(-1.24990000000000))*(x80)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((cj2)*(x78)))+(((IkReal(-0.000100000000000000))*(pz)))+(((x77)*(x79)))+(((IkReal(-1.00000000000000))*(pz)*(x81)))+(((IkReal(-0.529137361500000))*(sj2))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst1)*(((IkReal(-3.52770000000000e-5))+(((x77)*(x81)))+(((IkReal(0.000100000000000000))*(x80)))+(((pz)*(x79)))+(((IkReal(0.000100000000000000))*(x77)))+(((IkReal(-1.24990000000000))*(pz)))+(((IkReal(0.529137361500000))*(cj2)))+(((IkReal(-1.49995000000000))*(cj2)*(x80)))+(((sj2)*(x78)))+(((IkReal(-0.0194235162000000))*(sj2)))+(((x80)*(x81)))+(((IkReal(-1.00000000000000))*(cj2)*(x82))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j1array[0]=IKatan2(((gconst1)*(((IkReal(0.440927223000000))+(((sj2)*(x82)))+(((x79)*(x80)))+(((IkReal(1.49995000000000))*(sj2)*(x80)))+(((IkReal(-1.24990000000000))*(x77)))+(((IkReal(-1.24990000000000))*(x80)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((cj2)*(x78)))+(((IkReal(-0.000100000000000000))*(pz)))+(((x77)*(x79)))+(((IkReal(-1.00000000000000))*(pz)*(x81)))+(((IkReal(-0.529137361500000))*(sj2)))))), ((gconst1)*(((IkReal(-3.52770000000000e-5))+(((x77)*(x81)))+(((IkReal(0.000100000000000000))*(x80)))+(((pz)*(x79)))+(((IkReal(0.000100000000000000))*(x77)))+(((IkReal(-1.24990000000000))*(pz)))+(((IkReal(0.529137361500000))*(cj2)))+(((IkReal(-1.49995000000000))*(cj2)*(x80)))+(((sj2)*(x78)))+(((IkReal(-0.0194235162000000))*(sj2)))+(((x80)*(x81)))+(((IkReal(-1.00000000000000))*(cj2)*(x82)))))));
-sj1array[0]=IKsin(j1array[0]);
-cj1array[0]=IKcos(j1array[0]);
-if( j1array[0] > IKPI )
-{
-    j1array[0]-=IK2PI;
-}
-else if( j1array[0] < -IKPI )
-{    j1array[0]+=IK2PI;
-}
-j1valid[0] = true;
-for(int ij1 = 0; ij1 < 1; ++ij1)
-{
-if( !j1valid[ij1] )
-{
-    continue;
-}
-_ij1[0] = ij1; _ij1[1] = -1;
-for(int iij1 = ij1+1; iij1 < 1; ++iij1)
-{
-if( j1valid[iij1] && IKabs(cj1array[ij1]-cj1array[iij1]) < IKFAST_SOLUTION_THRESH && IKabs(sj1array[ij1]-sj1array[iij1]) < IKFAST_SOLUTION_THRESH )
-{
-    j1valid[iij1]=false; _ij1[1] = iij1; break; 
-}
-}
-j1 = j1array[ij1]; cj1 = cj1array[ij1]; sj1 = sj1array[ij1];
-{
-IkReal evalcond[5];
-IkReal x84=IKsin(j1);
-IkReal x85=IKcos(j1);
-IkReal x86=((IkReal(1.49995000000000))*(sj2));
-IkReal x87=((cj0)*(px));
-IkReal x88=((IkReal(0.0550600000000000))*(cj2));
-IkReal x89=((IkReal(1.49995000000000))*(cj2));
-IkReal x90=((py)*(sj0));
-IkReal x91=((IkReal(0.0550600000000000))*(sj2));
-IkReal x92=((IkReal(1.00000000000000))*(x85));
-IkReal x93=((IkReal(2.49980000000000))*(x84));
-IkReal x94=((pz)*(x85));
-IkReal x95=((pz)*(x84));
-IkReal x96=((IkReal(0.000200000000000000))*(x85));
-evalcond[0]=((IkReal(-1.24990000000000))+(((x84)*(x87)))+(x88)+(x86)+(x94)+(((IkReal(-0.352770000000000))*(x84)))+(((x84)*(x90))));
-evalcond[1]=((IkReal(-0.000100000000000000))+(((IkReal(-1.00000000000000))*(x90)*(x92)))+(((IkReal(-1.00000000000000))*(x87)*(x92)))+(x89)+(x95)+(((IkReal(0.352770000000000))*(x85)))+(((IkReal(-1.00000000000000))*(x91))));
-evalcond[2]=((((x84)*(x89)))+(((x85)*(x88)))+(((x85)*(x86)))+(((IkReal(-1.24990000000000))*(x85)))+(pz)+(((IkReal(-1.00000000000000))*(x84)*(x91)))+(((IkReal(-0.000100000000000000))*(x84))));
-evalcond[3]=((IkReal(0.352770000000000))+(((x85)*(x89)))+(((IkReal(1.24990000000000))*(x84)))+(((IkReal(-1.00000000000000))*(x87)))+(((IkReal(-1.00000000000000))*(x84)*(x86)))+(((IkReal(-1.00000000000000))*(x84)*(x88)))+(((IkReal(-1.00000000000000))*(x90)))+(((IkReal(-0.000100000000000000))*(x85)))+(((IkReal(-1.00000000000000))*(x85)*(x91))));
-evalcond[4]=((IkReal(0.566185873600000))+(((x87)*(x93)))+(((IkReal(-0.881854446000000))*(x84)))+(((IkReal(-1.00000000000000))*(x90)*(x96)))+(((IkReal(-1.00000000000000))*(x87)*(x96)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(7.05540000000000e-5))*(x85)))+(((x90)*(x93)))+(((IkReal(2.49980000000000))*(x94)))+(((IkReal(0.705540000000000))*(x90)))+(((IkReal(0.000200000000000000))*(x95)))+(((IkReal(0.705540000000000))*(x87))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j1array[1], cj1array[1], sj1array[1];
-bool j1valid[1]={false};
-_nj1 = 1;
-IkReal x236=(cj2)*(cj2);
-IkReal x237=(sj2)*(sj2);
-IkReal x238=((cj2)*(sj2));
-IkReal x239=((IkReal(1.00000000000000))*(pz));
-if( IKabs(((gconst0)*(((IkReal(-1.56225001000000))+(((IkReal(3.74957501000000))*(sj2)))+(((IkReal(-0.00303160360000000))*(x236)))+((pz)*(pz))+(((IkReal(0.137638988000000))*(cj2)))+(((IkReal(-0.165174494000000))*(x238)))+(((IkReal(-2.24985000250000))*(x237))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst0)*(((IkReal(0.000124990000000000))+(((IkReal(-1.00000000000000))*(py)*(sj0)*(x239)))+(((IkReal(-1.87479301100000))*(cj2)))+(((IkReal(0.352770000000000))*(pz)))+(((IkReal(-0.0825872470000000))*(x237)))+(((IkReal(2.24681839890000))*(x238)))+(((IkReal(-1.00000000000000))*(cj0)*(px)*(x239)))+(((IkReal(0.0686694990000000))*(sj2)))+(((IkReal(0.0825872470000000))*(x236))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j1array[0]=IKatan2(((gconst0)*(((IkReal(-1.56225001000000))+(((IkReal(3.74957501000000))*(sj2)))+(((IkReal(-0.00303160360000000))*(x236)))+((pz)*(pz))+(((IkReal(0.137638988000000))*(cj2)))+(((IkReal(-0.165174494000000))*(x238)))+(((IkReal(-2.24985000250000))*(x237)))))), ((gconst0)*(((IkReal(0.000124990000000000))+(((IkReal(-1.00000000000000))*(py)*(sj0)*(x239)))+(((IkReal(-1.87479301100000))*(cj2)))+(((IkReal(0.352770000000000))*(pz)))+(((IkReal(-0.0825872470000000))*(x237)))+(((IkReal(2.24681839890000))*(x238)))+(((IkReal(-1.00000000000000))*(cj0)*(px)*(x239)))+(((IkReal(0.0686694990000000))*(sj2)))+(((IkReal(0.0825872470000000))*(x236)))))));
-sj1array[0]=IKsin(j1array[0]);
-cj1array[0]=IKcos(j1array[0]);
-if( j1array[0] > IKPI )
-{
-    j1array[0]-=IK2PI;
-}
-else if( j1array[0] < -IKPI )
-{    j1array[0]+=IK2PI;
-}
-j1valid[0] = true;
-for(int ij1 = 0; ij1 < 1; ++ij1)
-{
-if( !j1valid[ij1] )
-{
-    continue;
-}
-_ij1[0] = ij1; _ij1[1] = -1;
-for(int iij1 = ij1+1; iij1 < 1; ++iij1)
-{
-if( j1valid[iij1] && IKabs(cj1array[ij1]-cj1array[iij1]) < IKFAST_SOLUTION_THRESH && IKabs(sj1array[ij1]-sj1array[iij1]) < IKFAST_SOLUTION_THRESH )
-{
-    j1valid[iij1]=false; _ij1[1] = iij1; break; 
-}
-}
-j1 = j1array[ij1]; cj1 = cj1array[ij1]; sj1 = sj1array[ij1];
-{
-IkReal evalcond[5];
-IkReal x240=IKsin(j1);
-IkReal x241=IKcos(j1);
-IkReal x242=((IkReal(1.49995000000000))*(sj2));
-IkReal x243=((cj0)*(px));
-IkReal x244=((IkReal(0.0550600000000000))*(cj2));
-IkReal x245=((IkReal(1.49995000000000))*(cj2));
-IkReal x246=((py)*(sj0));
-IkReal x247=((IkReal(0.0550600000000000))*(sj2));
-IkReal x248=((IkReal(1.00000000000000))*(x241));
-IkReal x249=((IkReal(2.49980000000000))*(x240));
-IkReal x250=((pz)*(x241));
-IkReal x251=((pz)*(x240));
-IkReal x252=((IkReal(0.000200000000000000))*(x241));
-evalcond[0]=((IkReal(-1.24990000000000))+(((x240)*(x243)))+(((x240)*(x246)))+(((IkReal(-0.352770000000000))*(x240)))+(x250)+(x242)+(x244));
-evalcond[1]=((IkReal(-0.000100000000000000))+(((IkReal(0.352770000000000))*(x241)))+(((IkReal(-1.00000000000000))*(x243)*(x248)))+(x251)+(x245)+(((IkReal(-1.00000000000000))*(x247)))+(((IkReal(-1.00000000000000))*(x246)*(x248))));
-evalcond[2]=((((x240)*(x245)))+(((IkReal(-1.24990000000000))*(x241)))+(pz)+(((x241)*(x244)))+(((x241)*(x242)))+(((IkReal(-1.00000000000000))*(x240)*(x247)))+(((IkReal(-0.000100000000000000))*(x240))));
-evalcond[3]=((IkReal(0.352770000000000))+(((IkReal(-1.00000000000000))*(x246)))+(((IkReal(-1.00000000000000))*(x243)))+(((IkReal(-1.00000000000000))*(x241)*(x247)))+(((x241)*(x245)))+(((IkReal(-1.00000000000000))*(x240)*(x242)))+(((IkReal(-1.00000000000000))*(x240)*(x244)))+(((IkReal(1.24990000000000))*(x240)))+(((IkReal(-0.000100000000000000))*(x241))));
-evalcond[4]=((IkReal(0.566185873600000))+(((IkReal(2.49980000000000))*(x250)))+(((IkReal(-1.00000000000000))*(x246)*(x252)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(0.000200000000000000))*(x251)))+(((IkReal(-0.881854446000000))*(x240)))+(((IkReal(0.705540000000000))*(x243)))+(((IkReal(0.705540000000000))*(x246)))+(((x246)*(x249)))+(((x243)*(x249)))+(((IkReal(-1.00000000000000))*(x243)*(x252)))+(((IkReal(7.05540000000000e-5))*(x241))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-}
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[2], cj0array[2], sj0array[2];
-bool j0valid[2]={false};
-_nj0 = 2;
-if( IKabs(((IkReal(-1.00000000000000))*(py))) < IKFAST_ATAN2_MAGTHRESH && IKabs(px) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x253=((IkReal(1.00000000000000))*(IKatan2(((IkReal(-1.00000000000000))*(py)), px)));
-if( ((((px)*(px))+((py)*(py)))) < (IkReal)-0.00001 )
-    continue;
-if( (((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30)))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30)))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x254=IKasin(((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30))));
-j0array[0]=((x254)+(((IkReal(-1.00000000000000))*(x253))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-j0array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x254)))+(((IkReal(-1.00000000000000))*(x253))));
-sj0array[1]=IKsin(j0array[1]);
-cj0array[1]=IKcos(j0array[1]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-if( j0array[1] > IKPI )
-{
-    j0array[1]-=IK2PI;
-}
-else if( j0array[1] < -IKPI )
-{    j0array[1]+=IK2PI;
-}
-j0valid[1] = true;
-for(int ij0 = 0; ij0 < 2; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 2; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-
-{
-IkReal j2array[2], cj2array[2], sj2array[2];
-bool j2valid[2]={false};
-_nj2 = 2;
-if( (((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0))))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0))))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x255=IKasin(((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0)))));
-j2array[0]=((IkReal(3.10482123119329))+(((IkReal(-1.00000000000000))*(x255))));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-j2array[1]=((IkReal(6.24641388478308))+(x255));
-sj2array[1]=IKsin(j2array[1]);
-cj2array[1]=IKcos(j2array[1]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-if( j2array[1] > IKPI )
-{
-    j2array[1]-=IK2PI;
-}
-else if( j2array[1] < -IKPI )
-{    j2array[1]+=IK2PI;
-}
-j2valid[1] = true;
-for(int ij2 = 0; ij2 < 2; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 2; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-
-{
-IkReal dummyeval[1];
-IkReal gconst0;
-IkReal x256=((py)*(sj0));
-IkReal x257=((IkReal(1.49995000000000))*(sj2));
-IkReal x258=((cj0)*(px));
-IkReal x259=((IkReal(0.0550600000000000))*(cj2));
-gconst0=IKsign(((IkReal(0.440927223000000))+(((x256)*(x257)))+(((x256)*(x259)))+(((x257)*(x258)))+(((IkReal(0.0550600000000000))*(pz)*(sj2)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((IkReal(-1.49995000000000))*(cj2)*(pz)))+(((IkReal(-1.24990000000000))*(x258)))+(((IkReal(-1.24990000000000))*(x256)))+(((x258)*(x259)))+(((IkReal(0.000100000000000000))*(pz)))+(((IkReal(-0.529137361500000))*(sj2)))));
-IkReal x260=((cj0)*(px));
-IkReal x261=((py)*(sj0));
-IkReal x262=((IkReal(550.600000000000))*(cj2));
-IkReal x263=((IkReal(14999.5000000000))*(sj2));
-dummyeval[0]=((IkReal(4409.27223000000))+(((x260)*(x262)))+(((x260)*(x263)))+(((IkReal(-5291.37361500000))*(sj2)))+(((IkReal(-194.235162000000))*(cj2)))+(((IkReal(-12499.0000000000))*(x261)))+(((IkReal(-12499.0000000000))*(x260)))+(pz)+(((x261)*(x263)))+(((x261)*(x262)))+(((IkReal(-14999.5000000000))*(cj2)*(pz)))+(((IkReal(550.600000000000))*(pz)*(sj2))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst1;
-IkReal x264=((cj0)*(px));
-IkReal x265=((py)*(sj0));
-gconst1=IKsign(((IkReal(-0.124446672900000))+(((IkReal(-1.00000000000000))*((x264)*(x264))))+(((IkReal(-1.00000000000000))*((pz)*(pz))))+(((IkReal(-2.00000000000000))*(x264)*(x265)))+(((IkReal(-1.00000000000000))*((x265)*(x265))))+(((IkReal(0.705540000000000))*(x264)))+(((IkReal(0.705540000000000))*(x265)))));
-IkReal x266=((py)*(sj0));
-IkReal x267=((cj0)*(px));
-dummyeval[0]=((IkReal(-1.00000000000000))+(((IkReal(-8.03557039088990))*((x266)*(x266))))+(((IkReal(-16.0711407817798))*(x266)*(x267)))+(((IkReal(-8.03557039088990))*((pz)*(pz))))+(((IkReal(5.66941633358846))*(x266)))+(((IkReal(5.66941633358846))*(x267)))+(((IkReal(-8.03557039088990))*((x267)*(x267)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j1array[1], cj1array[1], sj1array[1];
-bool j1valid[1]={false};
-_nj1 = 1;
-IkReal x268=((py)*(sj0));
-IkReal x269=((IkReal(1.49995000000000))*(pz));
-IkReal x270=((IkReal(0.0550600000000000))*(cj2));
-IkReal x271=((cj0)*(px));
-IkReal x272=((IkReal(0.0550600000000000))*(sj2));
-IkReal x273=((IkReal(1.49995000000000))*(x268));
-IkReal x274=((IkReal(0.0550600000000000))*(x271));
-if( IKabs(((gconst1)*(((IkReal(0.440927223000000))+(((IkReal(-1.00000000000000))*(pz)*(x272)))+(((sj2)*(x273)))+(((x270)*(x271)))+(((IkReal(-1.24990000000000))*(x271)))+(((IkReal(-1.24990000000000))*(x268)))+(((IkReal(1.49995000000000))*(sj2)*(x271)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((IkReal(-0.000100000000000000))*(pz)))+(((cj2)*(x269)))+(((IkReal(-0.529137361500000))*(sj2)))+(((x268)*(x270))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst1)*(((IkReal(-3.52770000000000e-5))+(((IkReal(0.000100000000000000))*(x268)))+(((x271)*(x272)))+(((IkReal(0.000100000000000000))*(x271)))+(((IkReal(-1.24990000000000))*(pz)))+(((IkReal(0.529137361500000))*(cj2)))+(((sj2)*(x269)))+(((IkReal(-1.49995000000000))*(cj2)*(x271)))+(((IkReal(-1.00000000000000))*(cj2)*(x273)))+(((IkReal(-0.0194235162000000))*(sj2)))+(((pz)*(x270)))+(((x268)*(x272))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j1array[0]=IKatan2(((gconst1)*(((IkReal(0.440927223000000))+(((IkReal(-1.00000000000000))*(pz)*(x272)))+(((sj2)*(x273)))+(((x270)*(x271)))+(((IkReal(-1.24990000000000))*(x271)))+(((IkReal(-1.24990000000000))*(x268)))+(((IkReal(1.49995000000000))*(sj2)*(x271)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((IkReal(-0.000100000000000000))*(pz)))+(((cj2)*(x269)))+(((IkReal(-0.529137361500000))*(sj2)))+(((x268)*(x270)))))), ((gconst1)*(((IkReal(-3.52770000000000e-5))+(((IkReal(0.000100000000000000))*(x268)))+(((x271)*(x272)))+(((IkReal(0.000100000000000000))*(x271)))+(((IkReal(-1.24990000000000))*(pz)))+(((IkReal(0.529137361500000))*(cj2)))+(((sj2)*(x269)))+(((IkReal(-1.49995000000000))*(cj2)*(x271)))+(((IkReal(-1.00000000000000))*(cj2)*(x273)))+(((IkReal(-0.0194235162000000))*(sj2)))+(((pz)*(x270)))+(((x268)*(x272)))))));
-sj1array[0]=IKsin(j1array[0]);
-cj1array[0]=IKcos(j1array[0]);
-if( j1array[0] > IKPI )
-{
-    j1array[0]-=IK2PI;
-}
-else if( j1array[0] < -IKPI )
-{    j1array[0]+=IK2PI;
-}
-j1valid[0] = true;
-for(int ij1 = 0; ij1 < 1; ++ij1)
-{
-if( !j1valid[ij1] )
-{
-    continue;
-}
-_ij1[0] = ij1; _ij1[1] = -1;
-for(int iij1 = ij1+1; iij1 < 1; ++iij1)
-{
-if( j1valid[iij1] && IKabs(cj1array[ij1]-cj1array[iij1]) < IKFAST_SOLUTION_THRESH && IKabs(sj1array[ij1]-sj1array[iij1]) < IKFAST_SOLUTION_THRESH )
-{
-    j1valid[iij1]=false; _ij1[1] = iij1; break; 
-}
-}
-j1 = j1array[ij1]; cj1 = cj1array[ij1]; sj1 = sj1array[ij1];
-{
-IkReal evalcond[5];
-IkReal x275=IKsin(j1);
-IkReal x276=IKcos(j1);
-IkReal x277=((IkReal(1.49995000000000))*(sj2));
-IkReal x278=((cj0)*(px));
-IkReal x279=((IkReal(0.0550600000000000))*(cj2));
-IkReal x280=((IkReal(1.49995000000000))*(cj2));
-IkReal x281=((py)*(sj0));
-IkReal x282=((IkReal(0.0550600000000000))*(sj2));
-IkReal x283=((IkReal(1.00000000000000))*(x276));
-IkReal x284=((IkReal(2.49980000000000))*(x275));
-IkReal x285=((pz)*(x276));
-IkReal x286=((pz)*(x275));
-IkReal x287=((IkReal(0.000200000000000000))*(x276));
-evalcond[0]=((IkReal(-1.24990000000000))+(((x275)*(x278)))+(((IkReal(-0.352770000000000))*(x275)))+(x277)+(x279)+(x285)+(((x275)*(x281))));
-evalcond[1]=((IkReal(-0.000100000000000000))+(((IkReal(0.352770000000000))*(x276)))+(((IkReal(-1.00000000000000))*(x281)*(x283)))+(x286)+(x280)+(((IkReal(-1.00000000000000))*(x282)))+(((IkReal(-1.00000000000000))*(x278)*(x283))));
-evalcond[2]=((((IkReal(-1.24990000000000))*(x276)))+(((x275)*(x280)))+(pz)+(((x276)*(x277)))+(((x276)*(x279)))+(((IkReal(-1.00000000000000))*(x275)*(x282)))+(((IkReal(-0.000100000000000000))*(x275))));
-evalcond[3]=((IkReal(0.352770000000000))+(((IkReal(-1.00000000000000))*(x278)))+(((IkReal(-1.00000000000000))*(x276)*(x282)))+(((IkReal(-1.00000000000000))*(x281)))+(((IkReal(1.24990000000000))*(x275)))+(((IkReal(-1.00000000000000))*(x275)*(x277)))+(((IkReal(-1.00000000000000))*(x275)*(x279)))+(((x276)*(x280)))+(((IkReal(-0.000100000000000000))*(x276))));
-evalcond[4]=((IkReal(0.566185873600000))+(((x278)*(x284)))+(((IkReal(2.49980000000000))*(x285)))+(((IkReal(-1.00000000000000))*(x281)*(x287)))+(((IkReal(0.000200000000000000))*(x286)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-0.881854446000000))*(x275)))+(((IkReal(0.705540000000000))*(x281)))+(((x281)*(x284)))+(((IkReal(0.705540000000000))*(x278)))+(((IkReal(7.05540000000000e-5))*(x276)))+(((IkReal(-1.00000000000000))*(x278)*(x287))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j1array[1], cj1array[1], sj1array[1];
-bool j1valid[1]={false};
-_nj1 = 1;
-IkReal x288=(cj2)*(cj2);
-IkReal x289=(sj2)*(sj2);
-IkReal x290=((cj2)*(sj2));
-IkReal x291=((IkReal(1.00000000000000))*(pz));
-if( IKabs(((gconst0)*(((IkReal(-1.56225001000000))+(((IkReal(3.74957501000000))*(sj2)))+(((IkReal(-0.165174494000000))*(x290)))+(((IkReal(-0.00303160360000000))*(x288)))+((pz)*(pz))+(((IkReal(0.137638988000000))*(cj2)))+(((IkReal(-2.24985000250000))*(x289))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst0)*(((IkReal(0.000124990000000000))+(((IkReal(-1.00000000000000))*(cj0)*(px)*(x291)))+(((IkReal(0.0825872470000000))*(x288)))+(((IkReal(-1.87479301100000))*(cj2)))+(((IkReal(0.352770000000000))*(pz)))+(((IkReal(-0.0825872470000000))*(x289)))+(((IkReal(-1.00000000000000))*(py)*(sj0)*(x291)))+(((IkReal(2.24681839890000))*(x290)))+(((IkReal(0.0686694990000000))*(sj2))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j1array[0]=IKatan2(((gconst0)*(((IkReal(-1.56225001000000))+(((IkReal(3.74957501000000))*(sj2)))+(((IkReal(-0.165174494000000))*(x290)))+(((IkReal(-0.00303160360000000))*(x288)))+((pz)*(pz))+(((IkReal(0.137638988000000))*(cj2)))+(((IkReal(-2.24985000250000))*(x289)))))), ((gconst0)*(((IkReal(0.000124990000000000))+(((IkReal(-1.00000000000000))*(cj0)*(px)*(x291)))+(((IkReal(0.0825872470000000))*(x288)))+(((IkReal(-1.87479301100000))*(cj2)))+(((IkReal(0.352770000000000))*(pz)))+(((IkReal(-0.0825872470000000))*(x289)))+(((IkReal(-1.00000000000000))*(py)*(sj0)*(x291)))+(((IkReal(2.24681839890000))*(x290)))+(((IkReal(0.0686694990000000))*(sj2)))))));
-sj1array[0]=IKsin(j1array[0]);
-cj1array[0]=IKcos(j1array[0]);
-if( j1array[0] > IKPI )
-{
-    j1array[0]-=IK2PI;
-}
-else if( j1array[0] < -IKPI )
-{    j1array[0]+=IK2PI;
-}
-j1valid[0] = true;
-for(int ij1 = 0; ij1 < 1; ++ij1)
-{
-if( !j1valid[ij1] )
-{
-    continue;
-}
-_ij1[0] = ij1; _ij1[1] = -1;
-for(int iij1 = ij1+1; iij1 < 1; ++iij1)
-{
-if( j1valid[iij1] && IKabs(cj1array[ij1]-cj1array[iij1]) < IKFAST_SOLUTION_THRESH && IKabs(sj1array[ij1]-sj1array[iij1]) < IKFAST_SOLUTION_THRESH )
-{
-    j1valid[iij1]=false; _ij1[1] = iij1; break; 
-}
-}
-j1 = j1array[ij1]; cj1 = cj1array[ij1]; sj1 = sj1array[ij1];
-{
-IkReal evalcond[5];
-IkReal x292=IKsin(j1);
-IkReal x293=IKcos(j1);
-IkReal x294=((IkReal(1.49995000000000))*(sj2));
-IkReal x295=((cj0)*(px));
-IkReal x296=((IkReal(0.0550600000000000))*(cj2));
-IkReal x297=((IkReal(1.49995000000000))*(cj2));
-IkReal x298=((py)*(sj0));
-IkReal x299=((IkReal(0.0550600000000000))*(sj2));
-IkReal x300=((IkReal(1.00000000000000))*(x293));
-IkReal x301=((IkReal(2.49980000000000))*(x292));
-IkReal x302=((pz)*(x293));
-IkReal x303=((pz)*(x292));
-IkReal x304=((IkReal(0.000200000000000000))*(x293));
-evalcond[0]=((IkReal(-1.24990000000000))+(x302)+(x294)+(x296)+(((x292)*(x298)))+(((x292)*(x295)))+(((IkReal(-0.352770000000000))*(x292))));
-evalcond[1]=((IkReal(-0.000100000000000000))+(((IkReal(-1.00000000000000))*(x298)*(x300)))+(((IkReal(-1.00000000000000))*(x299)))+(((IkReal(-1.00000000000000))*(x295)*(x300)))+(x303)+(x297)+(((IkReal(0.352770000000000))*(x293))));
-evalcond[2]=((((IkReal(-1.24990000000000))*(x293)))+(pz)+(((IkReal(-0.000100000000000000))*(x292)))+(((x293)*(x296)))+(((x293)*(x294)))+(((x292)*(x297)))+(((IkReal(-1.00000000000000))*(x292)*(x299))));
-evalcond[3]=((IkReal(0.352770000000000))+(((IkReal(-1.00000000000000))*(x295)))+(((IkReal(-1.00000000000000))*(x298)))+(((IkReal(-1.00000000000000))*(x293)*(x299)))+(((IkReal(1.24990000000000))*(x292)))+(((IkReal(-0.000100000000000000))*(x293)))+(((x293)*(x297)))+(((IkReal(-1.00000000000000))*(x292)*(x294)))+(((IkReal(-1.00000000000000))*(x292)*(x296))));
-evalcond[4]=((IkReal(0.566185873600000))+(((IkReal(-1.00000000000000))*(x298)*(x304)))+(((IkReal(0.000200000000000000))*(x303)))+(((IkReal(0.705540000000000))*(x298)))+(((IkReal(0.705540000000000))*(x295)))+(((IkReal(-1.00000000000000))*(x295)*(x304)))+(((IkReal(-1.00000000000000))*(pp)))+(((x298)*(x301)))+(((IkReal(7.05540000000000e-5))*(x293)))+(((x295)*(x301)))+(((IkReal(2.49980000000000))*(x302)))+(((IkReal(-0.881854446000000))*(x292))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-}
-}
-}
-}
-
-}
-
-}
-}
-return solutions.GetNumSolutions()>0;
-}
-inline void rotationfunction0(IkSolutionListBase<IkReal>& solutions) {
-for(int rotationiter = 0; rotationiter < 1; ++rotationiter) {
-IkReal x97=((cj0)*(r00));
-IkReal x98=((cj0)*(r01));
-IkReal x99=((sj1)*(sj2));
-IkReal x100=((IkReal(1.00000000000000))*(sj0));
-IkReal x101=((r10)*(sj0));
-IkReal x102=((IkReal(1.00000000000000))*(cj2));
-IkReal x103=((r11)*(sj0));
-IkReal x104=((cj0)*(r02));
-IkReal x105=((r12)*(sj0));
-IkReal x106=((((IkReal(-1.00000000000000))*(cj1)*(x102)))+(x99));
-IkReal x107=((((IkReal(-1.00000000000000))*(x99)))+(((cj1)*(cj2))));
-IkReal x108=((cj0)*(x107));
-IkReal x109=((((IkReal(-1.00000000000000))*(cj1)*(sj2)))+(((IkReal(-1.00000000000000))*(sj1)*(x102))));
-IkReal x110=((sj0)*(x109));
-new_r00=((((r20)*(x106)))+(((x109)*(x97)))+(((x101)*(x109))));
-new_r01=((((r21)*(x106)))+(((x103)*(x109)))+(((x109)*(x98))));
-new_r02=((((r22)*(x106)))+(((x105)*(x109)))+(((x104)*(x109))));
-new_r10=((((IkReal(-1.00000000000000))*(r00)*(x100)))+(((cj0)*(r10))));
-new_r11=((((IkReal(-1.00000000000000))*(r01)*(x100)))+(((cj0)*(r11))));
-new_r12=((((IkReal(-1.00000000000000))*(r02)*(x100)))+(((cj0)*(r12))));
-new_r20=((((x107)*(x97)))+(((r20)*(x109)))+(((x101)*(x107))));
-new_r21=((((x107)*(x98)))+(((r21)*(x109)))+(((x103)*(x107))));
-new_r22=((((r22)*(x109)))+(((x105)*(x107)))+(((x104)*(x107))));
-{
-IkReal j4array[2], cj4array[2], sj4array[2];
-bool j4valid[2]={false};
-_nj4 = 2;
-cj4array[0]=new_r22;
-if( cj4array[0] >= -1-IKFAST_SINCOS_THRESH && cj4array[0] <= 1+IKFAST_SINCOS_THRESH )
-{
-    j4valid[0] = j4valid[1] = true;
-    j4array[0] = IKacos(cj4array[0]);
-    sj4array[0] = IKsin(j4array[0]);
-    cj4array[1] = cj4array[0];
-    j4array[1] = -j4array[0];
-    sj4array[1] = -sj4array[0];
-}
-else if( isnan(cj4array[0]) )
-{
-    // probably any value will work
-    j4valid[0] = true;
-    cj4array[0] = 1; sj4array[0] = 0; j4array[0] = 0;
-}
-for(int ij4 = 0; ij4 < 2; ++ij4)
-{
-if( !j4valid[ij4] )
-{
-    continue;
-}
-_ij4[0] = ij4; _ij4[1] = -1;
-for(int iij4 = ij4+1; iij4 < 2; ++iij4)
-{
-if( j4valid[iij4] && IKabs(cj4array[ij4]-cj4array[iij4]) < IKFAST_SOLUTION_THRESH && IKabs(sj4array[ij4]-sj4array[iij4]) < IKFAST_SOLUTION_THRESH )
-{
-    j4valid[iij4]=false; _ij4[1] = iij4; break; 
-}
-}
-j4 = j4array[ij4]; cj4 = cj4array[ij4]; sj4 = sj4array[ij4];
-
-{
-IkReal dummyeval[1];
-IkReal gconst4;
-gconst4=IKsign(sj4);
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst2;
-gconst2=IKsign((((new_r12)*(new_r12))+((new_r02)*(new_r02))));
-dummyeval[0]=(((new_r12)*(new_r12))+((new_r02)*(new_r02)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst3;
-gconst3=IKsign(((((new_r10)*(new_r12)*(sj4)))+(((new_r00)*(new_r02)*(sj4)))));
-dummyeval[0]=((((new_r10)*(new_r12)*(sj4)))+(((new_r00)*(new_r02)*(sj4))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[7];
-IkReal x111=((IkReal(-1.00000000000000))+(new_r22));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=x111;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=new_r20;
-evalcond[5]=new_r21;
-evalcond[6]=x111;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  )
-{
-{
-IkReal j3array[2], cj3array[2], sj3array[2];
-bool j3valid[2]={false};
-_nj3 = 2;
-if( IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x112=IKatan2(new_r02, new_r12);
-j3array[0]=((IkReal(-1.00000000000000))*(x112));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-j3array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x112))));
-sj3array[1]=IKsin(j3array[1]);
-cj3array[1]=IKcos(j3array[1]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-if( j3array[1] > IKPI )
-{
-    j3array[1]-=IK2PI;
-}
-else if( j3array[1] < -IKPI )
-{    j3array[1]+=IK2PI;
-}
-j3valid[1] = true;
-for(int ij3 = 0; ij3 < 2; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 2; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[1];
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r02)*(IKsin(j3))))+(((new_r12)*(IKcos(j3)))));
-if( IKabs(evalcond[0]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r10)*(sj3)))+(((cj3)*(new_r00))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))))+IKsqr(((((new_r10)*(sj3)))+(((cj3)*(new_r00)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))), ((((new_r10)*(sj3)))+(((cj3)*(new_r00)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x113=IKsin(j5);
-IkReal x114=((IkReal(1.00000000000000))*(sj3));
-IkReal x115=((IkReal(1.00000000000000))*(IKcos(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r00)*(x114)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(x113))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(new_r01)*(x114)))+(((IkReal(-1.00000000000000))*(x115)))+(((cj3)*(new_r11))));
-evalcond[2]=((((new_r11)*(sj3)))+(x113)+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(((IkReal(-1.00000000000000))*(x115)))+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-}
-}
-
-} else
-{
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[5]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[6]=((IkReal(-1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  )
-{
-{
-IkReal j3array[2], cj3array[2], sj3array[2];
-bool j3valid[2]={false};
-_nj3 = 2;
-if( IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x116=IKatan2(new_r02, new_r12);
-j3array[0]=((IkReal(-1.00000000000000))*(x116));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-j3array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x116))));
-sj3array[1]=IKsin(j3array[1]);
-cj3array[1]=IKcos(j3array[1]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-if( j3array[1] > IKPI )
-{
-    j3array[1]-=IK2PI;
-}
-else if( j3array[1] < -IKPI )
-{    j3array[1]+=IK2PI;
-}
-j3valid[1] = true;
-for(int ij3 = 0; ij3 < 2; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 2; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[1];
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r02)*(IKsin(j3))))+(((new_r12)*(IKcos(j3)))));
-if( IKabs(evalcond[0]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((new_r11)*(sj3)))+(((cj3)*(new_r01))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))))+IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))), ((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x117=IKcos(j5);
-IkReal x118=((IkReal(1.00000000000000))*(sj3));
-IkReal x119=((IkReal(1.00000000000000))*(IKsin(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r00)*(x118)))+(((IkReal(-1.00000000000000))*(x119)))+(((cj3)*(new_r10))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(new_r01)*(x118)))+(((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(x117))));
-evalcond[2]=((((new_r11)*(sj3)))+(((IkReal(-1.00000000000000))*(x119)))+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(x117)+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j3array[1], cj3array[1], sj3array[1];
-bool j3valid[1]={false};
-_nj3 = 1;
-IkReal x120=((IkReal(-1.00000000000000))*(cj4)*(gconst3)*(new_r20));
-if( IKabs(((new_r12)*(x120))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r02)*(x120))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j3array[0]=IKatan2(((new_r12)*(x120)), ((new_r02)*(x120)));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-for(int ij3 = 0; ij3 < 1; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 1; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[6];
-IkReal x121=IKsin(j3);
-IkReal x122=IKcos(j3);
-IkReal x123=((IkReal(1.00000000000000))*(sj4));
-IkReal x124=((sj4)*(x121));
-IkReal x125=((sj4)*(x122));
-IkReal x126=((new_r02)*(x122));
-IkReal x127=((new_r12)*(x121));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r02)*(x121)))+(((new_r12)*(x122))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x123)))+(x126)+(x127));
-evalcond[2]=((((new_r00)*(x125)))+(((cj4)*(new_r20)))+(((new_r10)*(x124))));
-evalcond[3]=((((cj4)*(new_r21)))+(((new_r01)*(x125)))+(((new_r11)*(x124))));
-evalcond[4]=((IkReal(-1.00000000000000))+(((cj4)*(new_r22)))+(((new_r02)*(x125)))+(((new_r12)*(x124))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r22)*(x123)))+(((cj4)*(x126)))+(((cj4)*(x127))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst5;
-gconst5=IKsign(sj4);
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[11];
-IkReal x128=((IkReal(-1.00000000000000))+(new_r22));
-IkReal x129=((((IkReal(-1.00000000000000))*(new_r02)*(sj3)))+(((cj3)*(new_r12))));
-IkReal x130=((((new_r12)*(sj3)))+(((cj3)*(new_r02))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=x128;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x129;
-evalcond[5]=x129;
-evalcond[6]=x130;
-evalcond[7]=new_r20;
-evalcond[8]=new_r21;
-evalcond[9]=x128;
-evalcond[10]=x130;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r10)*(sj3)))+(((cj3)*(new_r00))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))))+IKsqr(((((new_r10)*(sj3)))+(((cj3)*(new_r00)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))), ((((new_r10)*(sj3)))+(((cj3)*(new_r00)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x131=IKsin(j5);
-IkReal x132=((IkReal(1.00000000000000))*(sj3));
-IkReal x133=((IkReal(1.00000000000000))*(IKcos(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r00)*(x132)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(x131))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(new_r01)*(x132)))+(((IkReal(-1.00000000000000))*(x133)))+(((cj3)*(new_r11))));
-evalcond[2]=((((new_r11)*(sj3)))+(x131)+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(((IkReal(-1.00000000000000))*(x133)))+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-IkReal x134=((new_r12)*(sj3));
-IkReal x135=((IkReal(1.00000000000000))*(new_r02));
-IkReal x136=((((IkReal(-1.00000000000000))*(sj3)*(x135)))+(((cj3)*(new_r12))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x136;
-evalcond[5]=x136;
-evalcond[6]=((x134)+(((cj3)*(new_r02))));
-evalcond[7]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[8]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[9]=((IkReal(-1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-evalcond[10]=((((IkReal(-1.00000000000000))*(cj3)*(x135)))+(((IkReal(-1.00000000000000))*(x134))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((new_r11)*(sj3)))+(((cj3)*(new_r01))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))))+IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))), ((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x137=IKcos(j5);
-IkReal x138=((IkReal(1.00000000000000))*(sj3));
-IkReal x139=((IkReal(1.00000000000000))*(IKsin(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r00)*(x138)))+(((IkReal(-1.00000000000000))*(x139)))+(((cj3)*(new_r10))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(new_r01)*(x138)))+(((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(x137))));
-evalcond[2]=((((new_r11)*(sj3)))+(((IkReal(-1.00000000000000))*(x139)))+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(x137)+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3)))))+IKsqr(((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3)))), ((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x140=IKsin(j5);
-IkReal x141=IKcos(j5);
-IkReal x142=((IkReal(1.00000000000000))*(sj3));
-IkReal x143=((new_r11)*(sj3));
-IkReal x144=((new_r10)*(sj3));
-IkReal x145=((cj3)*(cj4));
-IkReal x146=((IkReal(1.00000000000000))*(sj4));
-IkReal x147=((IkReal(1.00000000000000))*(x141));
-IkReal x148=((IkReal(1.00000000000000))*(x140));
-evalcond[0]=((((sj4)*(x141)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x140)*(x146)))+(new_r21));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x148)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x142))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r01)*(x142)))+(((IkReal(-1.00000000000000))*(x147)))+(((cj3)*(new_r11))));
-evalcond[4]=((x143)+(((cj3)*(new_r01)))+(((cj4)*(x140))));
-evalcond[5]=((x144)+(((cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(cj4)*(x147))));
-evalcond[6]=((((new_r01)*(x145)))+(((IkReal(-1.00000000000000))*(new_r21)*(x146)))+(x140)+(((cj4)*(x143))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x147)))+(((IkReal(-1.00000000000000))*(new_r20)*(x146)))+(((new_r00)*(x145)))+(((cj4)*(x144))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))))+IKsqr(((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))), ((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x149=IKsin(j5);
-IkReal x150=IKcos(j5);
-IkReal x151=((IkReal(1.00000000000000))*(sj3));
-IkReal x152=((new_r11)*(sj3));
-IkReal x153=((new_r10)*(sj3));
-IkReal x154=((cj3)*(cj4));
-IkReal x155=((IkReal(1.00000000000000))*(sj4));
-IkReal x156=((IkReal(1.00000000000000))*(x150));
-IkReal x157=((IkReal(1.00000000000000))*(x149));
-evalcond[0]=((((sj4)*(x150)))+(new_r20));
-evalcond[1]=((new_r21)+(((IkReal(-1.00000000000000))*(x149)*(x155))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x157)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x151))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x156)))+(((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(new_r01)*(x151))));
-evalcond[4]=((x152)+(((cj3)*(new_r01)))+(((cj4)*(x149))));
-evalcond[5]=((x153)+(((cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(cj4)*(x156))));
-evalcond[6]=((((cj4)*(x152)))+(((new_r01)*(x154)))+(((IkReal(-1.00000000000000))*(new_r21)*(x155)))+(x149));
-evalcond[7]=((((cj4)*(x153)))+(((IkReal(-1.00000000000000))*(new_r20)*(x155)))+(((IkReal(-1.00000000000000))*(x156)))+(((new_r00)*(x154))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((gconst5)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(gconst5)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst5)*(new_r21)), ((IkReal(-1.00000000000000))*(gconst5)*(new_r20)));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x158=IKsin(j5);
-IkReal x159=IKcos(j5);
-IkReal x160=((IkReal(1.00000000000000))*(sj3));
-IkReal x161=((new_r11)*(sj3));
-IkReal x162=((new_r10)*(sj3));
-IkReal x163=((cj3)*(cj4));
-IkReal x164=((IkReal(1.00000000000000))*(sj4));
-IkReal x165=((IkReal(1.00000000000000))*(x159));
-IkReal x166=((IkReal(1.00000000000000))*(x158));
-evalcond[0]=((((sj4)*(x159)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x158)*(x164)))+(new_r21));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r00)*(x160)))+(((IkReal(-1.00000000000000))*(x166)))+(((cj3)*(new_r10))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x165)))+(((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(new_r01)*(x160))));
-evalcond[4]=((((cj4)*(x158)))+(x161)+(((cj3)*(new_r01))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(cj4)*(x165)))+(x162)+(((cj3)*(new_r00))));
-evalcond[6]=((((new_r01)*(x163)))+(((cj4)*(x161)))+(((IkReal(-1.00000000000000))*(new_r21)*(x164)))+(x158));
-evalcond[7]=((((new_r00)*(x163)))+(((cj4)*(x162)))+(((IkReal(-1.00000000000000))*(x165)))+(((IkReal(-1.00000000000000))*(new_r20)*(x164))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j3array[1], cj3array[1], sj3array[1];
-bool j3valid[1]={false};
-_nj3 = 1;
-IkReal x167=((gconst2)*(sj4));
-if( IKabs(((new_r12)*(x167))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r02)*(x167))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j3array[0]=IKatan2(((new_r12)*(x167)), ((new_r02)*(x167)));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-for(int ij3 = 0; ij3 < 1; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 1; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[6];
-IkReal x168=IKsin(j3);
-IkReal x169=IKcos(j3);
-IkReal x170=((IkReal(1.00000000000000))*(sj4));
-IkReal x171=((sj4)*(x168));
-IkReal x172=((sj4)*(x169));
-IkReal x173=((new_r02)*(x169));
-IkReal x174=((new_r12)*(x168));
-evalcond[0]=((((new_r12)*(x169)))+(((IkReal(-1.00000000000000))*(new_r02)*(x168))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x170)))+(x173)+(x174));
-evalcond[2]=((((new_r00)*(x172)))+(((new_r10)*(x171)))+(((cj4)*(new_r20))));
-evalcond[3]=((((new_r01)*(x172)))+(((new_r11)*(x171)))+(((cj4)*(new_r21))));
-evalcond[4]=((IkReal(-1.00000000000000))+(((new_r02)*(x172)))+(((cj4)*(new_r22)))+(((new_r12)*(x171))));
-evalcond[5]=((((cj4)*(x174)))+(((cj4)*(x173)))+(((IkReal(-1.00000000000000))*(new_r22)*(x170))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst5;
-gconst5=IKsign(sj4);
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[11];
-IkReal x175=((IkReal(-1.00000000000000))+(new_r22));
-IkReal x176=((((IkReal(-1.00000000000000))*(new_r02)*(sj3)))+(((cj3)*(new_r12))));
-IkReal x177=((((new_r12)*(sj3)))+(((cj3)*(new_r02))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=x175;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x176;
-evalcond[5]=x176;
-evalcond[6]=x177;
-evalcond[7]=new_r20;
-evalcond[8]=new_r21;
-evalcond[9]=x175;
-evalcond[10]=x177;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r10)*(sj3)))+(((cj3)*(new_r00))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))))+IKsqr(((((new_r10)*(sj3)))+(((cj3)*(new_r00)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))), ((((new_r10)*(sj3)))+(((cj3)*(new_r00)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x178=IKsin(j5);
-IkReal x179=((IkReal(1.00000000000000))*(sj3));
-IkReal x180=((IkReal(1.00000000000000))*(IKcos(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x178)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x179))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x180)))+(((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(new_r01)*(x179))));
-evalcond[2]=((((new_r11)*(sj3)))+(x178)+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(((IkReal(-1.00000000000000))*(x180)))+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-IkReal x181=((new_r12)*(sj3));
-IkReal x182=((IkReal(1.00000000000000))*(new_r02));
-IkReal x183=((((cj3)*(new_r12)))+(((IkReal(-1.00000000000000))*(sj3)*(x182))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x183;
-evalcond[5]=x183;
-evalcond[6]=((x181)+(((cj3)*(new_r02))));
-evalcond[7]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[8]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[9]=((IkReal(-1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-evalcond[10]=((((IkReal(-1.00000000000000))*(x181)))+(((IkReal(-1.00000000000000))*(cj3)*(x182))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((new_r11)*(sj3)))+(((cj3)*(new_r01))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))))+IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))), ((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x184=IKcos(j5);
-IkReal x185=((IkReal(1.00000000000000))*(sj3));
-IkReal x186=((IkReal(1.00000000000000))*(IKsin(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x186)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x185))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x184)))+(((IkReal(-1.00000000000000))*(new_r01)*(x185)))+(((cj3)*(new_r11))));
-evalcond[2]=((((new_r11)*(sj3)))+(((IkReal(-1.00000000000000))*(x186)))+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(x184)+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3)))))+IKsqr(((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3)))), ((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x187=IKsin(j5);
-IkReal x188=IKcos(j5);
-IkReal x189=((IkReal(1.00000000000000))*(sj3));
-IkReal x190=((new_r11)*(sj3));
-IkReal x191=((new_r10)*(sj3));
-IkReal x192=((cj3)*(cj4));
-IkReal x193=((IkReal(1.00000000000000))*(sj4));
-IkReal x194=((IkReal(1.00000000000000))*(x188));
-IkReal x195=((IkReal(1.00000000000000))*(x187));
-evalcond[0]=((((sj4)*(x188)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x187)*(x193)))+(new_r21));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x195)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x189))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x194)))+(((IkReal(-1.00000000000000))*(new_r01)*(x189)))+(((cj3)*(new_r11))));
-evalcond[4]=((x190)+(((cj3)*(new_r01)))+(((cj4)*(x187))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(cj4)*(x194)))+(x191)+(((cj3)*(new_r00))));
-evalcond[6]=((((cj4)*(x190)))+(((new_r01)*(x192)))+(((IkReal(-1.00000000000000))*(new_r21)*(x193)))+(x187));
-evalcond[7]=((((cj4)*(x191)))+(((new_r00)*(x192)))+(((IkReal(-1.00000000000000))*(x194)))+(((IkReal(-1.00000000000000))*(new_r20)*(x193))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))))+IKsqr(((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))), ((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x196=IKsin(j5);
-IkReal x197=IKcos(j5);
-IkReal x198=((IkReal(1.00000000000000))*(sj3));
-IkReal x199=((new_r11)*(sj3));
-IkReal x200=((new_r10)*(sj3));
-IkReal x201=((cj3)*(cj4));
-IkReal x202=((IkReal(1.00000000000000))*(sj4));
-IkReal x203=((IkReal(1.00000000000000))*(x197));
-IkReal x204=((IkReal(1.00000000000000))*(x196));
-evalcond[0]=((((sj4)*(x197)))+(new_r20));
-evalcond[1]=((new_r21)+(((IkReal(-1.00000000000000))*(x196)*(x202))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x204)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x198))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x203)))+(((IkReal(-1.00000000000000))*(new_r01)*(x198)))+(((cj3)*(new_r11))));
-evalcond[4]=((((cj4)*(x196)))+(x199)+(((cj3)*(new_r01))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(cj4)*(x203)))+(x200)+(((cj3)*(new_r00))));
-evalcond[6]=((((cj4)*(x199)))+(((IkReal(-1.00000000000000))*(new_r21)*(x202)))+(((new_r01)*(x201)))+(x196));
-evalcond[7]=((((new_r00)*(x201)))+(((IkReal(-1.00000000000000))*(new_r20)*(x202)))+(((IkReal(-1.00000000000000))*(x203)))+(((cj4)*(x200))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((gconst5)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(gconst5)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst5)*(new_r21)), ((IkReal(-1.00000000000000))*(gconst5)*(new_r20)));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x205=IKsin(j5);
-IkReal x206=IKcos(j5);
-IkReal x207=((IkReal(1.00000000000000))*(sj3));
-IkReal x208=((new_r11)*(sj3));
-IkReal x209=((new_r10)*(sj3));
-IkReal x210=((cj3)*(cj4));
-IkReal x211=((IkReal(1.00000000000000))*(sj4));
-IkReal x212=((IkReal(1.00000000000000))*(x206));
-IkReal x213=((IkReal(1.00000000000000))*(x205));
-evalcond[0]=((((sj4)*(x206)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x205)*(x211)))+(new_r21));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r00)*(x207)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(x213))));
-evalcond[3]=((((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(x212)))+(((IkReal(-1.00000000000000))*(new_r01)*(x207))));
-evalcond[4]=((((cj4)*(x205)))+(x208)+(((cj3)*(new_r01))));
-evalcond[5]=((x209)+(((IkReal(-1.00000000000000))*(cj4)*(x212)))+(((cj3)*(new_r00))));
-evalcond[6]=((((cj4)*(x208)))+(x205)+(((IkReal(-1.00000000000000))*(new_r21)*(x211)))+(((new_r01)*(x210))));
-evalcond[7]=((((cj4)*(x209)))+(((new_r00)*(x210)))+(((IkReal(-1.00000000000000))*(new_r20)*(x211)))+(((IkReal(-1.00000000000000))*(x212))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((gconst4)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(gconst4)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst4)*(new_r21)), ((IkReal(-1.00000000000000))*(gconst4)*(new_r20)));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[2];
-evalcond[0]=((((sj4)*(IKcos(j5))))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(sj4)*(IKsin(j5))))+(new_r21));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst6;
-gconst6=IKsign((((new_r12)*(new_r12))+((new_r02)*(new_r02))));
-dummyeval[0]=(((new_r12)*(new_r12))+((new_r02)*(new_r02)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst7;
-gconst7=IKsign(((((IkReal(-1.00000000000000))*(new_r11)*(new_r12)))+(((IkReal(-1.00000000000000))*(new_r01)*(new_r02)))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*(new_r11)*(new_r12)))+(((IkReal(-1.00000000000000))*(new_r01)*(new_r02))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j3array[1], cj3array[1], sj3array[1];
-bool j3valid[1]={false};
-_nj3 = 1;
-IkReal x214=((cj4)*(gconst7)*(sj5));
-if( IKabs(((new_r12)*(x214))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r02)*(x214))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j3array[0]=IKatan2(((new_r12)*(x214)), ((new_r02)*(x214)));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-for(int ij3 = 0; ij3 < 1; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 1; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[12];
-IkReal x215=IKsin(j3);
-IkReal x216=IKcos(j3);
-IkReal x217=((IkReal(1.00000000000000))*(cj5));
-IkReal x218=((IkReal(1.00000000000000))*(sj4));
-IkReal x219=((cj4)*(x216));
-IkReal x220=((sj4)*(x216));
-IkReal x221=((cj4)*(x215));
-IkReal x222=((new_r11)*(x215));
-IkReal x223=((sj4)*(x215));
-IkReal x224=((IkReal(1.00000000000000))*(x215));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r02)*(x224)))+(((new_r12)*(x216))));
-evalcond[1]=((((new_r02)*(x216)))+(((IkReal(-1.00000000000000))*(x218)))+(((new_r12)*(x215))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(sj5)))+(((new_r10)*(x216)))+(((IkReal(-1.00000000000000))*(new_r00)*(x224))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r01)*(x224)))+(((IkReal(-1.00000000000000))*(x217)))+(((new_r11)*(x216))));
-evalcond[4]=((((cj4)*(sj5)))+(x222)+(((new_r01)*(x216))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(cj4)*(x217)))+(((new_r00)*(x216)))+(((new_r10)*(x215))));
-evalcond[6]=((((new_r00)*(x220)))+(((cj4)*(new_r20)))+(((new_r10)*(x223))));
-evalcond[7]=((((sj4)*(x222)))+(((new_r01)*(x220)))+(((cj4)*(new_r21))));
-evalcond[8]=((IkReal(-1.00000000000000))+(((new_r02)*(x220)))+(((cj4)*(new_r22)))+(((new_r12)*(x223))));
-evalcond[9]=((((new_r12)*(x221)))+(((new_r02)*(x219)))+(((IkReal(-1.00000000000000))*(new_r22)*(x218))));
-evalcond[10]=((sj5)+(((IkReal(-1.00000000000000))*(new_r21)*(x218)))+(((new_r11)*(x221)))+(((new_r01)*(x219))));
-evalcond[11]=((((new_r00)*(x219)))+(((IkReal(-1.00000000000000))*(new_r20)*(x218)))+(((new_r10)*(x221)))+(((IkReal(-1.00000000000000))*(x217))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  || IKabs(evalcond[8]) > 0.000001  || IKabs(evalcond[9]) > 0.000001  || IKabs(evalcond[10]) > 0.000001  || IKabs(evalcond[11]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j3array[1], cj3array[1], sj3array[1];
-bool j3valid[1]={false};
-_nj3 = 1;
-IkReal x225=((gconst6)*(sj4));
-if( IKabs(((new_r12)*(x225))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r02)*(x225))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j3array[0]=IKatan2(((new_r12)*(x225)), ((new_r02)*(x225)));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-for(int ij3 = 0; ij3 < 1; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 1; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[12];
-IkReal x226=IKsin(j3);
-IkReal x227=IKcos(j3);
-IkReal x228=((IkReal(1.00000000000000))*(cj5));
-IkReal x229=((IkReal(1.00000000000000))*(sj4));
-IkReal x230=((cj4)*(x227));
-IkReal x231=((sj4)*(x227));
-IkReal x232=((cj4)*(x226));
-IkReal x233=((new_r11)*(x226));
-IkReal x234=((sj4)*(x226));
-IkReal x235=((IkReal(1.00000000000000))*(x226));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r02)*(x235)))+(((new_r12)*(x227))));
-evalcond[1]=((((new_r02)*(x227)))+(((new_r12)*(x226)))+(((IkReal(-1.00000000000000))*(x229))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(sj5)))+(((new_r10)*(x227)))+(((IkReal(-1.00000000000000))*(new_r00)*(x235))));
-evalcond[3]=((((new_r11)*(x227)))+(((IkReal(-1.00000000000000))*(new_r01)*(x235)))+(((IkReal(-1.00000000000000))*(x228))));
-evalcond[4]=((((new_r01)*(x227)))+(((cj4)*(sj5)))+(x233));
-evalcond[5]=((((new_r00)*(x227)))+(((IkReal(-1.00000000000000))*(cj4)*(x228)))+(((new_r10)*(x226))));
-evalcond[6]=((((new_r10)*(x234)))+(((cj4)*(new_r20)))+(((new_r00)*(x231))));
-evalcond[7]=((((new_r01)*(x231)))+(((cj4)*(new_r21)))+(((sj4)*(x233))));
-evalcond[8]=((IkReal(-1.00000000000000))+(((new_r02)*(x231)))+(((cj4)*(new_r22)))+(((new_r12)*(x234))));
-evalcond[9]=((((new_r02)*(x230)))+(((new_r12)*(x232)))+(((IkReal(-1.00000000000000))*(new_r22)*(x229))));
-evalcond[10]=((sj5)+(((new_r11)*(x232)))+(((new_r01)*(x230)))+(((IkReal(-1.00000000000000))*(new_r21)*(x229))));
-evalcond[11]=((((new_r10)*(x232)))+(((new_r00)*(x230)))+(((IkReal(-1.00000000000000))*(new_r20)*(x229)))+(((IkReal(-1.00000000000000))*(x228))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  || IKabs(evalcond[8]) > 0.000001  || IKabs(evalcond[9]) > 0.000001  || IKabs(evalcond[10]) > 0.000001  || IKabs(evalcond[11]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-}
-}
-}
-}};
-
+  IkReal j0, cj0, sj0, htj0, j1, cj1, sj1, htj1, j2, cj2, sj2, htj2, j3, cj3, sj3, htj3, j4, cj4, sj4, htj4, j5, cj5,
+      sj5, htj5, new_r00, r00, rxp0_0, new_r01, r01, rxp0_1, new_r02, r02, rxp0_2, new_r10, r10, rxp1_0, new_r11, r11,
+      rxp1_1, new_r12, r12, rxp1_2, new_r20, r20, rxp2_0, new_r21, r21, rxp2_1, new_r22, r22, rxp2_2, new_px, px, npx,
+      new_py, py, npy, new_pz, pz, npz, pp;
+  unsigned char _ij0[2], _nj0, _ij1[2], _nj1, _ij2[2], _nj2, _ij3[2], _nj3, _ij4[2], _nj4, _ij5[2], _nj5;
+
+  bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions)
+  {
+    j0 = numeric_limits<IkReal>::quiet_NaN();
+    _ij0[0] = -1;
+    _ij0[1] = -1;
+    _nj0 = -1;
+    j1 = numeric_limits<IkReal>::quiet_NaN();
+    _ij1[0] = -1;
+    _ij1[1] = -1;
+    _nj1 = -1;
+    j2 = numeric_limits<IkReal>::quiet_NaN();
+    _ij2[0] = -1;
+    _ij2[1] = -1;
+    _nj2 = -1;
+    j3 = numeric_limits<IkReal>::quiet_NaN();
+    _ij3[0] = -1;
+    _ij3[1] = -1;
+    _nj3 = -1;
+    j4 = numeric_limits<IkReal>::quiet_NaN();
+    _ij4[0] = -1;
+    _ij4[1] = -1;
+    _nj4 = -1;
+    j5 = numeric_limits<IkReal>::quiet_NaN();
+    _ij5[0] = -1;
+    _ij5[1] = -1;
+    _nj5 = -1;
+    for (int dummyiter = 0; dummyiter < 1; ++dummyiter)
+    {
+      solutions.Clear();
+      r00 = eerot[0 * 3 + 0];
+      r01 = eerot[0 * 3 + 1];
+      r02 = eerot[0 * 3 + 2];
+      r10 = eerot[1 * 3 + 0];
+      r11 = eerot[1 * 3 + 1];
+      r12 = eerot[1 * 3 + 2];
+      r20 = eerot[2 * 3 + 0];
+      r21 = eerot[2 * 3 + 1];
+      r22 = eerot[2 * 3 + 2];
+      px = eetrans[0];
+      py = eetrans[1];
+      pz = eetrans[2];
+
+      new_r00 = ((IkReal(-1.00000000000000)) * (r02));
+      new_r01 = r01;
+      new_r02 = r00;
+      new_px = ((IkReal(0.00262000000000000)) + (((IkReal(-0.230000000000000)) * (r00))) + (px) +
+                (((IkReal(0.000240000000000000)) * (r02))));
+      new_r10 = ((IkReal(-1.00000000000000)) * (r12));
+      new_r11 = r11;
+      new_r12 = r10;
+      new_py = ((IkReal(-0.000980000000000000)) + (((IkReal(-0.230000000000000)) * (r10))) + (py) +
+                (((IkReal(0.000240000000000000)) * (r12))));
+      new_r20 = ((IkReal(-1.00000000000000)) * (r22));
+      new_r21 = r21;
+      new_r22 = r20;
+      new_pz = ((IkReal(-0.750190000000000)) + (pz) + (((IkReal(0.000240000000000000)) * (r22))) +
+                (((IkReal(-0.230000000000000)) * (r20))));
+      r00 = new_r00;
+      r01 = new_r01;
+      r02 = new_r02;
+      r10 = new_r10;
+      r11 = new_r11;
+      r12 = new_r12;
+      r20 = new_r20;
+      r21 = new_r21;
+      r22 = new_r22;
+      px = new_px;
+      py = new_py;
+      pz = new_pz;
+      pp = (((px) * (px)) + ((py) * (py)) + ((pz) * (pz)));
+      npx = ((((px) * (r00))) + (((py) * (r10))) + (((pz) * (r20))));
+      npy = ((((px) * (r01))) + (((py) * (r11))) + (((pz) * (r21))));
+      npz = ((((px) * (r02))) + (((py) * (r12))) + (((pz) * (r22))));
+      rxp0_0 = ((((IkReal(-1.00000000000000)) * (py) * (r20))) + (((pz) * (r10))));
+      rxp0_1 = ((((px) * (r20))) + (((IkReal(-1.00000000000000)) * (pz) * (r00))));
+      rxp0_2 = ((((IkReal(-1.00000000000000)) * (px) * (r10))) + (((py) * (r00))));
+      rxp1_0 = ((((IkReal(-1.00000000000000)) * (py) * (r21))) + (((pz) * (r11))));
+      rxp1_1 = ((((px) * (r21))) + (((IkReal(-1.00000000000000)) * (pz) * (r01))));
+      rxp1_2 = ((((IkReal(-1.00000000000000)) * (px) * (r11))) + (((py) * (r01))));
+      rxp2_0 = ((((IkReal(-1.00000000000000)) * (py) * (r22))) + (((pz) * (r12))));
+      rxp2_1 = ((((px) * (r22))) + (((IkReal(-1.00000000000000)) * (pz) * (r02))));
+      rxp2_2 = ((((IkReal(-1.00000000000000)) * (px) * (r12))) + (((py) * (r02))));
+      {
+        IkReal dummyeval[1];
+        dummyeval[0] = (((px) * (px)) + ((py) * (py)));
+        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+        {
+          {
+            IkReal dummyeval[1];
+            dummyeval[0] = (((px) * (px)) + ((py) * (py)));
+            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+            {
+              continue;
+            }
+            else
+            {
+              {
+                IkReal j0array[2], cj0array[2], sj0array[2];
+                bool j0valid[2] = { false };
+                _nj0 = 2;
+                if (IKabs(((IkReal(-1.00000000000000)) * (py))) < IKFAST_ATAN2_MAGTHRESH &&
+                    IKabs(px) < IKFAST_ATAN2_MAGTHRESH)
+                  continue;
+                IkReal x62 = ((IkReal(1.00000000000000)) * (IKatan2(((IkReal(-1.00000000000000)) * (py)), px)));
+                if (((((px) * (px)) + ((py) * (py)))) < (IkReal)-0.00001)
+                  continue;
+                if ((((IkReal(0.000980000000000000)) *
+                      (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                            ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                            (IkReal)1.0e30)))) < -1 - IKFAST_SINCOS_THRESH ||
+                    (((IkReal(0.000980000000000000)) *
+                      (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                            ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                            (IkReal)1.0e30)))) > 1 + IKFAST_SINCOS_THRESH)
+                  continue;
+                IkReal x63 = IKasin(((IkReal(0.000980000000000000)) *
+                                     (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                                           ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                                           (IkReal)1.0e30))));
+                j0array[0] = ((x63) + (((IkReal(-1.00000000000000)) * (x62))));
+                sj0array[0] = IKsin(j0array[0]);
+                cj0array[0] = IKcos(j0array[0]);
+                j0array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x62))) +
+                              (((IkReal(-1.00000000000000)) * (x63))));
+                sj0array[1] = IKsin(j0array[1]);
+                cj0array[1] = IKcos(j0array[1]);
+                if (j0array[0] > IKPI)
+                {
+                  j0array[0] -= IK2PI;
+                }
+                else if (j0array[0] < -IKPI)
+                {
+                  j0array[0] += IK2PI;
+                }
+                j0valid[0] = true;
+                if (j0array[1] > IKPI)
+                {
+                  j0array[1] -= IK2PI;
+                }
+                else if (j0array[1] < -IKPI)
+                {
+                  j0array[1] += IK2PI;
+                }
+                j0valid[1] = true;
+                for (int ij0 = 0; ij0 < 2; ++ij0)
+                {
+                  if (!j0valid[ij0])
+                  {
+                    continue;
+                  }
+                  _ij0[0] = ij0;
+                  _ij0[1] = -1;
+                  for (int iij0 = ij0 + 1; iij0 < 2; ++iij0)
+                  {
+                    if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                        IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                    {
+                      j0valid[iij0] = false;
+                      _ij0[1] = iij0;
+                      break;
+                    }
+                  }
+                  j0 = j0array[ij0];
+                  cj0 = cj0array[ij0];
+                  sj0 = sj0array[ij0];
+
+                  {
+                    IkReal j2array[2], cj2array[2], sj2array[2];
+                    bool j2valid[2] = { false };
+                    _nj2 = 2;
+                    if ((((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                          (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                          (((IkReal(0.188038678783115)) * (py) * (sj0))))) < -1 - IKFAST_SINCOS_THRESH ||
+                        (((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                          (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                          (((IkReal(0.188038678783115)) * (py) * (sj0))))) > 1 + IKFAST_SINCOS_THRESH)
+                      continue;
+                    IkReal x64 = IKasin(((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                                         (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                                         (((IkReal(0.188038678783115)) * (py) * (sj0)))));
+                    j2array[0] = ((IkReal(3.10482123119329)) + (((IkReal(-1.00000000000000)) * (x64))));
+                    sj2array[0] = IKsin(j2array[0]);
+                    cj2array[0] = IKcos(j2array[0]);
+                    j2array[1] = ((IkReal(6.24641388478308)) + (x64));
+                    sj2array[1] = IKsin(j2array[1]);
+                    cj2array[1] = IKcos(j2array[1]);
+                    if (j2array[0] > IKPI)
+                    {
+                      j2array[0] -= IK2PI;
+                    }
+                    else if (j2array[0] < -IKPI)
+                    {
+                      j2array[0] += IK2PI;
+                    }
+                    j2valid[0] = true;
+                    if (j2array[1] > IKPI)
+                    {
+                      j2array[1] -= IK2PI;
+                    }
+                    else if (j2array[1] < -IKPI)
+                    {
+                      j2array[1] += IK2PI;
+                    }
+                    j2valid[1] = true;
+                    for (int ij2 = 0; ij2 < 2; ++ij2)
+                    {
+                      if (!j2valid[ij2])
+                      {
+                        continue;
+                      }
+                      _ij2[0] = ij2;
+                      _ij2[1] = -1;
+                      for (int iij2 = ij2 + 1; iij2 < 2; ++iij2)
+                      {
+                        if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                            IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                        {
+                          j2valid[iij2] = false;
+                          _ij2[1] = iij2;
+                          break;
+                        }
+                      }
+                      j2 = j2array[ij2];
+                      cj2 = cj2array[ij2];
+                      sj2 = sj2array[ij2];
+
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst0;
+                        IkReal x65 = ((py) * (sj0));
+                        IkReal x66 = ((IkReal(1.49995000000000)) * (sj2));
+                        IkReal x67 = ((cj0) * (px));
+                        IkReal x68 = ((IkReal(0.0550600000000000)) * (cj2));
+                        gconst0 = IKsign(
+                            ((IkReal(0.440927223000000)) + (((IkReal(-1.24990000000000)) * (x65))) +
+                             (((IkReal(-1.24990000000000)) * (x67))) + (((IkReal(0.0550600000000000)) * (pz) * (sj2))) +
+                             (((x67) * (x68))) + (((IkReal(-0.0194235162000000)) * (cj2))) +
+                             (((IkReal(-1.49995000000000)) * (cj2) * (pz))) + (((x66) * (x67))) +
+                             (((IkReal(0.000100000000000000)) * (pz))) + (((IkReal(-0.529137361500000)) * (sj2))) +
+                             (((x65) * (x68))) + (((x65) * (x66)))));
+                        IkReal x69 = ((cj0) * (px));
+                        IkReal x70 = ((py) * (sj0));
+                        IkReal x71 = ((IkReal(550.600000000000)) * (cj2));
+                        IkReal x72 = ((IkReal(14999.5000000000)) * (sj2));
+                        dummyeval[0] =
+                            ((IkReal(4409.27223000000)) + (((IkReal(-12499.0000000000)) * (x69))) +
+                             (((IkReal(-5291.37361500000)) * (sj2))) + (((IkReal(-194.235162000000)) * (cj2))) +
+                             (((x69) * (x72))) + (((x69) * (x71))) + (pz) + (((x70) * (x71))) + (((x70) * (x72))) +
+                             (((IkReal(-14999.5000000000)) * (cj2) * (pz))) + (((IkReal(-12499.0000000000)) * (x70))) +
+                             (((IkReal(550.600000000000)) * (pz) * (sj2))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal dummyeval[1];
+                            IkReal gconst1;
+                            IkReal x73 = ((cj0) * (px));
+                            IkReal x74 = ((py) * (sj0));
+                            gconst1 = IKsign(
+                                ((IkReal(-0.124446672900000)) + (((IkReal(-1.00000000000000)) * ((x74) * (x74)))) +
+                                 (((IkReal(-2.00000000000000)) * (x73) * (x74))) +
+                                 (((IkReal(-1.00000000000000)) * ((pz) * (pz)))) +
+                                 (((IkReal(-1.00000000000000)) * ((x73) * (x73)))) +
+                                 (((IkReal(0.705540000000000)) * (x73))) + (((IkReal(0.705540000000000)) * (x74)))));
+                            IkReal x75 = ((py) * (sj0));
+                            IkReal x76 = ((cj0) * (px));
+                            dummyeval[0] =
+                                ((IkReal(-1.00000000000000)) + (((IkReal(-8.03557039088990)) * ((x76) * (x76)))) +
+                                 (((IkReal(5.66941633358846)) * (x75))) + (((IkReal(5.66941633358846)) * (x76))) +
+                                 (((IkReal(-8.03557039088990)) * ((pz) * (pz)))) +
+                                 (((IkReal(-8.03557039088990)) * ((x75) * (x75)))) +
+                                 (((IkReal(-16.0711407817798)) * (x75) * (x76))));
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              continue;
+                            }
+                            else
+                            {
+                              {
+                                IkReal j1array[1], cj1array[1], sj1array[1];
+                                bool j1valid[1] = { false };
+                                _nj1 = 1;
+                                IkReal x77 = ((py) * (sj0));
+                                IkReal x78 = ((IkReal(1.49995000000000)) * (pz));
+                                IkReal x79 = ((IkReal(0.0550600000000000)) * (cj2));
+                                IkReal x80 = ((cj0) * (px));
+                                IkReal x81 = ((IkReal(0.0550600000000000)) * (sj2));
+                                IkReal x82 = ((IkReal(1.49995000000000)) * (x77));
+                                IkReal x83 = ((IkReal(0.0550600000000000)) * (x80));
+                                if (IKabs(((gconst1) *
+                                           (((IkReal(0.440927223000000)) + (((sj2) * (x82))) + (((x79) * (x80))) +
+                                             (((IkReal(1.49995000000000)) * (sj2) * (x80))) +
+                                             (((IkReal(-1.24990000000000)) * (x77))) +
+                                             (((IkReal(-1.24990000000000)) * (x80))) +
+                                             (((IkReal(-0.0194235162000000)) * (cj2))) + (((cj2) * (x78))) +
+                                             (((IkReal(-0.000100000000000000)) * (pz))) + (((x77) * (x79))) +
+                                             (((IkReal(-1.00000000000000)) * (pz) * (x81))) +
+                                             (((IkReal(-0.529137361500000)) * (sj2))))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((gconst1) *
+                                           (((IkReal(-3.52770000000000e-5)) + (((x77) * (x81))) +
+                                             (((IkReal(0.000100000000000000)) * (x80))) + (((pz) * (x79))) +
+                                             (((IkReal(0.000100000000000000)) * (x77))) +
+                                             (((IkReal(-1.24990000000000)) * (pz))) +
+                                             (((IkReal(0.529137361500000)) * (cj2))) +
+                                             (((IkReal(-1.49995000000000)) * (cj2) * (x80))) + (((sj2) * (x78))) +
+                                             (((IkReal(-0.0194235162000000)) * (sj2))) + (((x80) * (x81))) +
+                                             (((IkReal(-1.00000000000000)) * (cj2) * (x82))))))) <
+                                        IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                j1array[0] = IKatan2(
+                                    ((gconst1) * (((IkReal(0.440927223000000)) + (((sj2) * (x82))) + (((x79) * (x80))) +
+                                                   (((IkReal(1.49995000000000)) * (sj2) * (x80))) +
+                                                   (((IkReal(-1.24990000000000)) * (x77))) +
+                                                   (((IkReal(-1.24990000000000)) * (x80))) +
+                                                   (((IkReal(-0.0194235162000000)) * (cj2))) + (((cj2) * (x78))) +
+                                                   (((IkReal(-0.000100000000000000)) * (pz))) + (((x77) * (x79))) +
+                                                   (((IkReal(-1.00000000000000)) * (pz) * (x81))) +
+                                                   (((IkReal(-0.529137361500000)) * (sj2)))))),
+                                    ((gconst1) * (((IkReal(-3.52770000000000e-5)) + (((x77) * (x81))) +
+                                                   (((IkReal(0.000100000000000000)) * (x80))) + (((pz) * (x79))) +
+                                                   (((IkReal(0.000100000000000000)) * (x77))) +
+                                                   (((IkReal(-1.24990000000000)) * (pz))) +
+                                                   (((IkReal(0.529137361500000)) * (cj2))) +
+                                                   (((IkReal(-1.49995000000000)) * (cj2) * (x80))) + (((sj2) * (x78))) +
+                                                   (((IkReal(-0.0194235162000000)) * (sj2))) + (((x80) * (x81))) +
+                                                   (((IkReal(-1.00000000000000)) * (cj2) * (x82)))))));
+                                sj1array[0] = IKsin(j1array[0]);
+                                cj1array[0] = IKcos(j1array[0]);
+                                if (j1array[0] > IKPI)
+                                {
+                                  j1array[0] -= IK2PI;
+                                }
+                                else if (j1array[0] < -IKPI)
+                                {
+                                  j1array[0] += IK2PI;
+                                }
+                                j1valid[0] = true;
+                                for (int ij1 = 0; ij1 < 1; ++ij1)
+                                {
+                                  if (!j1valid[ij1])
+                                  {
+                                    continue;
+                                  }
+                                  _ij1[0] = ij1;
+                                  _ij1[1] = -1;
+                                  for (int iij1 = ij1 + 1; iij1 < 1; ++iij1)
+                                  {
+                                    if (j1valid[iij1] &&
+                                        IKabs(cj1array[ij1] - cj1array[iij1]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj1array[ij1] - sj1array[iij1]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j1valid[iij1] = false;
+                                      _ij1[1] = iij1;
+                                      break;
+                                    }
+                                  }
+                                  j1 = j1array[ij1];
+                                  cj1 = cj1array[ij1];
+                                  sj1 = sj1array[ij1];
+                                  {
+                                    IkReal evalcond[5];
+                                    IkReal x84 = IKsin(j1);
+                                    IkReal x85 = IKcos(j1);
+                                    IkReal x86 = ((IkReal(1.49995000000000)) * (sj2));
+                                    IkReal x87 = ((cj0) * (px));
+                                    IkReal x88 = ((IkReal(0.0550600000000000)) * (cj2));
+                                    IkReal x89 = ((IkReal(1.49995000000000)) * (cj2));
+                                    IkReal x90 = ((py) * (sj0));
+                                    IkReal x91 = ((IkReal(0.0550600000000000)) * (sj2));
+                                    IkReal x92 = ((IkReal(1.00000000000000)) * (x85));
+                                    IkReal x93 = ((IkReal(2.49980000000000)) * (x84));
+                                    IkReal x94 = ((pz) * (x85));
+                                    IkReal x95 = ((pz) * (x84));
+                                    IkReal x96 = ((IkReal(0.000200000000000000)) * (x85));
+                                    evalcond[0] =
+                                        ((IkReal(-1.24990000000000)) + (((x84) * (x87))) + (x88) + (x86) + (x94) +
+                                         (((IkReal(-0.352770000000000)) * (x84))) + (((x84) * (x90))));
+                                    evalcond[1] = ((IkReal(-0.000100000000000000)) +
+                                                   (((IkReal(-1.00000000000000)) * (x90) * (x92))) +
+                                                   (((IkReal(-1.00000000000000)) * (x87) * (x92))) + (x89) + (x95) +
+                                                   (((IkReal(0.352770000000000)) * (x85))) +
+                                                   (((IkReal(-1.00000000000000)) * (x91))));
+                                    evalcond[2] = ((((x84) * (x89))) + (((x85) * (x88))) + (((x85) * (x86))) +
+                                                   (((IkReal(-1.24990000000000)) * (x85))) + (pz) +
+                                                   (((IkReal(-1.00000000000000)) * (x84) * (x91))) +
+                                                   (((IkReal(-0.000100000000000000)) * (x84))));
+                                    evalcond[3] = ((IkReal(0.352770000000000)) + (((x85) * (x89))) +
+                                                   (((IkReal(1.24990000000000)) * (x84))) +
+                                                   (((IkReal(-1.00000000000000)) * (x87))) +
+                                                   (((IkReal(-1.00000000000000)) * (x84) * (x86))) +
+                                                   (((IkReal(-1.00000000000000)) * (x84) * (x88))) +
+                                                   (((IkReal(-1.00000000000000)) * (x90))) +
+                                                   (((IkReal(-0.000100000000000000)) * (x85))) +
+                                                   (((IkReal(-1.00000000000000)) * (x85) * (x91))));
+                                    evalcond[4] = ((IkReal(0.566185873600000)) + (((x87) * (x93))) +
+                                                   (((IkReal(-0.881854446000000)) * (x84))) +
+                                                   (((IkReal(-1.00000000000000)) * (x90) * (x96))) +
+                                                   (((IkReal(-1.00000000000000)) * (x87) * (x96))) +
+                                                   (((IkReal(-1.00000000000000)) * (pp))) +
+                                                   (((IkReal(7.05540000000000e-5)) * (x85))) + (((x90) * (x93))) +
+                                                   (((IkReal(2.49980000000000)) * (x94))) +
+                                                   (((IkReal(0.705540000000000)) * (x90))) +
+                                                   (((IkReal(0.000200000000000000)) * (x95))) +
+                                                   (((IkReal(0.705540000000000)) * (x87))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  rotationfunction0(solutions);
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          {
+                            IkReal j1array[1], cj1array[1], sj1array[1];
+                            bool j1valid[1] = { false };
+                            _nj1 = 1;
+                            IkReal x236 = (cj2) * (cj2);
+                            IkReal x237 = (sj2) * (sj2);
+                            IkReal x238 = ((cj2) * (sj2));
+                            IkReal x239 = ((IkReal(1.00000000000000)) * (pz));
+                            if (IKabs(((gconst0) *
+                                       (((IkReal(-1.56225001000000)) + (((IkReal(3.74957501000000)) * (sj2))) +
+                                         (((IkReal(-0.00303160360000000)) * (x236))) + ((pz) * (pz)) +
+                                         (((IkReal(0.137638988000000)) * (cj2))) +
+                                         (((IkReal(-0.165174494000000)) * (x238))) +
+                                         (((IkReal(-2.24985000250000)) * (x237))))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((gconst0) * (((IkReal(0.000124990000000000)) +
+                                                     (((IkReal(-1.00000000000000)) * (py) * (sj0) * (x239))) +
+                                                     (((IkReal(-1.87479301100000)) * (cj2))) +
+                                                     (((IkReal(0.352770000000000)) * (pz))) +
+                                                     (((IkReal(-0.0825872470000000)) * (x237))) +
+                                                     (((IkReal(2.24681839890000)) * (x238))) +
+                                                     (((IkReal(-1.00000000000000)) * (cj0) * (px) * (x239))) +
+                                                     (((IkReal(0.0686694990000000)) * (sj2))) +
+                                                     (((IkReal(0.0825872470000000)) * (x236))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j1array[0] = IKatan2(
+                                ((gconst0) *
+                                 (((IkReal(-1.56225001000000)) + (((IkReal(3.74957501000000)) * (sj2))) +
+                                   (((IkReal(-0.00303160360000000)) * (x236))) + ((pz) * (pz)) +
+                                   (((IkReal(0.137638988000000)) * (cj2))) + (((IkReal(-0.165174494000000)) * (x238))) +
+                                   (((IkReal(-2.24985000250000)) * (x237)))))),
+                                ((gconst0) *
+                                 (((IkReal(0.000124990000000000)) +
+                                   (((IkReal(-1.00000000000000)) * (py) * (sj0) * (x239))) +
+                                   (((IkReal(-1.87479301100000)) * (cj2))) + (((IkReal(0.352770000000000)) * (pz))) +
+                                   (((IkReal(-0.0825872470000000)) * (x237))) +
+                                   (((IkReal(2.24681839890000)) * (x238))) +
+                                   (((IkReal(-1.00000000000000)) * (cj0) * (px) * (x239))) +
+                                   (((IkReal(0.0686694990000000)) * (sj2))) +
+                                   (((IkReal(0.0825872470000000)) * (x236)))))));
+                            sj1array[0] = IKsin(j1array[0]);
+                            cj1array[0] = IKcos(j1array[0]);
+                            if (j1array[0] > IKPI)
+                            {
+                              j1array[0] -= IK2PI;
+                            }
+                            else if (j1array[0] < -IKPI)
+                            {
+                              j1array[0] += IK2PI;
+                            }
+                            j1valid[0] = true;
+                            for (int ij1 = 0; ij1 < 1; ++ij1)
+                            {
+                              if (!j1valid[ij1])
+                              {
+                                continue;
+                              }
+                              _ij1[0] = ij1;
+                              _ij1[1] = -1;
+                              for (int iij1 = ij1 + 1; iij1 < 1; ++iij1)
+                              {
+                                if (j1valid[iij1] && IKabs(cj1array[ij1] - cj1array[iij1]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj1array[ij1] - sj1array[iij1]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j1valid[iij1] = false;
+                                  _ij1[1] = iij1;
+                                  break;
+                                }
+                              }
+                              j1 = j1array[ij1];
+                              cj1 = cj1array[ij1];
+                              sj1 = sj1array[ij1];
+                              {
+                                IkReal evalcond[5];
+                                IkReal x240 = IKsin(j1);
+                                IkReal x241 = IKcos(j1);
+                                IkReal x242 = ((IkReal(1.49995000000000)) * (sj2));
+                                IkReal x243 = ((cj0) * (px));
+                                IkReal x244 = ((IkReal(0.0550600000000000)) * (cj2));
+                                IkReal x245 = ((IkReal(1.49995000000000)) * (cj2));
+                                IkReal x246 = ((py) * (sj0));
+                                IkReal x247 = ((IkReal(0.0550600000000000)) * (sj2));
+                                IkReal x248 = ((IkReal(1.00000000000000)) * (x241));
+                                IkReal x249 = ((IkReal(2.49980000000000)) * (x240));
+                                IkReal x250 = ((pz) * (x241));
+                                IkReal x251 = ((pz) * (x240));
+                                IkReal x252 = ((IkReal(0.000200000000000000)) * (x241));
+                                evalcond[0] = ((IkReal(-1.24990000000000)) + (((x240) * (x243))) + (((x240) * (x246))) +
+                                               (((IkReal(-0.352770000000000)) * (x240))) + (x250) + (x242) + (x244));
+                                evalcond[1] =
+                                    ((IkReal(-0.000100000000000000)) + (((IkReal(0.352770000000000)) * (x241))) +
+                                     (((IkReal(-1.00000000000000)) * (x243) * (x248))) + (x251) + (x245) +
+                                     (((IkReal(-1.00000000000000)) * (x247))) +
+                                     (((IkReal(-1.00000000000000)) * (x246) * (x248))));
+                                evalcond[2] = ((((x240) * (x245))) + (((IkReal(-1.24990000000000)) * (x241))) + (pz) +
+                                               (((x241) * (x244))) + (((x241) * (x242))) +
+                                               (((IkReal(-1.00000000000000)) * (x240) * (x247))) +
+                                               (((IkReal(-0.000100000000000000)) * (x240))));
+                                evalcond[3] = ((IkReal(0.352770000000000)) + (((IkReal(-1.00000000000000)) * (x246))) +
+                                               (((IkReal(-1.00000000000000)) * (x243))) +
+                                               (((IkReal(-1.00000000000000)) * (x241) * (x247))) + (((x241) * (x245))) +
+                                               (((IkReal(-1.00000000000000)) * (x240) * (x242))) +
+                                               (((IkReal(-1.00000000000000)) * (x240) * (x244))) +
+                                               (((IkReal(1.24990000000000)) * (x240))) +
+                                               (((IkReal(-0.000100000000000000)) * (x241))));
+                                evalcond[4] = ((IkReal(0.566185873600000)) + (((IkReal(2.49980000000000)) * (x250))) +
+                                               (((IkReal(-1.00000000000000)) * (x246) * (x252))) +
+                                               (((IkReal(-1.00000000000000)) * (pp))) +
+                                               (((IkReal(0.000200000000000000)) * (x251))) +
+                                               (((IkReal(-0.881854446000000)) * (x240))) +
+                                               (((IkReal(0.705540000000000)) * (x243))) +
+                                               (((IkReal(0.705540000000000)) * (x246))) + (((x246) * (x249))) +
+                                               (((x243) * (x249))) + (((IkReal(-1.00000000000000)) * (x243) * (x252))) +
+                                               (((IkReal(7.05540000000000e-5)) * (x241))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              rotationfunction0(solutions);
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        else
+        {
+          {
+            IkReal j0array[2], cj0array[2], sj0array[2];
+            bool j0valid[2] = { false };
+            _nj0 = 2;
+            if (IKabs(((IkReal(-1.00000000000000)) * (py))) < IKFAST_ATAN2_MAGTHRESH &&
+                IKabs(px) < IKFAST_ATAN2_MAGTHRESH)
+              continue;
+            IkReal x253 = ((IkReal(1.00000000000000)) * (IKatan2(((IkReal(-1.00000000000000)) * (py)), px)));
+            if (((((px) * (px)) + ((py) * (py)))) < (IkReal)-0.00001)
+              continue;
+            if ((((IkReal(0.000980000000000000)) *
+                  (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                        ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                        (IkReal)1.0e30)))) < -1 - IKFAST_SINCOS_THRESH ||
+                (((IkReal(0.000980000000000000)) *
+                  (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                        ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                        (IkReal)1.0e30)))) > 1 + IKFAST_SINCOS_THRESH)
+              continue;
+            IkReal x254 = IKasin(
+                ((IkReal(0.000980000000000000)) * (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                                                        ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                                                        (IkReal)1.0e30))));
+            j0array[0] = ((x254) + (((IkReal(-1.00000000000000)) * (x253))));
+            sj0array[0] = IKsin(j0array[0]);
+            cj0array[0] = IKcos(j0array[0]);
+            j0array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x254))) +
+                          (((IkReal(-1.00000000000000)) * (x253))));
+            sj0array[1] = IKsin(j0array[1]);
+            cj0array[1] = IKcos(j0array[1]);
+            if (j0array[0] > IKPI)
+            {
+              j0array[0] -= IK2PI;
+            }
+            else if (j0array[0] < -IKPI)
+            {
+              j0array[0] += IK2PI;
+            }
+            j0valid[0] = true;
+            if (j0array[1] > IKPI)
+            {
+              j0array[1] -= IK2PI;
+            }
+            else if (j0array[1] < -IKPI)
+            {
+              j0array[1] += IK2PI;
+            }
+            j0valid[1] = true;
+            for (int ij0 = 0; ij0 < 2; ++ij0)
+            {
+              if (!j0valid[ij0])
+              {
+                continue;
+              }
+              _ij0[0] = ij0;
+              _ij0[1] = -1;
+              for (int iij0 = ij0 + 1; iij0 < 2; ++iij0)
+              {
+                if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                    IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                {
+                  j0valid[iij0] = false;
+                  _ij0[1] = iij0;
+                  break;
+                }
+              }
+              j0 = j0array[ij0];
+              cj0 = cj0array[ij0];
+              sj0 = sj0array[ij0];
+
+              {
+                IkReal j2array[2], cj2array[2], sj2array[2];
+                bool j2valid[2] = { false };
+                _nj2 = 2;
+                if ((((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                      (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                      (((IkReal(0.188038678783115)) * (py) * (sj0))))) < -1 - IKFAST_SINCOS_THRESH ||
+                    (((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                      (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                      (((IkReal(0.188038678783115)) * (py) * (sj0))))) > 1 + IKFAST_SINCOS_THRESH)
+                  continue;
+                IkReal x255 = IKasin(((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                                      (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                                      (((IkReal(0.188038678783115)) * (py) * (sj0)))));
+                j2array[0] = ((IkReal(3.10482123119329)) + (((IkReal(-1.00000000000000)) * (x255))));
+                sj2array[0] = IKsin(j2array[0]);
+                cj2array[0] = IKcos(j2array[0]);
+                j2array[1] = ((IkReal(6.24641388478308)) + (x255));
+                sj2array[1] = IKsin(j2array[1]);
+                cj2array[1] = IKcos(j2array[1]);
+                if (j2array[0] > IKPI)
+                {
+                  j2array[0] -= IK2PI;
+                }
+                else if (j2array[0] < -IKPI)
+                {
+                  j2array[0] += IK2PI;
+                }
+                j2valid[0] = true;
+                if (j2array[1] > IKPI)
+                {
+                  j2array[1] -= IK2PI;
+                }
+                else if (j2array[1] < -IKPI)
+                {
+                  j2array[1] += IK2PI;
+                }
+                j2valid[1] = true;
+                for (int ij2 = 0; ij2 < 2; ++ij2)
+                {
+                  if (!j2valid[ij2])
+                  {
+                    continue;
+                  }
+                  _ij2[0] = ij2;
+                  _ij2[1] = -1;
+                  for (int iij2 = ij2 + 1; iij2 < 2; ++iij2)
+                  {
+                    if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                        IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                    {
+                      j2valid[iij2] = false;
+                      _ij2[1] = iij2;
+                      break;
+                    }
+                  }
+                  j2 = j2array[ij2];
+                  cj2 = cj2array[ij2];
+                  sj2 = sj2array[ij2];
+
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst0;
+                    IkReal x256 = ((py) * (sj0));
+                    IkReal x257 = ((IkReal(1.49995000000000)) * (sj2));
+                    IkReal x258 = ((cj0) * (px));
+                    IkReal x259 = ((IkReal(0.0550600000000000)) * (cj2));
+                    gconst0 = IKsign(
+                        ((IkReal(0.440927223000000)) + (((x256) * (x257))) + (((x256) * (x259))) + (((x257) * (x258))) +
+                         (((IkReal(0.0550600000000000)) * (pz) * (sj2))) + (((IkReal(-0.0194235162000000)) * (cj2))) +
+                         (((IkReal(-1.49995000000000)) * (cj2) * (pz))) + (((IkReal(-1.24990000000000)) * (x258))) +
+                         (((IkReal(-1.24990000000000)) * (x256))) + (((x258) * (x259))) +
+                         (((IkReal(0.000100000000000000)) * (pz))) + (((IkReal(-0.529137361500000)) * (sj2)))));
+                    IkReal x260 = ((cj0) * (px));
+                    IkReal x261 = ((py) * (sj0));
+                    IkReal x262 = ((IkReal(550.600000000000)) * (cj2));
+                    IkReal x263 = ((IkReal(14999.5000000000)) * (sj2));
+                    dummyeval[0] =
+                        ((IkReal(4409.27223000000)) + (((x260) * (x262))) + (((x260) * (x263))) +
+                         (((IkReal(-5291.37361500000)) * (sj2))) + (((IkReal(-194.235162000000)) * (cj2))) +
+                         (((IkReal(-12499.0000000000)) * (x261))) + (((IkReal(-12499.0000000000)) * (x260))) + (pz) +
+                         (((x261) * (x263))) + (((x261) * (x262))) + (((IkReal(-14999.5000000000)) * (cj2) * (pz))) +
+                         (((IkReal(550.600000000000)) * (pz) * (sj2))));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst1;
+                        IkReal x264 = ((cj0) * (px));
+                        IkReal x265 = ((py) * (sj0));
+                        gconst1 = IKsign(
+                            ((IkReal(-0.124446672900000)) + (((IkReal(-1.00000000000000)) * ((x264) * (x264)))) +
+                             (((IkReal(-1.00000000000000)) * ((pz) * (pz)))) +
+                             (((IkReal(-2.00000000000000)) * (x264) * (x265))) +
+                             (((IkReal(-1.00000000000000)) * ((x265) * (x265)))) +
+                             (((IkReal(0.705540000000000)) * (x264))) + (((IkReal(0.705540000000000)) * (x265)))));
+                        IkReal x266 = ((py) * (sj0));
+                        IkReal x267 = ((cj0) * (px));
+                        dummyeval[0] =
+                            ((IkReal(-1.00000000000000)) + (((IkReal(-8.03557039088990)) * ((x266) * (x266)))) +
+                             (((IkReal(-16.0711407817798)) * (x266) * (x267))) +
+                             (((IkReal(-8.03557039088990)) * ((pz) * (pz)))) + (((IkReal(5.66941633358846)) * (x266))) +
+                             (((IkReal(5.66941633358846)) * (x267))) +
+                             (((IkReal(-8.03557039088990)) * ((x267) * (x267)))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          continue;
+                        }
+                        else
+                        {
+                          {
+                            IkReal j1array[1], cj1array[1], sj1array[1];
+                            bool j1valid[1] = { false };
+                            _nj1 = 1;
+                            IkReal x268 = ((py) * (sj0));
+                            IkReal x269 = ((IkReal(1.49995000000000)) * (pz));
+                            IkReal x270 = ((IkReal(0.0550600000000000)) * (cj2));
+                            IkReal x271 = ((cj0) * (px));
+                            IkReal x272 = ((IkReal(0.0550600000000000)) * (sj2));
+                            IkReal x273 = ((IkReal(1.49995000000000)) * (x268));
+                            IkReal x274 = ((IkReal(0.0550600000000000)) * (x271));
+                            if (IKabs(((gconst1) *
+                                       (((IkReal(0.440927223000000)) + (((IkReal(-1.00000000000000)) * (pz) * (x272))) +
+                                         (((sj2) * (x273))) + (((x270) * (x271))) +
+                                         (((IkReal(-1.24990000000000)) * (x271))) +
+                                         (((IkReal(-1.24990000000000)) * (x268))) +
+                                         (((IkReal(1.49995000000000)) * (sj2) * (x271))) +
+                                         (((IkReal(-0.0194235162000000)) * (cj2))) +
+                                         (((IkReal(-0.000100000000000000)) * (pz))) + (((cj2) * (x269))) +
+                                         (((IkReal(-0.529137361500000)) * (sj2))) + (((x268) * (x270))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs((
+                                    (gconst1) *
+                                    (((IkReal(-3.52770000000000e-5)) + (((IkReal(0.000100000000000000)) * (x268))) +
+                                      (((x271) * (x272))) + (((IkReal(0.000100000000000000)) * (x271))) +
+                                      (((IkReal(-1.24990000000000)) * (pz))) + (((IkReal(0.529137361500000)) * (cj2))) +
+                                      (((sj2) * (x269))) + (((IkReal(-1.49995000000000)) * (cj2) * (x271))) +
+                                      (((IkReal(-1.00000000000000)) * (cj2) * (x273))) +
+                                      (((IkReal(-0.0194235162000000)) * (sj2))) + (((pz) * (x270))) +
+                                      (((x268) * (x272))))))) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j1array[0] = IKatan2(
+                                ((gconst1) *
+                                 (((IkReal(0.440927223000000)) + (((IkReal(-1.00000000000000)) * (pz) * (x272))) +
+                                   (((sj2) * (x273))) + (((x270) * (x271))) + (((IkReal(-1.24990000000000)) * (x271))) +
+                                   (((IkReal(-1.24990000000000)) * (x268))) +
+                                   (((IkReal(1.49995000000000)) * (sj2) * (x271))) +
+                                   (((IkReal(-0.0194235162000000)) * (cj2))) +
+                                   (((IkReal(-0.000100000000000000)) * (pz))) + (((cj2) * (x269))) +
+                                   (((IkReal(-0.529137361500000)) * (sj2))) + (((x268) * (x270)))))),
+                                ((gconst1) *
+                                 (((IkReal(-3.52770000000000e-5)) + (((IkReal(0.000100000000000000)) * (x268))) +
+                                   (((x271) * (x272))) + (((IkReal(0.000100000000000000)) * (x271))) +
+                                   (((IkReal(-1.24990000000000)) * (pz))) + (((IkReal(0.529137361500000)) * (cj2))) +
+                                   (((sj2) * (x269))) + (((IkReal(-1.49995000000000)) * (cj2) * (x271))) +
+                                   (((IkReal(-1.00000000000000)) * (cj2) * (x273))) +
+                                   (((IkReal(-0.0194235162000000)) * (sj2))) + (((pz) * (x270))) +
+                                   (((x268) * (x272)))))));
+                            sj1array[0] = IKsin(j1array[0]);
+                            cj1array[0] = IKcos(j1array[0]);
+                            if (j1array[0] > IKPI)
+                            {
+                              j1array[0] -= IK2PI;
+                            }
+                            else if (j1array[0] < -IKPI)
+                            {
+                              j1array[0] += IK2PI;
+                            }
+                            j1valid[0] = true;
+                            for (int ij1 = 0; ij1 < 1; ++ij1)
+                            {
+                              if (!j1valid[ij1])
+                              {
+                                continue;
+                              }
+                              _ij1[0] = ij1;
+                              _ij1[1] = -1;
+                              for (int iij1 = ij1 + 1; iij1 < 1; ++iij1)
+                              {
+                                if (j1valid[iij1] && IKabs(cj1array[ij1] - cj1array[iij1]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj1array[ij1] - sj1array[iij1]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j1valid[iij1] = false;
+                                  _ij1[1] = iij1;
+                                  break;
+                                }
+                              }
+                              j1 = j1array[ij1];
+                              cj1 = cj1array[ij1];
+                              sj1 = sj1array[ij1];
+                              {
+                                IkReal evalcond[5];
+                                IkReal x275 = IKsin(j1);
+                                IkReal x276 = IKcos(j1);
+                                IkReal x277 = ((IkReal(1.49995000000000)) * (sj2));
+                                IkReal x278 = ((cj0) * (px));
+                                IkReal x279 = ((IkReal(0.0550600000000000)) * (cj2));
+                                IkReal x280 = ((IkReal(1.49995000000000)) * (cj2));
+                                IkReal x281 = ((py) * (sj0));
+                                IkReal x282 = ((IkReal(0.0550600000000000)) * (sj2));
+                                IkReal x283 = ((IkReal(1.00000000000000)) * (x276));
+                                IkReal x284 = ((IkReal(2.49980000000000)) * (x275));
+                                IkReal x285 = ((pz) * (x276));
+                                IkReal x286 = ((pz) * (x275));
+                                IkReal x287 = ((IkReal(0.000200000000000000)) * (x276));
+                                evalcond[0] = ((IkReal(-1.24990000000000)) + (((x275) * (x278))) +
+                                               (((IkReal(-0.352770000000000)) * (x275))) + (x277) + (x279) + (x285) +
+                                               (((x275) * (x281))));
+                                evalcond[1] =
+                                    ((IkReal(-0.000100000000000000)) + (((IkReal(0.352770000000000)) * (x276))) +
+                                     (((IkReal(-1.00000000000000)) * (x281) * (x283))) + (x286) + (x280) +
+                                     (((IkReal(-1.00000000000000)) * (x282))) +
+                                     (((IkReal(-1.00000000000000)) * (x278) * (x283))));
+                                evalcond[2] = ((((IkReal(-1.24990000000000)) * (x276))) + (((x275) * (x280))) + (pz) +
+                                               (((x276) * (x277))) + (((x276) * (x279))) +
+                                               (((IkReal(-1.00000000000000)) * (x275) * (x282))) +
+                                               (((IkReal(-0.000100000000000000)) * (x275))));
+                                evalcond[3] = ((IkReal(0.352770000000000)) + (((IkReal(-1.00000000000000)) * (x278))) +
+                                               (((IkReal(-1.00000000000000)) * (x276) * (x282))) +
+                                               (((IkReal(-1.00000000000000)) * (x281))) +
+                                               (((IkReal(1.24990000000000)) * (x275))) +
+                                               (((IkReal(-1.00000000000000)) * (x275) * (x277))) +
+                                               (((IkReal(-1.00000000000000)) * (x275) * (x279))) + (((x276) * (x280))) +
+                                               (((IkReal(-0.000100000000000000)) * (x276))));
+                                evalcond[4] = ((IkReal(0.566185873600000)) + (((x278) * (x284))) +
+                                               (((IkReal(2.49980000000000)) * (x285))) +
+                                               (((IkReal(-1.00000000000000)) * (x281) * (x287))) +
+                                               (((IkReal(0.000200000000000000)) * (x286))) +
+                                               (((IkReal(-1.00000000000000)) * (pp))) +
+                                               (((IkReal(-0.881854446000000)) * (x275))) +
+                                               (((IkReal(0.705540000000000)) * (x281))) + (((x281) * (x284))) +
+                                               (((IkReal(0.705540000000000)) * (x278))) +
+                                               (((IkReal(7.05540000000000e-5)) * (x276))) +
+                                               (((IkReal(-1.00000000000000)) * (x278) * (x287))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              rotationfunction0(solutions);
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j1array[1], cj1array[1], sj1array[1];
+                        bool j1valid[1] = { false };
+                        _nj1 = 1;
+                        IkReal x288 = (cj2) * (cj2);
+                        IkReal x289 = (sj2) * (sj2);
+                        IkReal x290 = ((cj2) * (sj2));
+                        IkReal x291 = ((IkReal(1.00000000000000)) * (pz));
+                        if (IKabs(((gconst0) * (((IkReal(-1.56225001000000)) + (((IkReal(3.74957501000000)) * (sj2))) +
+                                                 (((IkReal(-0.165174494000000)) * (x290))) +
+                                                 (((IkReal(-0.00303160360000000)) * (x288))) + ((pz) * (pz)) +
+                                                 (((IkReal(0.137638988000000)) * (cj2))) +
+                                                 (((IkReal(-2.24985000250000)) * (x289))))))) <
+                                IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(
+                                ((gconst0) *
+                                 (((IkReal(0.000124990000000000)) +
+                                   (((IkReal(-1.00000000000000)) * (cj0) * (px) * (x291))) +
+                                   (((IkReal(0.0825872470000000)) * (x288))) + (((IkReal(-1.87479301100000)) * (cj2))) +
+                                   (((IkReal(0.352770000000000)) * (pz))) + (((IkReal(-0.0825872470000000)) * (x289))) +
+                                   (((IkReal(-1.00000000000000)) * (py) * (sj0) * (x291))) +
+                                   (((IkReal(2.24681839890000)) * (x290))) +
+                                   (((IkReal(0.0686694990000000)) * (sj2))))))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j1array[0] = IKatan2(
+                            ((gconst0) *
+                             (((IkReal(-1.56225001000000)) + (((IkReal(3.74957501000000)) * (sj2))) +
+                               (((IkReal(-0.165174494000000)) * (x290))) + (((IkReal(-0.00303160360000000)) * (x288))) +
+                               ((pz) * (pz)) + (((IkReal(0.137638988000000)) * (cj2))) +
+                               (((IkReal(-2.24985000250000)) * (x289)))))),
+                            ((gconst0) *
+                             (((IkReal(0.000124990000000000)) +
+                               (((IkReal(-1.00000000000000)) * (cj0) * (px) * (x291))) +
+                               (((IkReal(0.0825872470000000)) * (x288))) + (((IkReal(-1.87479301100000)) * (cj2))) +
+                               (((IkReal(0.352770000000000)) * (pz))) + (((IkReal(-0.0825872470000000)) * (x289))) +
+                               (((IkReal(-1.00000000000000)) * (py) * (sj0) * (x291))) +
+                               (((IkReal(2.24681839890000)) * (x290))) + (((IkReal(0.0686694990000000)) * (sj2)))))));
+                        sj1array[0] = IKsin(j1array[0]);
+                        cj1array[0] = IKcos(j1array[0]);
+                        if (j1array[0] > IKPI)
+                        {
+                          j1array[0] -= IK2PI;
+                        }
+                        else if (j1array[0] < -IKPI)
+                        {
+                          j1array[0] += IK2PI;
+                        }
+                        j1valid[0] = true;
+                        for (int ij1 = 0; ij1 < 1; ++ij1)
+                        {
+                          if (!j1valid[ij1])
+                          {
+                            continue;
+                          }
+                          _ij1[0] = ij1;
+                          _ij1[1] = -1;
+                          for (int iij1 = ij1 + 1; iij1 < 1; ++iij1)
+                          {
+                            if (j1valid[iij1] && IKabs(cj1array[ij1] - cj1array[iij1]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj1array[ij1] - sj1array[iij1]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j1valid[iij1] = false;
+                              _ij1[1] = iij1;
+                              break;
+                            }
+                          }
+                          j1 = j1array[ij1];
+                          cj1 = cj1array[ij1];
+                          sj1 = sj1array[ij1];
+                          {
+                            IkReal evalcond[5];
+                            IkReal x292 = IKsin(j1);
+                            IkReal x293 = IKcos(j1);
+                            IkReal x294 = ((IkReal(1.49995000000000)) * (sj2));
+                            IkReal x295 = ((cj0) * (px));
+                            IkReal x296 = ((IkReal(0.0550600000000000)) * (cj2));
+                            IkReal x297 = ((IkReal(1.49995000000000)) * (cj2));
+                            IkReal x298 = ((py) * (sj0));
+                            IkReal x299 = ((IkReal(0.0550600000000000)) * (sj2));
+                            IkReal x300 = ((IkReal(1.00000000000000)) * (x293));
+                            IkReal x301 = ((IkReal(2.49980000000000)) * (x292));
+                            IkReal x302 = ((pz) * (x293));
+                            IkReal x303 = ((pz) * (x292));
+                            IkReal x304 = ((IkReal(0.000200000000000000)) * (x293));
+                            evalcond[0] =
+                                ((IkReal(-1.24990000000000)) + (x302) + (x294) + (x296) + (((x292) * (x298))) +
+                                 (((x292) * (x295))) + (((IkReal(-0.352770000000000)) * (x292))));
+                            evalcond[1] =
+                                ((IkReal(-0.000100000000000000)) + (((IkReal(-1.00000000000000)) * (x298) * (x300))) +
+                                 (((IkReal(-1.00000000000000)) * (x299))) +
+                                 (((IkReal(-1.00000000000000)) * (x295) * (x300))) + (x303) + (x297) +
+                                 (((IkReal(0.352770000000000)) * (x293))));
+                            evalcond[2] = ((((IkReal(-1.24990000000000)) * (x293))) + (pz) +
+                                           (((IkReal(-0.000100000000000000)) * (x292))) + (((x293) * (x296))) +
+                                           (((x293) * (x294))) + (((x292) * (x297))) +
+                                           (((IkReal(-1.00000000000000)) * (x292) * (x299))));
+                            evalcond[3] = ((IkReal(0.352770000000000)) + (((IkReal(-1.00000000000000)) * (x295))) +
+                                           (((IkReal(-1.00000000000000)) * (x298))) +
+                                           (((IkReal(-1.00000000000000)) * (x293) * (x299))) +
+                                           (((IkReal(1.24990000000000)) * (x292))) +
+                                           (((IkReal(-0.000100000000000000)) * (x293))) + (((x293) * (x297))) +
+                                           (((IkReal(-1.00000000000000)) * (x292) * (x294))) +
+                                           (((IkReal(-1.00000000000000)) * (x292) * (x296))));
+                            evalcond[4] =
+                                ((IkReal(0.566185873600000)) + (((IkReal(-1.00000000000000)) * (x298) * (x304))) +
+                                 (((IkReal(0.000200000000000000)) * (x303))) +
+                                 (((IkReal(0.705540000000000)) * (x298))) + (((IkReal(0.705540000000000)) * (x295))) +
+                                 (((IkReal(-1.00000000000000)) * (x295) * (x304))) +
+                                 (((IkReal(-1.00000000000000)) * (pp))) + (((x298) * (x301))) +
+                                 (((IkReal(7.05540000000000e-5)) * (x293))) + (((x295) * (x301))) +
+                                 (((IkReal(2.49980000000000)) * (x302))) + (((IkReal(-0.881854446000000)) * (x292))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          rotationfunction0(solutions);
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return solutions.GetNumSolutions() > 0;
+  }
+  inline void rotationfunction0(IkSolutionListBase<IkReal>& solutions)
+  {
+    for (int rotationiter = 0; rotationiter < 1; ++rotationiter)
+    {
+      IkReal x97 = ((cj0) * (r00));
+      IkReal x98 = ((cj0) * (r01));
+      IkReal x99 = ((sj1) * (sj2));
+      IkReal x100 = ((IkReal(1.00000000000000)) * (sj0));
+      IkReal x101 = ((r10) * (sj0));
+      IkReal x102 = ((IkReal(1.00000000000000)) * (cj2));
+      IkReal x103 = ((r11) * (sj0));
+      IkReal x104 = ((cj0) * (r02));
+      IkReal x105 = ((r12) * (sj0));
+      IkReal x106 = ((((IkReal(-1.00000000000000)) * (cj1) * (x102))) + (x99));
+      IkReal x107 = ((((IkReal(-1.00000000000000)) * (x99))) + (((cj1) * (cj2))));
+      IkReal x108 = ((cj0) * (x107));
+      IkReal x109 =
+          ((((IkReal(-1.00000000000000)) * (cj1) * (sj2))) + (((IkReal(-1.00000000000000)) * (sj1) * (x102))));
+      IkReal x110 = ((sj0) * (x109));
+      new_r00 = ((((r20) * (x106))) + (((x109) * (x97))) + (((x101) * (x109))));
+      new_r01 = ((((r21) * (x106))) + (((x103) * (x109))) + (((x109) * (x98))));
+      new_r02 = ((((r22) * (x106))) + (((x105) * (x109))) + (((x104) * (x109))));
+      new_r10 = ((((IkReal(-1.00000000000000)) * (r00) * (x100))) + (((cj0) * (r10))));
+      new_r11 = ((((IkReal(-1.00000000000000)) * (r01) * (x100))) + (((cj0) * (r11))));
+      new_r12 = ((((IkReal(-1.00000000000000)) * (r02) * (x100))) + (((cj0) * (r12))));
+      new_r20 = ((((x107) * (x97))) + (((r20) * (x109))) + (((x101) * (x107))));
+      new_r21 = ((((x107) * (x98))) + (((r21) * (x109))) + (((x103) * (x107))));
+      new_r22 = ((((r22) * (x109))) + (((x105) * (x107))) + (((x104) * (x107))));
+      {
+        IkReal j4array[2], cj4array[2], sj4array[2];
+        bool j4valid[2] = { false };
+        _nj4 = 2;
+        cj4array[0] = new_r22;
+        if (cj4array[0] >= -1 - IKFAST_SINCOS_THRESH && cj4array[0] <= 1 + IKFAST_SINCOS_THRESH)
+        {
+          j4valid[0] = j4valid[1] = true;
+          j4array[0] = IKacos(cj4array[0]);
+          sj4array[0] = IKsin(j4array[0]);
+          cj4array[1] = cj4array[0];
+          j4array[1] = -j4array[0];
+          sj4array[1] = -sj4array[0];
+        }
+        else if (isnan(cj4array[0]))
+        {
+          // probably any value will work
+          j4valid[0] = true;
+          cj4array[0] = 1;
+          sj4array[0] = 0;
+          j4array[0] = 0;
+        }
+        for (int ij4 = 0; ij4 < 2; ++ij4)
+        {
+          if (!j4valid[ij4])
+          {
+            continue;
+          }
+          _ij4[0] = ij4;
+          _ij4[1] = -1;
+          for (int iij4 = ij4 + 1; iij4 < 2; ++iij4)
+          {
+            if (j4valid[iij4] && IKabs(cj4array[ij4] - cj4array[iij4]) < IKFAST_SOLUTION_THRESH &&
+                IKabs(sj4array[ij4] - sj4array[iij4]) < IKFAST_SOLUTION_THRESH)
+            {
+              j4valid[iij4] = false;
+              _ij4[1] = iij4;
+              break;
+            }
+          }
+          j4 = j4array[ij4];
+          cj4 = cj4array[ij4];
+          sj4 = sj4array[ij4];
+
+          {
+            IkReal dummyeval[1];
+            IkReal gconst4;
+            gconst4 = IKsign(sj4);
+            dummyeval[0] = sj4;
+            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+            {
+              {
+                IkReal dummyeval[1];
+                IkReal gconst2;
+                gconst2 = IKsign((((new_r12) * (new_r12)) + ((new_r02) * (new_r02))));
+                dummyeval[0] = (((new_r12) * (new_r12)) + ((new_r02) * (new_r02)));
+                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                {
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst3;
+                    gconst3 = IKsign(((((new_r10) * (new_r12) * (sj4))) + (((new_r00) * (new_r02) * (sj4)))));
+                    dummyeval[0] = ((((new_r10) * (new_r12) * (sj4))) + (((new_r00) * (new_r02) * (sj4))));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal evalcond[7];
+                        IkReal x111 = ((IkReal(-1.00000000000000)) + (new_r22));
+                        evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                       (IKfmod(((IkReal(3.14159265358979)) + (j4)), IkReal(6.28318530717959))));
+                        evalcond[1] = x111;
+                        evalcond[2] = new_r20;
+                        evalcond[3] = new_r21;
+                        evalcond[4] = new_r20;
+                        evalcond[5] = new_r21;
+                        evalcond[6] = x111;
+                        if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                            IKabs(evalcond[2]) < 0.0000010000000000 && IKabs(evalcond[3]) < 0.0000010000000000 &&
+                            IKabs(evalcond[4]) < 0.0000010000000000 && IKabs(evalcond[5]) < 0.0000010000000000 &&
+                            IKabs(evalcond[6]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal j3array[2], cj3array[2], sj3array[2];
+                            bool j3valid[2] = { false };
+                            _nj3 = 2;
+                            if (IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            IkReal x112 = IKatan2(new_r02, new_r12);
+                            j3array[0] = ((IkReal(-1.00000000000000)) * (x112));
+                            sj3array[0] = IKsin(j3array[0]);
+                            cj3array[0] = IKcos(j3array[0]);
+                            j3array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x112))));
+                            sj3array[1] = IKsin(j3array[1]);
+                            cj3array[1] = IKcos(j3array[1]);
+                            if (j3array[0] > IKPI)
+                            {
+                              j3array[0] -= IK2PI;
+                            }
+                            else if (j3array[0] < -IKPI)
+                            {
+                              j3array[0] += IK2PI;
+                            }
+                            j3valid[0] = true;
+                            if (j3array[1] > IKPI)
+                            {
+                              j3array[1] -= IK2PI;
+                            }
+                            else if (j3array[1] < -IKPI)
+                            {
+                              j3array[1] += IK2PI;
+                            }
+                            j3valid[1] = true;
+                            for (int ij3 = 0; ij3 < 2; ++ij3)
+                            {
+                              if (!j3valid[ij3])
+                              {
+                                continue;
+                              }
+                              _ij3[0] = ij3;
+                              _ij3[1] = -1;
+                              for (int iij3 = ij3 + 1; iij3 < 2; ++iij3)
+                              {
+                                if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j3valid[iij3] = false;
+                                  _ij3[1] = iij3;
+                                  break;
+                                }
+                              }
+                              j3 = j3array[ij3];
+                              cj3 = cj3array[ij3];
+                              sj3 = sj3array[ij3];
+                              {
+                                IkReal evalcond[1];
+                                evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r02) * (IKsin(j3)))) +
+                                               (((new_r12) * (IKcos(j3)))));
+                                if (IKabs(evalcond[0]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                IkReal j5array[1], cj5array[1], sj5array[1];
+                                bool j5valid[1] = { false };
+                                _nj5 = 1;
+                                if (IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) <
+                                        IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                 (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) +
+                                          IKsqr(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) - 1) <=
+                                        IKFAST_SINCOS_THRESH)
+                                  continue;
+                                j5array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                      (((IkReal(-1.00000000000000)) * (new_r11) * (sj3)))),
+                                                     ((((new_r10) * (sj3))) + (((cj3) * (new_r00)))));
+                                sj5array[0] = IKsin(j5array[0]);
+                                cj5array[0] = IKcos(j5array[0]);
+                                if (j5array[0] > IKPI)
+                                {
+                                  j5array[0] -= IK2PI;
+                                }
+                                else if (j5array[0] < -IKPI)
+                                {
+                                  j5array[0] += IK2PI;
+                                }
+                                j5valid[0] = true;
+                                for (int ij5 = 0; ij5 < 1; ++ij5)
+                                {
+                                  if (!j5valid[ij5])
+                                  {
+                                    continue;
+                                  }
+                                  _ij5[0] = ij5;
+                                  _ij5[1] = -1;
+                                  for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                  {
+                                    if (j5valid[iij5] &&
+                                        IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j5valid[iij5] = false;
+                                      _ij5[1] = iij5;
+                                      break;
+                                    }
+                                  }
+                                  j5 = j5array[ij5];
+                                  cj5 = cj5array[ij5];
+                                  sj5 = sj5array[ij5];
+                                  {
+                                    IkReal evalcond[4];
+                                    IkReal x113 = IKsin(j5);
+                                    IkReal x114 = ((IkReal(1.00000000000000)) * (sj3));
+                                    IkReal x115 = ((IkReal(1.00000000000000)) * (IKcos(j5)));
+                                    evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r00) * (x114))) +
+                                                   (((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (x113))));
+                                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (new_r01) * (x114))) +
+                                                   (((IkReal(-1.00000000000000)) * (x115))) + (((cj3) * (new_r11))));
+                                    evalcond[2] = ((((new_r11) * (sj3))) + (x113) + (((cj3) * (new_r01))));
+                                    evalcond[3] = ((((new_r10) * (sj3))) + (((IkReal(-1.00000000000000)) * (x115))) +
+                                                   (((cj3) * (new_r00))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                    vinfos[0].jointtype = 1;
+                                    vinfos[0].foffset = j0;
+                                    vinfos[0].indices[0] = _ij0[0];
+                                    vinfos[0].indices[1] = _ij0[1];
+                                    vinfos[0].maxsolutions = _nj0;
+                                    vinfos[1].jointtype = 1;
+                                    vinfos[1].foffset = j1;
+                                    vinfos[1].indices[0] = _ij1[0];
+                                    vinfos[1].indices[1] = _ij1[1];
+                                    vinfos[1].maxsolutions = _nj1;
+                                    vinfos[2].jointtype = 1;
+                                    vinfos[2].foffset = j2;
+                                    vinfos[2].indices[0] = _ij2[0];
+                                    vinfos[2].indices[1] = _ij2[1];
+                                    vinfos[2].maxsolutions = _nj2;
+                                    vinfos[3].jointtype = 1;
+                                    vinfos[3].foffset = j3;
+                                    vinfos[3].indices[0] = _ij3[0];
+                                    vinfos[3].indices[1] = _ij3[1];
+                                    vinfos[3].maxsolutions = _nj3;
+                                    vinfos[4].jointtype = 1;
+                                    vinfos[4].foffset = j4;
+                                    vinfos[4].indices[0] = _ij4[0];
+                                    vinfos[4].indices[1] = _ij4[1];
+                                    vinfos[4].maxsolutions = _nj4;
+                                    vinfos[5].jointtype = 1;
+                                    vinfos[5].foffset = j5;
+                                    vinfos[5].indices[0] = _ij5[0];
+                                    vinfos[5].indices[1] = _ij5[1];
+                                    vinfos[5].maxsolutions = _nj5;
+                                    std::vector<int> vfree(0);
+                                    solutions.AddSolution(vinfos, vfree);
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                         (IKfmod(((IkReal(1.11022302462516e-16)) + (j4)), IkReal(6.28318530717959))));
+                          evalcond[1] = ((IkReal(1.00000000000000)) + (new_r22));
+                          evalcond[2] = new_r20;
+                          evalcond[3] = new_r21;
+                          evalcond[4] = ((IkReal(-1.00000000000000)) * (new_r20));
+                          evalcond[5] = ((IkReal(-1.00000000000000)) * (new_r21));
+                          evalcond[6] = ((IkReal(-1.00000000000000)) + (((IkReal(-1.00000000000000)) * (new_r22))));
+                          if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                              IKabs(evalcond[2]) < 0.0000010000000000 && IKabs(evalcond[3]) < 0.0000010000000000 &&
+                              IKabs(evalcond[4]) < 0.0000010000000000 && IKabs(evalcond[5]) < 0.0000010000000000 &&
+                              IKabs(evalcond[6]) < 0.0000010000000000)
+                          {
+                            {
+                              IkReal j3array[2], cj3array[2], sj3array[2];
+                              bool j3valid[2] = { false };
+                              _nj3 = 2;
+                              if (IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH)
+                                continue;
+                              IkReal x116 = IKatan2(new_r02, new_r12);
+                              j3array[0] = ((IkReal(-1.00000000000000)) * (x116));
+                              sj3array[0] = IKsin(j3array[0]);
+                              cj3array[0] = IKcos(j3array[0]);
+                              j3array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x116))));
+                              sj3array[1] = IKsin(j3array[1]);
+                              cj3array[1] = IKcos(j3array[1]);
+                              if (j3array[0] > IKPI)
+                              {
+                                j3array[0] -= IK2PI;
+                              }
+                              else if (j3array[0] < -IKPI)
+                              {
+                                j3array[0] += IK2PI;
+                              }
+                              j3valid[0] = true;
+                              if (j3array[1] > IKPI)
+                              {
+                                j3array[1] -= IK2PI;
+                              }
+                              else if (j3array[1] < -IKPI)
+                              {
+                                j3array[1] += IK2PI;
+                              }
+                              j3valid[1] = true;
+                              for (int ij3 = 0; ij3 < 2; ++ij3)
+                              {
+                                if (!j3valid[ij3])
+                                {
+                                  continue;
+                                }
+                                _ij3[0] = ij3;
+                                _ij3[1] = -1;
+                                for (int iij3 = ij3 + 1; iij3 < 2; ++iij3)
+                                {
+                                  if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                                      IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                                  {
+                                    j3valid[iij3] = false;
+                                    _ij3[1] = iij3;
+                                    break;
+                                  }
+                                }
+                                j3 = j3array[ij3];
+                                cj3 = cj3array[ij3];
+                                sj3 = sj3array[ij3];
+                                {
+                                  IkReal evalcond[1];
+                                  evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r02) * (IKsin(j3)))) +
+                                                 (((new_r12) * (IKcos(j3)))));
+                                  if (IKabs(evalcond[0]) > 0.000001)
+                                  {
+                                    continue;
+                                  }
+                                }
+
+                                {
+                                  IkReal j5array[1], cj5array[1], sj5array[1];
+                                  bool j5valid[1] = { false };
+                                  _nj5 = 1;
+                                  if (IKabs(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                      IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                             (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) <
+                                          IKFAST_ATAN2_MAGTHRESH &&
+                                      IKabs(IKsqr(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) +
+                                            IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) -
+                                            1) <= IKFAST_SINCOS_THRESH)
+                                    continue;
+                                  j5array[0] = IKatan2(((((new_r11) * (sj3))) + (((cj3) * (new_r01)))),
+                                                       ((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                        (((IkReal(-1.00000000000000)) * (new_r10) * (sj3)))));
+                                  sj5array[0] = IKsin(j5array[0]);
+                                  cj5array[0] = IKcos(j5array[0]);
+                                  if (j5array[0] > IKPI)
+                                  {
+                                    j5array[0] -= IK2PI;
+                                  }
+                                  else if (j5array[0] < -IKPI)
+                                  {
+                                    j5array[0] += IK2PI;
+                                  }
+                                  j5valid[0] = true;
+                                  for (int ij5 = 0; ij5 < 1; ++ij5)
+                                  {
+                                    if (!j5valid[ij5])
+                                    {
+                                      continue;
+                                    }
+                                    _ij5[0] = ij5;
+                                    _ij5[1] = -1;
+                                    for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                    {
+                                      if (j5valid[iij5] &&
+                                          IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                          IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                      {
+                                        j5valid[iij5] = false;
+                                        _ij5[1] = iij5;
+                                        break;
+                                      }
+                                    }
+                                    j5 = j5array[ij5];
+                                    cj5 = cj5array[ij5];
+                                    sj5 = sj5array[ij5];
+                                    {
+                                      IkReal evalcond[4];
+                                      IkReal x117 = IKcos(j5);
+                                      IkReal x118 = ((IkReal(1.00000000000000)) * (sj3));
+                                      IkReal x119 = ((IkReal(1.00000000000000)) * (IKsin(j5)));
+                                      evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r00) * (x118))) +
+                                                     (((IkReal(-1.00000000000000)) * (x119))) + (((cj3) * (new_r10))));
+                                      evalcond[1] = ((((IkReal(-1.00000000000000)) * (new_r01) * (x118))) +
+                                                     (((cj3) * (new_r11))) + (((IkReal(-1.00000000000000)) * (x117))));
+                                      evalcond[2] = ((((new_r11) * (sj3))) + (((IkReal(-1.00000000000000)) * (x119))) +
+                                                     (((cj3) * (new_r01))));
+                                      evalcond[3] = ((((new_r10) * (sj3))) + (x117) + (((cj3) * (new_r00))));
+                                      if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                          IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                      {
+                                        continue;
+                                      }
+                                    }
+
+                                    {
+                                      std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                      vinfos[0].jointtype = 1;
+                                      vinfos[0].foffset = j0;
+                                      vinfos[0].indices[0] = _ij0[0];
+                                      vinfos[0].indices[1] = _ij0[1];
+                                      vinfos[0].maxsolutions = _nj0;
+                                      vinfos[1].jointtype = 1;
+                                      vinfos[1].foffset = j1;
+                                      vinfos[1].indices[0] = _ij1[0];
+                                      vinfos[1].indices[1] = _ij1[1];
+                                      vinfos[1].maxsolutions = _nj1;
+                                      vinfos[2].jointtype = 1;
+                                      vinfos[2].foffset = j2;
+                                      vinfos[2].indices[0] = _ij2[0];
+                                      vinfos[2].indices[1] = _ij2[1];
+                                      vinfos[2].maxsolutions = _nj2;
+                                      vinfos[3].jointtype = 1;
+                                      vinfos[3].foffset = j3;
+                                      vinfos[3].indices[0] = _ij3[0];
+                                      vinfos[3].indices[1] = _ij3[1];
+                                      vinfos[3].maxsolutions = _nj3;
+                                      vinfos[4].jointtype = 1;
+                                      vinfos[4].foffset = j4;
+                                      vinfos[4].indices[0] = _ij4[0];
+                                      vinfos[4].indices[1] = _ij4[1];
+                                      vinfos[4].maxsolutions = _nj4;
+                                      vinfos[5].jointtype = 1;
+                                      vinfos[5].foffset = j5;
+                                      vinfos[5].indices[0] = _ij5[0];
+                                      vinfos[5].indices[1] = _ij5[1];
+                                      vinfos[5].maxsolutions = _nj5;
+                                      std::vector<int> vfree(0);
+                                      solutions.AddSolution(vinfos, vfree);
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                          else
+                          {
+                            if (1)
+                            {
+                              continue;
+                            }
+                            else
+                            {
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j3array[1], cj3array[1], sj3array[1];
+                        bool j3valid[1] = { false };
+                        _nj3 = 1;
+                        IkReal x120 = ((IkReal(-1.00000000000000)) * (cj4) * (gconst3) * (new_r20));
+                        if (IKabs(((new_r12) * (x120))) < IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((new_r02) * (x120))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j3array[0] = IKatan2(((new_r12) * (x120)), ((new_r02) * (x120)));
+                        sj3array[0] = IKsin(j3array[0]);
+                        cj3array[0] = IKcos(j3array[0]);
+                        if (j3array[0] > IKPI)
+                        {
+                          j3array[0] -= IK2PI;
+                        }
+                        else if (j3array[0] < -IKPI)
+                        {
+                          j3array[0] += IK2PI;
+                        }
+                        j3valid[0] = true;
+                        for (int ij3 = 0; ij3 < 1; ++ij3)
+                        {
+                          if (!j3valid[ij3])
+                          {
+                            continue;
+                          }
+                          _ij3[0] = ij3;
+                          _ij3[1] = -1;
+                          for (int iij3 = ij3 + 1; iij3 < 1; ++iij3)
+                          {
+                            if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j3valid[iij3] = false;
+                              _ij3[1] = iij3;
+                              break;
+                            }
+                          }
+                          j3 = j3array[ij3];
+                          cj3 = cj3array[ij3];
+                          sj3 = sj3array[ij3];
+                          {
+                            IkReal evalcond[6];
+                            IkReal x121 = IKsin(j3);
+                            IkReal x122 = IKcos(j3);
+                            IkReal x123 = ((IkReal(1.00000000000000)) * (sj4));
+                            IkReal x124 = ((sj4) * (x121));
+                            IkReal x125 = ((sj4) * (x122));
+                            IkReal x126 = ((new_r02) * (x122));
+                            IkReal x127 = ((new_r12) * (x121));
+                            evalcond[0] =
+                                ((((IkReal(-1.00000000000000)) * (new_r02) * (x121))) + (((new_r12) * (x122))));
+                            evalcond[1] = ((((IkReal(-1.00000000000000)) * (x123))) + (x126) + (x127));
+                            evalcond[2] = ((((new_r00) * (x125))) + (((cj4) * (new_r20))) + (((new_r10) * (x124))));
+                            evalcond[3] = ((((cj4) * (new_r21))) + (((new_r01) * (x125))) + (((new_r11) * (x124))));
+                            evalcond[4] = ((IkReal(-1.00000000000000)) + (((cj4) * (new_r22))) +
+                                           (((new_r02) * (x125))) + (((new_r12) * (x124))));
+                            evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r22) * (x123))) + (((cj4) * (x126))) +
+                                           (((cj4) * (x127))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          {
+                            IkReal dummyeval[1];
+                            IkReal gconst5;
+                            gconst5 = IKsign(sj4);
+                            dummyeval[0] = sj4;
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal dummyeval[1];
+                                dummyeval[0] = sj4;
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal dummyeval[1];
+                                    dummyeval[0] = sj4;
+                                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                    {
+                                      {
+                                        IkReal evalcond[11];
+                                        IkReal x128 = ((IkReal(-1.00000000000000)) + (new_r22));
+                                        IkReal x129 = ((((IkReal(-1.00000000000000)) * (new_r02) * (sj3))) +
+                                                       (((cj3) * (new_r12))));
+                                        IkReal x130 = ((((new_r12) * (sj3))) + (((cj3) * (new_r02))));
+                                        evalcond[0] =
+                                            ((IkReal(-3.14159265358979)) +
+                                             (IKfmod(((IkReal(3.14159265358979)) + (j4)), IkReal(6.28318530717959))));
+                                        evalcond[1] = x128;
+                                        evalcond[2] = new_r20;
+                                        evalcond[3] = new_r21;
+                                        evalcond[4] = x129;
+                                        evalcond[5] = x129;
+                                        evalcond[6] = x130;
+                                        evalcond[7] = new_r20;
+                                        evalcond[8] = new_r21;
+                                        evalcond[9] = x128;
+                                        evalcond[10] = x130;
+                                        if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[10]) < 0.0000010000000000)
+                                        {
+                                          {
+                                            IkReal j5array[1], cj5array[1], sj5array[1];
+                                            bool j5valid[1] = { false };
+                                            _nj5 = 1;
+                                            if (IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) <
+                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                IKabs(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) <
+                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                             (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) +
+                                                      IKsqr(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) - 1) <=
+                                                    IKFAST_SINCOS_THRESH)
+                                              continue;
+                                            j5array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                                  (((IkReal(-1.00000000000000)) * (new_r11) * (sj3)))),
+                                                                 ((((new_r10) * (sj3))) + (((cj3) * (new_r00)))));
+                                            sj5array[0] = IKsin(j5array[0]);
+                                            cj5array[0] = IKcos(j5array[0]);
+                                            if (j5array[0] > IKPI)
+                                            {
+                                              j5array[0] -= IK2PI;
+                                            }
+                                            else if (j5array[0] < -IKPI)
+                                            {
+                                              j5array[0] += IK2PI;
+                                            }
+                                            j5valid[0] = true;
+                                            for (int ij5 = 0; ij5 < 1; ++ij5)
+                                            {
+                                              if (!j5valid[ij5])
+                                              {
+                                                continue;
+                                              }
+                                              _ij5[0] = ij5;
+                                              _ij5[1] = -1;
+                                              for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                              {
+                                                if (j5valid[iij5] &&
+                                                    IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                                    IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                                {
+                                                  j5valid[iij5] = false;
+                                                  _ij5[1] = iij5;
+                                                  break;
+                                                }
+                                              }
+                                              j5 = j5array[ij5];
+                                              cj5 = cj5array[ij5];
+                                              sj5 = sj5array[ij5];
+                                              {
+                                                IkReal evalcond[4];
+                                                IkReal x131 = IKsin(j5);
+                                                IkReal x132 = ((IkReal(1.00000000000000)) * (sj3));
+                                                IkReal x133 = ((IkReal(1.00000000000000)) * (IKcos(j5)));
+                                                evalcond[0] =
+                                                    ((((IkReal(-1.00000000000000)) * (new_r00) * (x132))) +
+                                                     (((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (x131))));
+                                                evalcond[1] =
+                                                    ((((IkReal(-1.00000000000000)) * (new_r01) * (x132))) +
+                                                     (((IkReal(-1.00000000000000)) * (x133))) + (((cj3) * (new_r11))));
+                                                evalcond[2] = ((((new_r11) * (sj3))) + (x131) + (((cj3) * (new_r01))));
+                                                evalcond[3] =
+                                                    ((((new_r10) * (sj3))) + (((IkReal(-1.00000000000000)) * (x133))) +
+                                                     (((cj3) * (new_r00))));
+                                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                {
+                                                  continue;
+                                                }
+                                              }
+
+                                              {
+                                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                                vinfos[0].jointtype = 1;
+                                                vinfos[0].foffset = j0;
+                                                vinfos[0].indices[0] = _ij0[0];
+                                                vinfos[0].indices[1] = _ij0[1];
+                                                vinfos[0].maxsolutions = _nj0;
+                                                vinfos[1].jointtype = 1;
+                                                vinfos[1].foffset = j1;
+                                                vinfos[1].indices[0] = _ij1[0];
+                                                vinfos[1].indices[1] = _ij1[1];
+                                                vinfos[1].maxsolutions = _nj1;
+                                                vinfos[2].jointtype = 1;
+                                                vinfos[2].foffset = j2;
+                                                vinfos[2].indices[0] = _ij2[0];
+                                                vinfos[2].indices[1] = _ij2[1];
+                                                vinfos[2].maxsolutions = _nj2;
+                                                vinfos[3].jointtype = 1;
+                                                vinfos[3].foffset = j3;
+                                                vinfos[3].indices[0] = _ij3[0];
+                                                vinfos[3].indices[1] = _ij3[1];
+                                                vinfos[3].maxsolutions = _nj3;
+                                                vinfos[4].jointtype = 1;
+                                                vinfos[4].foffset = j4;
+                                                vinfos[4].indices[0] = _ij4[0];
+                                                vinfos[4].indices[1] = _ij4[1];
+                                                vinfos[4].maxsolutions = _nj4;
+                                                vinfos[5].jointtype = 1;
+                                                vinfos[5].foffset = j5;
+                                                vinfos[5].indices[0] = _ij5[0];
+                                                vinfos[5].indices[1] = _ij5[1];
+                                                vinfos[5].maxsolutions = _nj5;
+                                                std::vector<int> vfree(0);
+                                                solutions.AddSolution(vinfos, vfree);
+                                              }
+                                            }
+                                          }
+                                        }
+                                        else
+                                        {
+                                          IkReal x134 = ((new_r12) * (sj3));
+                                          IkReal x135 = ((IkReal(1.00000000000000)) * (new_r02));
+                                          IkReal x136 = ((((IkReal(-1.00000000000000)) * (sj3) * (x135))) +
+                                                         (((cj3) * (new_r12))));
+                                          evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                         (IKfmod(((IkReal(1.11022302462516e-16)) + (j4)),
+                                                                 IkReal(6.28318530717959))));
+                                          evalcond[1] = ((IkReal(1.00000000000000)) + (new_r22));
+                                          evalcond[2] = new_r20;
+                                          evalcond[3] = new_r21;
+                                          evalcond[4] = x136;
+                                          evalcond[5] = x136;
+                                          evalcond[6] = ((x134) + (((cj3) * (new_r02))));
+                                          evalcond[7] = ((IkReal(-1.00000000000000)) * (new_r20));
+                                          evalcond[8] = ((IkReal(-1.00000000000000)) * (new_r21));
+                                          evalcond[9] = ((IkReal(-1.00000000000000)) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r22))));
+                                          evalcond[10] = ((((IkReal(-1.00000000000000)) * (cj3) * (x135))) +
+                                                          (((IkReal(-1.00000000000000)) * (x134))));
+                                          if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[10]) < 0.0000010000000000)
+                                          {
+                                            {
+                                              IkReal j5array[1], cj5array[1], sj5array[1];
+                                              bool j5valid[1] = { false };
+                                              _nj5 = 1;
+                                              if (IKabs(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) <
+                                                      IKFAST_ATAN2_MAGTHRESH &&
+                                                  IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) <
+                                                      IKFAST_ATAN2_MAGTHRESH &&
+                                                  IKabs(IKsqr(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) +
+                                                        IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                               (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) -
+                                                        1) <= IKFAST_SINCOS_THRESH)
+                                                continue;
+                                              j5array[0] =
+                                                  IKatan2(((((new_r11) * (sj3))) + (((cj3) * (new_r01)))),
+                                                          ((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r10) * (sj3)))));
+                                              sj5array[0] = IKsin(j5array[0]);
+                                              cj5array[0] = IKcos(j5array[0]);
+                                              if (j5array[0] > IKPI)
+                                              {
+                                                j5array[0] -= IK2PI;
+                                              }
+                                              else if (j5array[0] < -IKPI)
+                                              {
+                                                j5array[0] += IK2PI;
+                                              }
+                                              j5valid[0] = true;
+                                              for (int ij5 = 0; ij5 < 1; ++ij5)
+                                              {
+                                                if (!j5valid[ij5])
+                                                {
+                                                  continue;
+                                                }
+                                                _ij5[0] = ij5;
+                                                _ij5[1] = -1;
+                                                for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                                {
+                                                  if (j5valid[iij5] &&
+                                                      IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                                      IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                                  {
+                                                    j5valid[iij5] = false;
+                                                    _ij5[1] = iij5;
+                                                    break;
+                                                  }
+                                                }
+                                                j5 = j5array[ij5];
+                                                cj5 = cj5array[ij5];
+                                                sj5 = sj5array[ij5];
+                                                {
+                                                  IkReal evalcond[4];
+                                                  IkReal x137 = IKcos(j5);
+                                                  IkReal x138 = ((IkReal(1.00000000000000)) * (sj3));
+                                                  IkReal x139 = ((IkReal(1.00000000000000)) * (IKsin(j5)));
+                                                  evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r00) * (x138))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x139))) +
+                                                                 (((cj3) * (new_r10))));
+                                                  evalcond[1] = ((((IkReal(-1.00000000000000)) * (new_r01) * (x138))) +
+                                                                 (((cj3) * (new_r11))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x137))));
+                                                  evalcond[2] = ((((new_r11) * (sj3))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x139))) +
+                                                                 (((cj3) * (new_r01))));
+                                                  evalcond[3] =
+                                                      ((((new_r10) * (sj3))) + (x137) + (((cj3) * (new_r00))));
+                                                  if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                      IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                  {
+                                                    continue;
+                                                  }
+                                                }
+
+                                                {
+                                                  std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                                  vinfos[0].jointtype = 1;
+                                                  vinfos[0].foffset = j0;
+                                                  vinfos[0].indices[0] = _ij0[0];
+                                                  vinfos[0].indices[1] = _ij0[1];
+                                                  vinfos[0].maxsolutions = _nj0;
+                                                  vinfos[1].jointtype = 1;
+                                                  vinfos[1].foffset = j1;
+                                                  vinfos[1].indices[0] = _ij1[0];
+                                                  vinfos[1].indices[1] = _ij1[1];
+                                                  vinfos[1].maxsolutions = _nj1;
+                                                  vinfos[2].jointtype = 1;
+                                                  vinfos[2].foffset = j2;
+                                                  vinfos[2].indices[0] = _ij2[0];
+                                                  vinfos[2].indices[1] = _ij2[1];
+                                                  vinfos[2].maxsolutions = _nj2;
+                                                  vinfos[3].jointtype = 1;
+                                                  vinfos[3].foffset = j3;
+                                                  vinfos[3].indices[0] = _ij3[0];
+                                                  vinfos[3].indices[1] = _ij3[1];
+                                                  vinfos[3].maxsolutions = _nj3;
+                                                  vinfos[4].jointtype = 1;
+                                                  vinfos[4].foffset = j4;
+                                                  vinfos[4].indices[0] = _ij4[0];
+                                                  vinfos[4].indices[1] = _ij4[1];
+                                                  vinfos[4].maxsolutions = _nj4;
+                                                  vinfos[5].jointtype = 1;
+                                                  vinfos[5].foffset = j5;
+                                                  vinfos[5].indices[0] = _ij5[0];
+                                                  vinfos[5].indices[1] = _ij5[1];
+                                                  vinfos[5].maxsolutions = _nj5;
+                                                  std::vector<int> vfree(0);
+                                                  solutions.AddSolution(vinfos, vfree);
+                                                }
+                                              }
+                                            }
+                                          }
+                                          else
+                                          {
+                                            if (1)
+                                            {
+                                              continue;
+                                            }
+                                            else
+                                            {
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                    else
+                                    {
+                                      {
+                                        IkReal j5array[1], cj5array[1], sj5array[1];
+                                        bool j5valid[1] = { false };
+                                        _nj5 = 1;
+                                        if (IKabs(((((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (new_r00) *
+                                                                             (sj3))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(((IkReal(-1.00000000000000)) * (new_r20) *
+                                                   (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(
+                                                IKsqr(((((cj3) * (new_r10))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r00) * (sj3))))) +
+                                                IKsqr(((IkReal(-1.00000000000000)) * (new_r20) *
+                                                       (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) -
+                                                1) <= IKFAST_SINCOS_THRESH)
+                                          continue;
+                                        j5array[0] =
+                                            IKatan2(((((cj3) * (new_r10))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r00) * (sj3)))),
+                                                    ((IkReal(-1.00000000000000)) * (new_r20) *
+                                                     (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30))));
+                                        sj5array[0] = IKsin(j5array[0]);
+                                        cj5array[0] = IKcos(j5array[0]);
+                                        if (j5array[0] > IKPI)
+                                        {
+                                          j5array[0] -= IK2PI;
+                                        }
+                                        else if (j5array[0] < -IKPI)
+                                        {
+                                          j5array[0] += IK2PI;
+                                        }
+                                        j5valid[0] = true;
+                                        for (int ij5 = 0; ij5 < 1; ++ij5)
+                                        {
+                                          if (!j5valid[ij5])
+                                          {
+                                            continue;
+                                          }
+                                          _ij5[0] = ij5;
+                                          _ij5[1] = -1;
+                                          for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                          {
+                                            if (j5valid[iij5] &&
+                                                IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                                IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                            {
+                                              j5valid[iij5] = false;
+                                              _ij5[1] = iij5;
+                                              break;
+                                            }
+                                          }
+                                          j5 = j5array[ij5];
+                                          cj5 = cj5array[ij5];
+                                          sj5 = sj5array[ij5];
+                                          {
+                                            IkReal evalcond[8];
+                                            IkReal x140 = IKsin(j5);
+                                            IkReal x141 = IKcos(j5);
+                                            IkReal x142 = ((IkReal(1.00000000000000)) * (sj3));
+                                            IkReal x143 = ((new_r11) * (sj3));
+                                            IkReal x144 = ((new_r10) * (sj3));
+                                            IkReal x145 = ((cj3) * (cj4));
+                                            IkReal x146 = ((IkReal(1.00000000000000)) * (sj4));
+                                            IkReal x147 = ((IkReal(1.00000000000000)) * (x141));
+                                            IkReal x148 = ((IkReal(1.00000000000000)) * (x140));
+                                            evalcond[0] = ((((sj4) * (x141))) + (new_r20));
+                                            evalcond[1] =
+                                                ((((IkReal(-1.00000000000000)) * (x140) * (x146))) + (new_r21));
+                                            evalcond[2] =
+                                                ((((IkReal(-1.00000000000000)) * (x148))) + (((cj3) * (new_r10))) +
+                                                 (((IkReal(-1.00000000000000)) * (new_r00) * (x142))));
+                                            evalcond[3] =
+                                                ((((IkReal(-1.00000000000000)) * (new_r01) * (x142))) +
+                                                 (((IkReal(-1.00000000000000)) * (x147))) + (((cj3) * (new_r11))));
+                                            evalcond[4] = ((x143) + (((cj3) * (new_r01))) + (((cj4) * (x140))));
+                                            evalcond[5] = ((x144) + (((cj3) * (new_r00))) +
+                                                           (((IkReal(-1.00000000000000)) * (cj4) * (x147))));
+                                            evalcond[6] = ((((new_r01) * (x145))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r21) * (x146))) +
+                                                           (x140) + (((cj4) * (x143))));
+                                            evalcond[7] = ((((IkReal(-1.00000000000000)) * (x147))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r20) * (x146))) +
+                                                           (((new_r00) * (x145))) + (((cj4) * (x144))));
+                                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                                IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                            {
+                                              continue;
+                                            }
+                                          }
+
+                                          {
+                                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                            vinfos[0].jointtype = 1;
+                                            vinfos[0].foffset = j0;
+                                            vinfos[0].indices[0] = _ij0[0];
+                                            vinfos[0].indices[1] = _ij0[1];
+                                            vinfos[0].maxsolutions = _nj0;
+                                            vinfos[1].jointtype = 1;
+                                            vinfos[1].foffset = j1;
+                                            vinfos[1].indices[0] = _ij1[0];
+                                            vinfos[1].indices[1] = _ij1[1];
+                                            vinfos[1].maxsolutions = _nj1;
+                                            vinfos[2].jointtype = 1;
+                                            vinfos[2].foffset = j2;
+                                            vinfos[2].indices[0] = _ij2[0];
+                                            vinfos[2].indices[1] = _ij2[1];
+                                            vinfos[2].maxsolutions = _nj2;
+                                            vinfos[3].jointtype = 1;
+                                            vinfos[3].foffset = j3;
+                                            vinfos[3].indices[0] = _ij3[0];
+                                            vinfos[3].indices[1] = _ij3[1];
+                                            vinfos[3].maxsolutions = _nj3;
+                                            vinfos[4].jointtype = 1;
+                                            vinfos[4].foffset = j4;
+                                            vinfos[4].indices[0] = _ij4[0];
+                                            vinfos[4].indices[1] = _ij4[1];
+                                            vinfos[4].maxsolutions = _nj4;
+                                            vinfos[5].jointtype = 1;
+                                            vinfos[5].foffset = j5;
+                                            vinfos[5].indices[0] = _ij5[0];
+                                            vinfos[5].indices[1] = _ij5[1];
+                                            vinfos[5].maxsolutions = _nj5;
+                                            std::vector<int> vfree(0);
+                                            solutions.AddSolution(vinfos, vfree);
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j5array[1], cj5array[1], sj5array[1];
+                                    bool j5valid[1] = { false };
+                                    _nj5 = 1;
+                                    if (IKabs(((new_r21) *
+                                               (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) +
+                                               (((cj3) * (new_r11))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(IKsqr(((new_r21) *
+                                                     (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) +
+                                              IKsqr(((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) +
+                                                     (((cj3) * (new_r11))))) -
+                                              1) <= IKFAST_SINCOS_THRESH)
+                                      continue;
+                                    j5array[0] = IKatan2(
+                                        ((new_r21) * (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30))),
+                                        ((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) + (((cj3) * (new_r11)))));
+                                    sj5array[0] = IKsin(j5array[0]);
+                                    cj5array[0] = IKcos(j5array[0]);
+                                    if (j5array[0] > IKPI)
+                                    {
+                                      j5array[0] -= IK2PI;
+                                    }
+                                    else if (j5array[0] < -IKPI)
+                                    {
+                                      j5array[0] += IK2PI;
+                                    }
+                                    j5valid[0] = true;
+                                    for (int ij5 = 0; ij5 < 1; ++ij5)
+                                    {
+                                      if (!j5valid[ij5])
+                                      {
+                                        continue;
+                                      }
+                                      _ij5[0] = ij5;
+                                      _ij5[1] = -1;
+                                      for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                      {
+                                        if (j5valid[iij5] &&
+                                            IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j5valid[iij5] = false;
+                                          _ij5[1] = iij5;
+                                          break;
+                                        }
+                                      }
+                                      j5 = j5array[ij5];
+                                      cj5 = cj5array[ij5];
+                                      sj5 = sj5array[ij5];
+                                      {
+                                        IkReal evalcond[8];
+                                        IkReal x149 = IKsin(j5);
+                                        IkReal x150 = IKcos(j5);
+                                        IkReal x151 = ((IkReal(1.00000000000000)) * (sj3));
+                                        IkReal x152 = ((new_r11) * (sj3));
+                                        IkReal x153 = ((new_r10) * (sj3));
+                                        IkReal x154 = ((cj3) * (cj4));
+                                        IkReal x155 = ((IkReal(1.00000000000000)) * (sj4));
+                                        IkReal x156 = ((IkReal(1.00000000000000)) * (x150));
+                                        IkReal x157 = ((IkReal(1.00000000000000)) * (x149));
+                                        evalcond[0] = ((((sj4) * (x150))) + (new_r20));
+                                        evalcond[1] = ((new_r21) + (((IkReal(-1.00000000000000)) * (x149) * (x155))));
+                                        evalcond[2] =
+                                            ((((IkReal(-1.00000000000000)) * (x157))) + (((cj3) * (new_r10))) +
+                                             (((IkReal(-1.00000000000000)) * (new_r00) * (x151))));
+                                        evalcond[3] =
+                                            ((((IkReal(-1.00000000000000)) * (x156))) + (((cj3) * (new_r11))) +
+                                             (((IkReal(-1.00000000000000)) * (new_r01) * (x151))));
+                                        evalcond[4] = ((x152) + (((cj3) * (new_r01))) + (((cj4) * (x149))));
+                                        evalcond[5] = ((x153) + (((cj3) * (new_r00))) +
+                                                       (((IkReal(-1.00000000000000)) * (cj4) * (x156))));
+                                        evalcond[6] = ((((cj4) * (x152))) + (((new_r01) * (x154))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r21) * (x155))) + (x149));
+                                        evalcond[7] =
+                                            ((((cj4) * (x153))) + (((IkReal(-1.00000000000000)) * (new_r20) * (x155))) +
+                                             (((IkReal(-1.00000000000000)) * (x156))) + (((new_r00) * (x154))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                            IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              {
+                                IkReal j5array[1], cj5array[1], sj5array[1];
+                                bool j5valid[1] = { false };
+                                _nj5 = 1;
+                                if (IKabs(((gconst5) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((IkReal(-1.00000000000000)) * (gconst5) * (new_r20))) <
+                                        IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                j5array[0] = IKatan2(((gconst5) * (new_r21)),
+                                                     ((IkReal(-1.00000000000000)) * (gconst5) * (new_r20)));
+                                sj5array[0] = IKsin(j5array[0]);
+                                cj5array[0] = IKcos(j5array[0]);
+                                if (j5array[0] > IKPI)
+                                {
+                                  j5array[0] -= IK2PI;
+                                }
+                                else if (j5array[0] < -IKPI)
+                                {
+                                  j5array[0] += IK2PI;
+                                }
+                                j5valid[0] = true;
+                                for (int ij5 = 0; ij5 < 1; ++ij5)
+                                {
+                                  if (!j5valid[ij5])
+                                  {
+                                    continue;
+                                  }
+                                  _ij5[0] = ij5;
+                                  _ij5[1] = -1;
+                                  for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                  {
+                                    if (j5valid[iij5] &&
+                                        IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j5valid[iij5] = false;
+                                      _ij5[1] = iij5;
+                                      break;
+                                    }
+                                  }
+                                  j5 = j5array[ij5];
+                                  cj5 = cj5array[ij5];
+                                  sj5 = sj5array[ij5];
+                                  {
+                                    IkReal evalcond[8];
+                                    IkReal x158 = IKsin(j5);
+                                    IkReal x159 = IKcos(j5);
+                                    IkReal x160 = ((IkReal(1.00000000000000)) * (sj3));
+                                    IkReal x161 = ((new_r11) * (sj3));
+                                    IkReal x162 = ((new_r10) * (sj3));
+                                    IkReal x163 = ((cj3) * (cj4));
+                                    IkReal x164 = ((IkReal(1.00000000000000)) * (sj4));
+                                    IkReal x165 = ((IkReal(1.00000000000000)) * (x159));
+                                    IkReal x166 = ((IkReal(1.00000000000000)) * (x158));
+                                    evalcond[0] = ((((sj4) * (x159))) + (new_r20));
+                                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (x158) * (x164))) + (new_r21));
+                                    evalcond[2] = ((((IkReal(-1.00000000000000)) * (new_r00) * (x160))) +
+                                                   (((IkReal(-1.00000000000000)) * (x166))) + (((cj3) * (new_r10))));
+                                    evalcond[3] = ((((IkReal(-1.00000000000000)) * (x165))) + (((cj3) * (new_r11))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r01) * (x160))));
+                                    evalcond[4] = ((((cj4) * (x158))) + (x161) + (((cj3) * (new_r01))));
+                                    evalcond[5] = ((((IkReal(-1.00000000000000)) * (cj4) * (x165))) + (x162) +
+                                                   (((cj3) * (new_r00))));
+                                    evalcond[6] = ((((new_r01) * (x163))) + (((cj4) * (x161))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r21) * (x164))) + (x158));
+                                    evalcond[7] = ((((new_r00) * (x163))) + (((cj4) * (x162))) +
+                                                   (((IkReal(-1.00000000000000)) * (x165))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r20) * (x164))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                        IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                    vinfos[0].jointtype = 1;
+                                    vinfos[0].foffset = j0;
+                                    vinfos[0].indices[0] = _ij0[0];
+                                    vinfos[0].indices[1] = _ij0[1];
+                                    vinfos[0].maxsolutions = _nj0;
+                                    vinfos[1].jointtype = 1;
+                                    vinfos[1].foffset = j1;
+                                    vinfos[1].indices[0] = _ij1[0];
+                                    vinfos[1].indices[1] = _ij1[1];
+                                    vinfos[1].maxsolutions = _nj1;
+                                    vinfos[2].jointtype = 1;
+                                    vinfos[2].foffset = j2;
+                                    vinfos[2].indices[0] = _ij2[0];
+                                    vinfos[2].indices[1] = _ij2[1];
+                                    vinfos[2].maxsolutions = _nj2;
+                                    vinfos[3].jointtype = 1;
+                                    vinfos[3].foffset = j3;
+                                    vinfos[3].indices[0] = _ij3[0];
+                                    vinfos[3].indices[1] = _ij3[1];
+                                    vinfos[3].maxsolutions = _nj3;
+                                    vinfos[4].jointtype = 1;
+                                    vinfos[4].foffset = j4;
+                                    vinfos[4].indices[0] = _ij4[0];
+                                    vinfos[4].indices[1] = _ij4[1];
+                                    vinfos[4].maxsolutions = _nj4;
+                                    vinfos[5].jointtype = 1;
+                                    vinfos[5].foffset = j5;
+                                    vinfos[5].indices[0] = _ij5[0];
+                                    vinfos[5].indices[1] = _ij5[1];
+                                    vinfos[5].maxsolutions = _nj5;
+                                    std::vector<int> vfree(0);
+                                    solutions.AddSolution(vinfos, vfree);
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                else
+                {
+                  {
+                    IkReal j3array[1], cj3array[1], sj3array[1];
+                    bool j3valid[1] = { false };
+                    _nj3 = 1;
+                    IkReal x167 = ((gconst2) * (sj4));
+                    if (IKabs(((new_r12) * (x167))) < IKFAST_ATAN2_MAGTHRESH &&
+                        IKabs(((new_r02) * (x167))) < IKFAST_ATAN2_MAGTHRESH)
+                      continue;
+                    j3array[0] = IKatan2(((new_r12) * (x167)), ((new_r02) * (x167)));
+                    sj3array[0] = IKsin(j3array[0]);
+                    cj3array[0] = IKcos(j3array[0]);
+                    if (j3array[0] > IKPI)
+                    {
+                      j3array[0] -= IK2PI;
+                    }
+                    else if (j3array[0] < -IKPI)
+                    {
+                      j3array[0] += IK2PI;
+                    }
+                    j3valid[0] = true;
+                    for (int ij3 = 0; ij3 < 1; ++ij3)
+                    {
+                      if (!j3valid[ij3])
+                      {
+                        continue;
+                      }
+                      _ij3[0] = ij3;
+                      _ij3[1] = -1;
+                      for (int iij3 = ij3 + 1; iij3 < 1; ++iij3)
+                      {
+                        if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                            IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                        {
+                          j3valid[iij3] = false;
+                          _ij3[1] = iij3;
+                          break;
+                        }
+                      }
+                      j3 = j3array[ij3];
+                      cj3 = cj3array[ij3];
+                      sj3 = sj3array[ij3];
+                      {
+                        IkReal evalcond[6];
+                        IkReal x168 = IKsin(j3);
+                        IkReal x169 = IKcos(j3);
+                        IkReal x170 = ((IkReal(1.00000000000000)) * (sj4));
+                        IkReal x171 = ((sj4) * (x168));
+                        IkReal x172 = ((sj4) * (x169));
+                        IkReal x173 = ((new_r02) * (x169));
+                        IkReal x174 = ((new_r12) * (x168));
+                        evalcond[0] = ((((new_r12) * (x169))) + (((IkReal(-1.00000000000000)) * (new_r02) * (x168))));
+                        evalcond[1] = ((((IkReal(-1.00000000000000)) * (x170))) + (x173) + (x174));
+                        evalcond[2] = ((((new_r00) * (x172))) + (((new_r10) * (x171))) + (((cj4) * (new_r20))));
+                        evalcond[3] = ((((new_r01) * (x172))) + (((new_r11) * (x171))) + (((cj4) * (new_r21))));
+                        evalcond[4] = ((IkReal(-1.00000000000000)) + (((new_r02) * (x172))) + (((cj4) * (new_r22))) +
+                                       (((new_r12) * (x171))));
+                        evalcond[5] = ((((cj4) * (x174))) + (((cj4) * (x173))) +
+                                       (((IkReal(-1.00000000000000)) * (new_r22) * (x170))));
+                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                        {
+                          continue;
+                        }
+                      }
+
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst5;
+                        gconst5 = IKsign(sj4);
+                        dummyeval[0] = sj4;
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal dummyeval[1];
+                            dummyeval[0] = sj4;
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal dummyeval[1];
+                                dummyeval[0] = sj4;
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal evalcond[11];
+                                    IkReal x175 = ((IkReal(-1.00000000000000)) + (new_r22));
+                                    IkReal x176 =
+                                        ((((IkReal(-1.00000000000000)) * (new_r02) * (sj3))) + (((cj3) * (new_r12))));
+                                    IkReal x177 = ((((new_r12) * (sj3))) + (((cj3) * (new_r02))));
+                                    evalcond[0] =
+                                        ((IkReal(-3.14159265358979)) +
+                                         (IKfmod(((IkReal(3.14159265358979)) + (j4)), IkReal(6.28318530717959))));
+                                    evalcond[1] = x175;
+                                    evalcond[2] = new_r20;
+                                    evalcond[3] = new_r21;
+                                    evalcond[4] = x176;
+                                    evalcond[5] = x176;
+                                    evalcond[6] = x177;
+                                    evalcond[7] = new_r20;
+                                    evalcond[8] = new_r21;
+                                    evalcond[9] = x175;
+                                    evalcond[10] = x177;
+                                    if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[10]) < 0.0000010000000000)
+                                    {
+                                      {
+                                        IkReal j5array[1], cj5array[1], sj5array[1];
+                                        bool j5valid[1] = { false };
+                                        _nj5 = 1;
+                                        if (IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) +
+                                                  IKsqr(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) - 1) <=
+                                                IKFAST_SINCOS_THRESH)
+                                          continue;
+                                        j5array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                              (((IkReal(-1.00000000000000)) * (new_r11) * (sj3)))),
+                                                             ((((new_r10) * (sj3))) + (((cj3) * (new_r00)))));
+                                        sj5array[0] = IKsin(j5array[0]);
+                                        cj5array[0] = IKcos(j5array[0]);
+                                        if (j5array[0] > IKPI)
+                                        {
+                                          j5array[0] -= IK2PI;
+                                        }
+                                        else if (j5array[0] < -IKPI)
+                                        {
+                                          j5array[0] += IK2PI;
+                                        }
+                                        j5valid[0] = true;
+                                        for (int ij5 = 0; ij5 < 1; ++ij5)
+                                        {
+                                          if (!j5valid[ij5])
+                                          {
+                                            continue;
+                                          }
+                                          _ij5[0] = ij5;
+                                          _ij5[1] = -1;
+                                          for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                          {
+                                            if (j5valid[iij5] &&
+                                                IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                                IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                            {
+                                              j5valid[iij5] = false;
+                                              _ij5[1] = iij5;
+                                              break;
+                                            }
+                                          }
+                                          j5 = j5array[ij5];
+                                          cj5 = cj5array[ij5];
+                                          sj5 = sj5array[ij5];
+                                          {
+                                            IkReal evalcond[4];
+                                            IkReal x178 = IKsin(j5);
+                                            IkReal x179 = ((IkReal(1.00000000000000)) * (sj3));
+                                            IkReal x180 = ((IkReal(1.00000000000000)) * (IKcos(j5)));
+                                            evalcond[0] =
+                                                ((((IkReal(-1.00000000000000)) * (x178))) + (((cj3) * (new_r10))) +
+                                                 (((IkReal(-1.00000000000000)) * (new_r00) * (x179))));
+                                            evalcond[1] =
+                                                ((((IkReal(-1.00000000000000)) * (x180))) + (((cj3) * (new_r11))) +
+                                                 (((IkReal(-1.00000000000000)) * (new_r01) * (x179))));
+                                            evalcond[2] = ((((new_r11) * (sj3))) + (x178) + (((cj3) * (new_r01))));
+                                            evalcond[3] =
+                                                ((((new_r10) * (sj3))) + (((IkReal(-1.00000000000000)) * (x180))) +
+                                                 (((cj3) * (new_r00))));
+                                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                            {
+                                              continue;
+                                            }
+                                          }
+
+                                          {
+                                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                            vinfos[0].jointtype = 1;
+                                            vinfos[0].foffset = j0;
+                                            vinfos[0].indices[0] = _ij0[0];
+                                            vinfos[0].indices[1] = _ij0[1];
+                                            vinfos[0].maxsolutions = _nj0;
+                                            vinfos[1].jointtype = 1;
+                                            vinfos[1].foffset = j1;
+                                            vinfos[1].indices[0] = _ij1[0];
+                                            vinfos[1].indices[1] = _ij1[1];
+                                            vinfos[1].maxsolutions = _nj1;
+                                            vinfos[2].jointtype = 1;
+                                            vinfos[2].foffset = j2;
+                                            vinfos[2].indices[0] = _ij2[0];
+                                            vinfos[2].indices[1] = _ij2[1];
+                                            vinfos[2].maxsolutions = _nj2;
+                                            vinfos[3].jointtype = 1;
+                                            vinfos[3].foffset = j3;
+                                            vinfos[3].indices[0] = _ij3[0];
+                                            vinfos[3].indices[1] = _ij3[1];
+                                            vinfos[3].maxsolutions = _nj3;
+                                            vinfos[4].jointtype = 1;
+                                            vinfos[4].foffset = j4;
+                                            vinfos[4].indices[0] = _ij4[0];
+                                            vinfos[4].indices[1] = _ij4[1];
+                                            vinfos[4].maxsolutions = _nj4;
+                                            vinfos[5].jointtype = 1;
+                                            vinfos[5].foffset = j5;
+                                            vinfos[5].indices[0] = _ij5[0];
+                                            vinfos[5].indices[1] = _ij5[1];
+                                            vinfos[5].maxsolutions = _nj5;
+                                            std::vector<int> vfree(0);
+                                            solutions.AddSolution(vinfos, vfree);
+                                          }
+                                        }
+                                      }
+                                    }
+                                    else
+                                    {
+                                      IkReal x181 = ((new_r12) * (sj3));
+                                      IkReal x182 = ((IkReal(1.00000000000000)) * (new_r02));
+                                      IkReal x183 =
+                                          ((((cj3) * (new_r12))) + (((IkReal(-1.00000000000000)) * (sj3) * (x182))));
+                                      evalcond[0] =
+                                          ((IkReal(-3.14159265358979)) +
+                                           (IKfmod(((IkReal(1.11022302462516e-16)) + (j4)), IkReal(6.28318530717959))));
+                                      evalcond[1] = ((IkReal(1.00000000000000)) + (new_r22));
+                                      evalcond[2] = new_r20;
+                                      evalcond[3] = new_r21;
+                                      evalcond[4] = x183;
+                                      evalcond[5] = x183;
+                                      evalcond[6] = ((x181) + (((cj3) * (new_r02))));
+                                      evalcond[7] = ((IkReal(-1.00000000000000)) * (new_r20));
+                                      evalcond[8] = ((IkReal(-1.00000000000000)) * (new_r21));
+                                      evalcond[9] =
+                                          ((IkReal(-1.00000000000000)) + (((IkReal(-1.00000000000000)) * (new_r22))));
+                                      evalcond[10] = ((((IkReal(-1.00000000000000)) * (x181))) +
+                                                      (((IkReal(-1.00000000000000)) * (cj3) * (x182))));
+                                      if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[10]) < 0.0000010000000000)
+                                      {
+                                        {
+                                          IkReal j5array[1], cj5array[1], sj5array[1];
+                                          bool j5valid[1] = { false };
+                                          _nj5 = 1;
+                                          if (IKabs(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) <
+                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                              IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) <
+                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                              IKabs(IKsqr(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) +
+                                                    IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) -
+                                                    1) <= IKFAST_SINCOS_THRESH)
+                                            continue;
+                                          j5array[0] = IKatan2(((((new_r11) * (sj3))) + (((cj3) * (new_r01)))),
+                                                               ((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                                (((IkReal(-1.00000000000000)) * (new_r10) * (sj3)))));
+                                          sj5array[0] = IKsin(j5array[0]);
+                                          cj5array[0] = IKcos(j5array[0]);
+                                          if (j5array[0] > IKPI)
+                                          {
+                                            j5array[0] -= IK2PI;
+                                          }
+                                          else if (j5array[0] < -IKPI)
+                                          {
+                                            j5array[0] += IK2PI;
+                                          }
+                                          j5valid[0] = true;
+                                          for (int ij5 = 0; ij5 < 1; ++ij5)
+                                          {
+                                            if (!j5valid[ij5])
+                                            {
+                                              continue;
+                                            }
+                                            _ij5[0] = ij5;
+                                            _ij5[1] = -1;
+                                            for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                            {
+                                              if (j5valid[iij5] &&
+                                                  IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                                  IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                              {
+                                                j5valid[iij5] = false;
+                                                _ij5[1] = iij5;
+                                                break;
+                                              }
+                                            }
+                                            j5 = j5array[ij5];
+                                            cj5 = cj5array[ij5];
+                                            sj5 = sj5array[ij5];
+                                            {
+                                              IkReal evalcond[4];
+                                              IkReal x184 = IKcos(j5);
+                                              IkReal x185 = ((IkReal(1.00000000000000)) * (sj3));
+                                              IkReal x186 = ((IkReal(1.00000000000000)) * (IKsin(j5)));
+                                              evalcond[0] =
+                                                  ((((IkReal(-1.00000000000000)) * (x186))) + (((cj3) * (new_r10))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r00) * (x185))));
+                                              evalcond[1] = ((((IkReal(-1.00000000000000)) * (x184))) +
+                                                             (((IkReal(-1.00000000000000)) * (new_r01) * (x185))) +
+                                                             (((cj3) * (new_r11))));
+                                              evalcond[2] =
+                                                  ((((new_r11) * (sj3))) + (((IkReal(-1.00000000000000)) * (x186))) +
+                                                   (((cj3) * (new_r01))));
+                                              evalcond[3] = ((((new_r10) * (sj3))) + (x184) + (((cj3) * (new_r00))));
+                                              if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                  IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                              {
+                                                continue;
+                                              }
+                                            }
+
+                                            {
+                                              std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                              vinfos[0].jointtype = 1;
+                                              vinfos[0].foffset = j0;
+                                              vinfos[0].indices[0] = _ij0[0];
+                                              vinfos[0].indices[1] = _ij0[1];
+                                              vinfos[0].maxsolutions = _nj0;
+                                              vinfos[1].jointtype = 1;
+                                              vinfos[1].foffset = j1;
+                                              vinfos[1].indices[0] = _ij1[0];
+                                              vinfos[1].indices[1] = _ij1[1];
+                                              vinfos[1].maxsolutions = _nj1;
+                                              vinfos[2].jointtype = 1;
+                                              vinfos[2].foffset = j2;
+                                              vinfos[2].indices[0] = _ij2[0];
+                                              vinfos[2].indices[1] = _ij2[1];
+                                              vinfos[2].maxsolutions = _nj2;
+                                              vinfos[3].jointtype = 1;
+                                              vinfos[3].foffset = j3;
+                                              vinfos[3].indices[0] = _ij3[0];
+                                              vinfos[3].indices[1] = _ij3[1];
+                                              vinfos[3].maxsolutions = _nj3;
+                                              vinfos[4].jointtype = 1;
+                                              vinfos[4].foffset = j4;
+                                              vinfos[4].indices[0] = _ij4[0];
+                                              vinfos[4].indices[1] = _ij4[1];
+                                              vinfos[4].maxsolutions = _nj4;
+                                              vinfos[5].jointtype = 1;
+                                              vinfos[5].foffset = j5;
+                                              vinfos[5].indices[0] = _ij5[0];
+                                              vinfos[5].indices[1] = _ij5[1];
+                                              vinfos[5].maxsolutions = _nj5;
+                                              std::vector<int> vfree(0);
+                                              solutions.AddSolution(vinfos, vfree);
+                                            }
+                                          }
+                                        }
+                                      }
+                                      else
+                                      {
+                                        if (1)
+                                        {
+                                          continue;
+                                        }
+                                        else
+                                        {
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j5array[1], cj5array[1], sj5array[1];
+                                    bool j5valid[1] = { false };
+                                    _nj5 = 1;
+                                    if (IKabs(((((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (new_r00) *
+                                                                         (sj3))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((IkReal(-1.00000000000000)) * (new_r20) *
+                                               (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(IKsqr(((((cj3) * (new_r10))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r00) * (sj3))))) +
+                                              IKsqr(((IkReal(-1.00000000000000)) * (new_r20) *
+                                                     (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) -
+                                              1) <= IKFAST_SINCOS_THRESH)
+                                      continue;
+                                    j5array[0] = IKatan2(
+                                        ((((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (new_r00) * (sj3)))),
+                                        ((IkReal(-1.00000000000000)) * (new_r20) *
+                                         (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30))));
+                                    sj5array[0] = IKsin(j5array[0]);
+                                    cj5array[0] = IKcos(j5array[0]);
+                                    if (j5array[0] > IKPI)
+                                    {
+                                      j5array[0] -= IK2PI;
+                                    }
+                                    else if (j5array[0] < -IKPI)
+                                    {
+                                      j5array[0] += IK2PI;
+                                    }
+                                    j5valid[0] = true;
+                                    for (int ij5 = 0; ij5 < 1; ++ij5)
+                                    {
+                                      if (!j5valid[ij5])
+                                      {
+                                        continue;
+                                      }
+                                      _ij5[0] = ij5;
+                                      _ij5[1] = -1;
+                                      for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                      {
+                                        if (j5valid[iij5] &&
+                                            IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j5valid[iij5] = false;
+                                          _ij5[1] = iij5;
+                                          break;
+                                        }
+                                      }
+                                      j5 = j5array[ij5];
+                                      cj5 = cj5array[ij5];
+                                      sj5 = sj5array[ij5];
+                                      {
+                                        IkReal evalcond[8];
+                                        IkReal x187 = IKsin(j5);
+                                        IkReal x188 = IKcos(j5);
+                                        IkReal x189 = ((IkReal(1.00000000000000)) * (sj3));
+                                        IkReal x190 = ((new_r11) * (sj3));
+                                        IkReal x191 = ((new_r10) * (sj3));
+                                        IkReal x192 = ((cj3) * (cj4));
+                                        IkReal x193 = ((IkReal(1.00000000000000)) * (sj4));
+                                        IkReal x194 = ((IkReal(1.00000000000000)) * (x188));
+                                        IkReal x195 = ((IkReal(1.00000000000000)) * (x187));
+                                        evalcond[0] = ((((sj4) * (x188))) + (new_r20));
+                                        evalcond[1] = ((((IkReal(-1.00000000000000)) * (x187) * (x193))) + (new_r21));
+                                        evalcond[2] =
+                                            ((((IkReal(-1.00000000000000)) * (x195))) + (((cj3) * (new_r10))) +
+                                             (((IkReal(-1.00000000000000)) * (new_r00) * (x189))));
+                                        evalcond[3] = ((((IkReal(-1.00000000000000)) * (x194))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r01) * (x189))) +
+                                                       (((cj3) * (new_r11))));
+                                        evalcond[4] = ((x190) + (((cj3) * (new_r01))) + (((cj4) * (x187))));
+                                        evalcond[5] = ((((IkReal(-1.00000000000000)) * (cj4) * (x194))) + (x191) +
+                                                       (((cj3) * (new_r00))));
+                                        evalcond[6] = ((((cj4) * (x190))) + (((new_r01) * (x192))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r21) * (x193))) + (x187));
+                                        evalcond[7] = ((((cj4) * (x191))) + (((new_r00) * (x192))) +
+                                                       (((IkReal(-1.00000000000000)) * (x194))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r20) * (x193))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                            IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              {
+                                IkReal j5array[1], cj5array[1], sj5array[1];
+                                bool j5valid[1] = { false };
+                                _nj5 = 1;
+                                if (IKabs(((new_r21) * (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) <
+                                        IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) +
+                                           (((cj3) * (new_r11))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(IKsqr(((new_r21) *
+                                                 (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) +
+                                          IKsqr(((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) +
+                                                 (((cj3) * (new_r11))))) -
+                                          1) <= IKFAST_SINCOS_THRESH)
+                                  continue;
+                                j5array[0] = IKatan2(
+                                    ((new_r21) * (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30))),
+                                    ((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) + (((cj3) * (new_r11)))));
+                                sj5array[0] = IKsin(j5array[0]);
+                                cj5array[0] = IKcos(j5array[0]);
+                                if (j5array[0] > IKPI)
+                                {
+                                  j5array[0] -= IK2PI;
+                                }
+                                else if (j5array[0] < -IKPI)
+                                {
+                                  j5array[0] += IK2PI;
+                                }
+                                j5valid[0] = true;
+                                for (int ij5 = 0; ij5 < 1; ++ij5)
+                                {
+                                  if (!j5valid[ij5])
+                                  {
+                                    continue;
+                                  }
+                                  _ij5[0] = ij5;
+                                  _ij5[1] = -1;
+                                  for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                  {
+                                    if (j5valid[iij5] &&
+                                        IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j5valid[iij5] = false;
+                                      _ij5[1] = iij5;
+                                      break;
+                                    }
+                                  }
+                                  j5 = j5array[ij5];
+                                  cj5 = cj5array[ij5];
+                                  sj5 = sj5array[ij5];
+                                  {
+                                    IkReal evalcond[8];
+                                    IkReal x196 = IKsin(j5);
+                                    IkReal x197 = IKcos(j5);
+                                    IkReal x198 = ((IkReal(1.00000000000000)) * (sj3));
+                                    IkReal x199 = ((new_r11) * (sj3));
+                                    IkReal x200 = ((new_r10) * (sj3));
+                                    IkReal x201 = ((cj3) * (cj4));
+                                    IkReal x202 = ((IkReal(1.00000000000000)) * (sj4));
+                                    IkReal x203 = ((IkReal(1.00000000000000)) * (x197));
+                                    IkReal x204 = ((IkReal(1.00000000000000)) * (x196));
+                                    evalcond[0] = ((((sj4) * (x197))) + (new_r20));
+                                    evalcond[1] = ((new_r21) + (((IkReal(-1.00000000000000)) * (x196) * (x202))));
+                                    evalcond[2] = ((((IkReal(-1.00000000000000)) * (x204))) + (((cj3) * (new_r10))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r00) * (x198))));
+                                    evalcond[3] =
+                                        ((((IkReal(-1.00000000000000)) * (x203))) +
+                                         (((IkReal(-1.00000000000000)) * (new_r01) * (x198))) + (((cj3) * (new_r11))));
+                                    evalcond[4] = ((((cj4) * (x196))) + (x199) + (((cj3) * (new_r01))));
+                                    evalcond[5] = ((((IkReal(-1.00000000000000)) * (cj4) * (x203))) + (x200) +
+                                                   (((cj3) * (new_r00))));
+                                    evalcond[6] =
+                                        ((((cj4) * (x199))) + (((IkReal(-1.00000000000000)) * (new_r21) * (x202))) +
+                                         (((new_r01) * (x201))) + (x196));
+                                    evalcond[7] =
+                                        ((((new_r00) * (x201))) + (((IkReal(-1.00000000000000)) * (new_r20) * (x202))) +
+                                         (((IkReal(-1.00000000000000)) * (x203))) + (((cj4) * (x200))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                        IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                    vinfos[0].jointtype = 1;
+                                    vinfos[0].foffset = j0;
+                                    vinfos[0].indices[0] = _ij0[0];
+                                    vinfos[0].indices[1] = _ij0[1];
+                                    vinfos[0].maxsolutions = _nj0;
+                                    vinfos[1].jointtype = 1;
+                                    vinfos[1].foffset = j1;
+                                    vinfos[1].indices[0] = _ij1[0];
+                                    vinfos[1].indices[1] = _ij1[1];
+                                    vinfos[1].maxsolutions = _nj1;
+                                    vinfos[2].jointtype = 1;
+                                    vinfos[2].foffset = j2;
+                                    vinfos[2].indices[0] = _ij2[0];
+                                    vinfos[2].indices[1] = _ij2[1];
+                                    vinfos[2].maxsolutions = _nj2;
+                                    vinfos[3].jointtype = 1;
+                                    vinfos[3].foffset = j3;
+                                    vinfos[3].indices[0] = _ij3[0];
+                                    vinfos[3].indices[1] = _ij3[1];
+                                    vinfos[3].maxsolutions = _nj3;
+                                    vinfos[4].jointtype = 1;
+                                    vinfos[4].foffset = j4;
+                                    vinfos[4].indices[0] = _ij4[0];
+                                    vinfos[4].indices[1] = _ij4[1];
+                                    vinfos[4].maxsolutions = _nj4;
+                                    vinfos[5].jointtype = 1;
+                                    vinfos[5].foffset = j5;
+                                    vinfos[5].indices[0] = _ij5[0];
+                                    vinfos[5].indices[1] = _ij5[1];
+                                    vinfos[5].maxsolutions = _nj5;
+                                    std::vector<int> vfree(0);
+                                    solutions.AddSolution(vinfos, vfree);
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          {
+                            IkReal j5array[1], cj5array[1], sj5array[1];
+                            bool j5valid[1] = { false };
+                            _nj5 = 1;
+                            if (IKabs(((gconst5) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((IkReal(-1.00000000000000)) * (gconst5) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j5array[0] =
+                                IKatan2(((gconst5) * (new_r21)), ((IkReal(-1.00000000000000)) * (gconst5) * (new_r20)));
+                            sj5array[0] = IKsin(j5array[0]);
+                            cj5array[0] = IKcos(j5array[0]);
+                            if (j5array[0] > IKPI)
+                            {
+                              j5array[0] -= IK2PI;
+                            }
+                            else if (j5array[0] < -IKPI)
+                            {
+                              j5array[0] += IK2PI;
+                            }
+                            j5valid[0] = true;
+                            for (int ij5 = 0; ij5 < 1; ++ij5)
+                            {
+                              if (!j5valid[ij5])
+                              {
+                                continue;
+                              }
+                              _ij5[0] = ij5;
+                              _ij5[1] = -1;
+                              for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                              {
+                                if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j5valid[iij5] = false;
+                                  _ij5[1] = iij5;
+                                  break;
+                                }
+                              }
+                              j5 = j5array[ij5];
+                              cj5 = cj5array[ij5];
+                              sj5 = sj5array[ij5];
+                              {
+                                IkReal evalcond[8];
+                                IkReal x205 = IKsin(j5);
+                                IkReal x206 = IKcos(j5);
+                                IkReal x207 = ((IkReal(1.00000000000000)) * (sj3));
+                                IkReal x208 = ((new_r11) * (sj3));
+                                IkReal x209 = ((new_r10) * (sj3));
+                                IkReal x210 = ((cj3) * (cj4));
+                                IkReal x211 = ((IkReal(1.00000000000000)) * (sj4));
+                                IkReal x212 = ((IkReal(1.00000000000000)) * (x206));
+                                IkReal x213 = ((IkReal(1.00000000000000)) * (x205));
+                                evalcond[0] = ((((sj4) * (x206))) + (new_r20));
+                                evalcond[1] = ((((IkReal(-1.00000000000000)) * (x205) * (x211))) + (new_r21));
+                                evalcond[2] = ((((IkReal(-1.00000000000000)) * (new_r00) * (x207))) +
+                                               (((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (x213))));
+                                evalcond[3] = ((((cj3) * (new_r11))) + (((IkReal(-1.00000000000000)) * (x212))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r01) * (x207))));
+                                evalcond[4] = ((((cj4) * (x205))) + (x208) + (((cj3) * (new_r01))));
+                                evalcond[5] =
+                                    ((x209) + (((IkReal(-1.00000000000000)) * (cj4) * (x212))) + (((cj3) * (new_r00))));
+                                evalcond[6] =
+                                    ((((cj4) * (x208))) + (x205) +
+                                     (((IkReal(-1.00000000000000)) * (new_r21) * (x211))) + (((new_r01) * (x210))));
+                                evalcond[7] = ((((cj4) * (x209))) + (((new_r00) * (x210))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r20) * (x211))) +
+                                               (((IkReal(-1.00000000000000)) * (x212))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                    IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                vinfos[0].jointtype = 1;
+                                vinfos[0].foffset = j0;
+                                vinfos[0].indices[0] = _ij0[0];
+                                vinfos[0].indices[1] = _ij0[1];
+                                vinfos[0].maxsolutions = _nj0;
+                                vinfos[1].jointtype = 1;
+                                vinfos[1].foffset = j1;
+                                vinfos[1].indices[0] = _ij1[0];
+                                vinfos[1].indices[1] = _ij1[1];
+                                vinfos[1].maxsolutions = _nj1;
+                                vinfos[2].jointtype = 1;
+                                vinfos[2].foffset = j2;
+                                vinfos[2].indices[0] = _ij2[0];
+                                vinfos[2].indices[1] = _ij2[1];
+                                vinfos[2].maxsolutions = _nj2;
+                                vinfos[3].jointtype = 1;
+                                vinfos[3].foffset = j3;
+                                vinfos[3].indices[0] = _ij3[0];
+                                vinfos[3].indices[1] = _ij3[1];
+                                vinfos[3].maxsolutions = _nj3;
+                                vinfos[4].jointtype = 1;
+                                vinfos[4].foffset = j4;
+                                vinfos[4].indices[0] = _ij4[0];
+                                vinfos[4].indices[1] = _ij4[1];
+                                vinfos[4].maxsolutions = _nj4;
+                                vinfos[5].jointtype = 1;
+                                vinfos[5].foffset = j5;
+                                vinfos[5].indices[0] = _ij5[0];
+                                vinfos[5].indices[1] = _ij5[1];
+                                vinfos[5].maxsolutions = _nj5;
+                                std::vector<int> vfree(0);
+                                solutions.AddSolution(vinfos, vfree);
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            else
+            {
+              {
+                IkReal j5array[1], cj5array[1], sj5array[1];
+                bool j5valid[1] = { false };
+                _nj5 = 1;
+                if (IKabs(((gconst4) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                    IKabs(((IkReal(-1.00000000000000)) * (gconst4) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH)
+                  continue;
+                j5array[0] = IKatan2(((gconst4) * (new_r21)), ((IkReal(-1.00000000000000)) * (gconst4) * (new_r20)));
+                sj5array[0] = IKsin(j5array[0]);
+                cj5array[0] = IKcos(j5array[0]);
+                if (j5array[0] > IKPI)
+                {
+                  j5array[0] -= IK2PI;
+                }
+                else if (j5array[0] < -IKPI)
+                {
+                  j5array[0] += IK2PI;
+                }
+                j5valid[0] = true;
+                for (int ij5 = 0; ij5 < 1; ++ij5)
+                {
+                  if (!j5valid[ij5])
+                  {
+                    continue;
+                  }
+                  _ij5[0] = ij5;
+                  _ij5[1] = -1;
+                  for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                  {
+                    if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                        IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                    {
+                      j5valid[iij5] = false;
+                      _ij5[1] = iij5;
+                      break;
+                    }
+                  }
+                  j5 = j5array[ij5];
+                  cj5 = cj5array[ij5];
+                  sj5 = sj5array[ij5];
+                  {
+                    IkReal evalcond[2];
+                    evalcond[0] = ((((sj4) * (IKcos(j5)))) + (new_r20));
+                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (sj4) * (IKsin(j5)))) + (new_r21));
+                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001)
+                    {
+                      continue;
+                    }
+                  }
+
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst6;
+                    gconst6 = IKsign((((new_r12) * (new_r12)) + ((new_r02) * (new_r02))));
+                    dummyeval[0] = (((new_r12) * (new_r12)) + ((new_r02) * (new_r02)));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst7;
+                        gconst7 = IKsign(((((IkReal(-1.00000000000000)) * (new_r11) * (new_r12))) +
+                                          (((IkReal(-1.00000000000000)) * (new_r01) * (new_r02)))));
+                        dummyeval[0] = ((((IkReal(-1.00000000000000)) * (new_r11) * (new_r12))) +
+                                        (((IkReal(-1.00000000000000)) * (new_r01) * (new_r02))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          continue;
+                        }
+                        else
+                        {
+                          {
+                            IkReal j3array[1], cj3array[1], sj3array[1];
+                            bool j3valid[1] = { false };
+                            _nj3 = 1;
+                            IkReal x214 = ((cj4) * (gconst7) * (sj5));
+                            if (IKabs(((new_r12) * (x214))) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((new_r02) * (x214))) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j3array[0] = IKatan2(((new_r12) * (x214)), ((new_r02) * (x214)));
+                            sj3array[0] = IKsin(j3array[0]);
+                            cj3array[0] = IKcos(j3array[0]);
+                            if (j3array[0] > IKPI)
+                            {
+                              j3array[0] -= IK2PI;
+                            }
+                            else if (j3array[0] < -IKPI)
+                            {
+                              j3array[0] += IK2PI;
+                            }
+                            j3valid[0] = true;
+                            for (int ij3 = 0; ij3 < 1; ++ij3)
+                            {
+                              if (!j3valid[ij3])
+                              {
+                                continue;
+                              }
+                              _ij3[0] = ij3;
+                              _ij3[1] = -1;
+                              for (int iij3 = ij3 + 1; iij3 < 1; ++iij3)
+                              {
+                                if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j3valid[iij3] = false;
+                                  _ij3[1] = iij3;
+                                  break;
+                                }
+                              }
+                              j3 = j3array[ij3];
+                              cj3 = cj3array[ij3];
+                              sj3 = sj3array[ij3];
+                              {
+                                IkReal evalcond[12];
+                                IkReal x215 = IKsin(j3);
+                                IkReal x216 = IKcos(j3);
+                                IkReal x217 = ((IkReal(1.00000000000000)) * (cj5));
+                                IkReal x218 = ((IkReal(1.00000000000000)) * (sj4));
+                                IkReal x219 = ((cj4) * (x216));
+                                IkReal x220 = ((sj4) * (x216));
+                                IkReal x221 = ((cj4) * (x215));
+                                IkReal x222 = ((new_r11) * (x215));
+                                IkReal x223 = ((sj4) * (x215));
+                                IkReal x224 = ((IkReal(1.00000000000000)) * (x215));
+                                evalcond[0] =
+                                    ((((IkReal(-1.00000000000000)) * (new_r02) * (x224))) + (((new_r12) * (x216))));
+                                evalcond[1] = ((((new_r02) * (x216))) + (((IkReal(-1.00000000000000)) * (x218))) +
+                                               (((new_r12) * (x215))));
+                                evalcond[2] = ((((IkReal(-1.00000000000000)) * (sj5))) + (((new_r10) * (x216))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r00) * (x224))));
+                                evalcond[3] = ((((IkReal(-1.00000000000000)) * (new_r01) * (x224))) +
+                                               (((IkReal(-1.00000000000000)) * (x217))) + (((new_r11) * (x216))));
+                                evalcond[4] = ((((cj4) * (sj5))) + (x222) + (((new_r01) * (x216))));
+                                evalcond[5] = ((((IkReal(-1.00000000000000)) * (cj4) * (x217))) +
+                                               (((new_r00) * (x216))) + (((new_r10) * (x215))));
+                                evalcond[6] = ((((new_r00) * (x220))) + (((cj4) * (new_r20))) + (((new_r10) * (x223))));
+                                evalcond[7] = ((((sj4) * (x222))) + (((new_r01) * (x220))) + (((cj4) * (new_r21))));
+                                evalcond[8] = ((IkReal(-1.00000000000000)) + (((new_r02) * (x220))) +
+                                               (((cj4) * (new_r22))) + (((new_r12) * (x223))));
+                                evalcond[9] = ((((new_r12) * (x221))) + (((new_r02) * (x219))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r22) * (x218))));
+                                evalcond[10] = ((sj5) + (((IkReal(-1.00000000000000)) * (new_r21) * (x218))) +
+                                                (((new_r11) * (x221))) + (((new_r01) * (x219))));
+                                evalcond[11] =
+                                    ((((new_r00) * (x219))) + (((IkReal(-1.00000000000000)) * (new_r20) * (x218))) +
+                                     (((new_r10) * (x221))) + (((IkReal(-1.00000000000000)) * (x217))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                    IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001 ||
+                                    IKabs(evalcond[8]) > 0.000001 || IKabs(evalcond[9]) > 0.000001 ||
+                                    IKabs(evalcond[10]) > 0.000001 || IKabs(evalcond[11]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                vinfos[0].jointtype = 1;
+                                vinfos[0].foffset = j0;
+                                vinfos[0].indices[0] = _ij0[0];
+                                vinfos[0].indices[1] = _ij0[1];
+                                vinfos[0].maxsolutions = _nj0;
+                                vinfos[1].jointtype = 1;
+                                vinfos[1].foffset = j1;
+                                vinfos[1].indices[0] = _ij1[0];
+                                vinfos[1].indices[1] = _ij1[1];
+                                vinfos[1].maxsolutions = _nj1;
+                                vinfos[2].jointtype = 1;
+                                vinfos[2].foffset = j2;
+                                vinfos[2].indices[0] = _ij2[0];
+                                vinfos[2].indices[1] = _ij2[1];
+                                vinfos[2].maxsolutions = _nj2;
+                                vinfos[3].jointtype = 1;
+                                vinfos[3].foffset = j3;
+                                vinfos[3].indices[0] = _ij3[0];
+                                vinfos[3].indices[1] = _ij3[1];
+                                vinfos[3].maxsolutions = _nj3;
+                                vinfos[4].jointtype = 1;
+                                vinfos[4].foffset = j4;
+                                vinfos[4].indices[0] = _ij4[0];
+                                vinfos[4].indices[1] = _ij4[1];
+                                vinfos[4].maxsolutions = _nj4;
+                                vinfos[5].jointtype = 1;
+                                vinfos[5].foffset = j5;
+                                vinfos[5].indices[0] = _ij5[0];
+                                vinfos[5].indices[1] = _ij5[1];
+                                vinfos[5].maxsolutions = _nj5;
+                                std::vector<int> vfree(0);
+                                solutions.AddSolution(vinfos, vfree);
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j3array[1], cj3array[1], sj3array[1];
+                        bool j3valid[1] = { false };
+                        _nj3 = 1;
+                        IkReal x225 = ((gconst6) * (sj4));
+                        if (IKabs(((new_r12) * (x225))) < IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((new_r02) * (x225))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j3array[0] = IKatan2(((new_r12) * (x225)), ((new_r02) * (x225)));
+                        sj3array[0] = IKsin(j3array[0]);
+                        cj3array[0] = IKcos(j3array[0]);
+                        if (j3array[0] > IKPI)
+                        {
+                          j3array[0] -= IK2PI;
+                        }
+                        else if (j3array[0] < -IKPI)
+                        {
+                          j3array[0] += IK2PI;
+                        }
+                        j3valid[0] = true;
+                        for (int ij3 = 0; ij3 < 1; ++ij3)
+                        {
+                          if (!j3valid[ij3])
+                          {
+                            continue;
+                          }
+                          _ij3[0] = ij3;
+                          _ij3[1] = -1;
+                          for (int iij3 = ij3 + 1; iij3 < 1; ++iij3)
+                          {
+                            if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j3valid[iij3] = false;
+                              _ij3[1] = iij3;
+                              break;
+                            }
+                          }
+                          j3 = j3array[ij3];
+                          cj3 = cj3array[ij3];
+                          sj3 = sj3array[ij3];
+                          {
+                            IkReal evalcond[12];
+                            IkReal x226 = IKsin(j3);
+                            IkReal x227 = IKcos(j3);
+                            IkReal x228 = ((IkReal(1.00000000000000)) * (cj5));
+                            IkReal x229 = ((IkReal(1.00000000000000)) * (sj4));
+                            IkReal x230 = ((cj4) * (x227));
+                            IkReal x231 = ((sj4) * (x227));
+                            IkReal x232 = ((cj4) * (x226));
+                            IkReal x233 = ((new_r11) * (x226));
+                            IkReal x234 = ((sj4) * (x226));
+                            IkReal x235 = ((IkReal(1.00000000000000)) * (x226));
+                            evalcond[0] =
+                                ((((IkReal(-1.00000000000000)) * (new_r02) * (x235))) + (((new_r12) * (x227))));
+                            evalcond[1] = ((((new_r02) * (x227))) + (((new_r12) * (x226))) +
+                                           (((IkReal(-1.00000000000000)) * (x229))));
+                            evalcond[2] = ((((IkReal(-1.00000000000000)) * (sj5))) + (((new_r10) * (x227))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r00) * (x235))));
+                            evalcond[3] =
+                                ((((new_r11) * (x227))) + (((IkReal(-1.00000000000000)) * (new_r01) * (x235))) +
+                                 (((IkReal(-1.00000000000000)) * (x228))));
+                            evalcond[4] = ((((new_r01) * (x227))) + (((cj4) * (sj5))) + (x233));
+                            evalcond[5] = ((((new_r00) * (x227))) + (((IkReal(-1.00000000000000)) * (cj4) * (x228))) +
+                                           (((new_r10) * (x226))));
+                            evalcond[6] = ((((new_r10) * (x234))) + (((cj4) * (new_r20))) + (((new_r00) * (x231))));
+                            evalcond[7] = ((((new_r01) * (x231))) + (((cj4) * (new_r21))) + (((sj4) * (x233))));
+                            evalcond[8] = ((IkReal(-1.00000000000000)) + (((new_r02) * (x231))) +
+                                           (((cj4) * (new_r22))) + (((new_r12) * (x234))));
+                            evalcond[9] = ((((new_r02) * (x230))) + (((new_r12) * (x232))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r22) * (x229))));
+                            evalcond[10] = ((sj5) + (((new_r11) * (x232))) + (((new_r01) * (x230))) +
+                                            (((IkReal(-1.00000000000000)) * (new_r21) * (x229))));
+                            evalcond[11] = ((((new_r10) * (x232))) + (((new_r00) * (x230))) +
+                                            (((IkReal(-1.00000000000000)) * (new_r20) * (x229))) +
+                                            (((IkReal(-1.00000000000000)) * (x228))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001 ||
+                                IKabs(evalcond[8]) > 0.000001 || IKabs(evalcond[9]) > 0.000001 ||
+                                IKabs(evalcond[10]) > 0.000001 || IKabs(evalcond[11]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          {
+                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                            vinfos[0].jointtype = 1;
+                            vinfos[0].foffset = j0;
+                            vinfos[0].indices[0] = _ij0[0];
+                            vinfos[0].indices[1] = _ij0[1];
+                            vinfos[0].maxsolutions = _nj0;
+                            vinfos[1].jointtype = 1;
+                            vinfos[1].foffset = j1;
+                            vinfos[1].indices[0] = _ij1[0];
+                            vinfos[1].indices[1] = _ij1[1];
+                            vinfos[1].maxsolutions = _nj1;
+                            vinfos[2].jointtype = 1;
+                            vinfos[2].foffset = j2;
+                            vinfos[2].indices[0] = _ij2[0];
+                            vinfos[2].indices[1] = _ij2[1];
+                            vinfos[2].maxsolutions = _nj2;
+                            vinfos[3].jointtype = 1;
+                            vinfos[3].foffset = j3;
+                            vinfos[3].indices[0] = _ij3[0];
+                            vinfos[3].indices[1] = _ij3[1];
+                            vinfos[3].maxsolutions = _nj3;
+                            vinfos[4].jointtype = 1;
+                            vinfos[4].foffset = j4;
+                            vinfos[4].indices[0] = _ij4[0];
+                            vinfos[4].indices[1] = _ij4[1];
+                            vinfos[4].maxsolutions = _nj4;
+                            vinfos[5].jointtype = 1;
+                            vinfos[5].foffset = j5;
+                            vinfos[5].indices[0] = _ij5[0];
+                            vinfos[5].indices[1] = _ij5[1];
+                            vinfos[5].maxsolutions = _nj5;
+                            std::vector<int> vfree(0);
+                            solutions.AddSolution(vinfos, vfree);
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
 
 /// solves the inverse kinematics equations.
 /// \param pfree is an array specifying the free joints of the chain.
-IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions) {
-IKSolver solver;
-return solver.ComputeIk(eetrans,eerot,pfree,solutions);
+IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree,
+                          IkSolutionListBase<IkReal>& solutions)
+{
+  IKSolver solver;
+  return solver.ComputeIk(eetrans, eerot, pfree, solutions);
 }
 
-IKFAST_API const char* GetKinematicsHash() { return "<robot:genericrobot - kuka_kr210 (328f5fa894ca1be3105acbe6b4ce997b)>"; }
+IKFAST_API const char* GetKinematicsHash()
+{
+  return "<robot:genericrobot - kuka_kr210 (328f5fa894ca1be3105acbe6b4ce997b)>";
+}
 
-IKFAST_API const char* GetIkFastVersion() { return IKFAST_STRINGIZE(IKFAST_VERSION); }
+IKFAST_API const char* GetIkFastVersion()
+{
+  return IKFAST_STRINGIZE(IKFAST_VERSION);
+}
 
 #ifdef IKFAST_NAMESPACE
-} // end namespace
+}  // end namespace
 #endif
 
 #ifndef IKFAST_NO_MAIN
@@ -2821,41 +3813,54 @@ using namespace IKFAST_NAMESPACE;
 #endif
 int main(int argc, char** argv)
 {
-    if( argc != 12+GetNumFreeParameters()+1 ) {
-        printf("\nUsage: ./ik r00 r01 r02 t0 r10 r11 r12 t1 r20 r21 r22 t2 free0 ...\n\n"
-               "Returns the ik solutions given the transformation of the end effector specified by\n"
-               "a 3x3 rotation R (rXX), and a 3x1 translation (tX).\n"
-               "There are %d free parameters that have to be specified.\n\n",GetNumFreeParameters());
-        return 1;
-    }
+  if (argc != 12 + GetNumFreeParameters() + 1)
+  {
+    printf("\nUsage: ./ik r00 r01 r02 t0 r10 r11 r12 t1 r20 r21 r22 t2 free0 ...\n\n"
+           "Returns the ik solutions given the transformation of the end effector specified by\n"
+           "a 3x3 rotation R (rXX), and a 3x1 translation (tX).\n"
+           "There are %d free parameters that have to be specified.\n\n",
+           GetNumFreeParameters());
+    return 1;
+  }
 
-    IkSolutionList<IkReal> solutions;
-    std::vector<IkReal> vfree(GetNumFreeParameters());
-    IkReal eerot[9],eetrans[3];
-    eerot[0] = atof(argv[1]); eerot[1] = atof(argv[2]); eerot[2] = atof(argv[3]); eetrans[0] = atof(argv[4]);
-    eerot[3] = atof(argv[5]); eerot[4] = atof(argv[6]); eerot[5] = atof(argv[7]); eetrans[1] = atof(argv[8]);
-    eerot[6] = atof(argv[9]); eerot[7] = atof(argv[10]); eerot[8] = atof(argv[11]); eetrans[2] = atof(argv[12]);
-    for(std::size_t i = 0; i < vfree.size(); ++i)
-        vfree[i] = atof(argv[13+i]);
-    bool bSuccess = ComputeIk(eetrans, eerot, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
+  IkSolutionList<IkReal> solutions;
+  std::vector<IkReal> vfree(GetNumFreeParameters());
+  IkReal eerot[9], eetrans[3];
+  eerot[0] = atof(argv[1]);
+  eerot[1] = atof(argv[2]);
+  eerot[2] = atof(argv[3]);
+  eetrans[0] = atof(argv[4]);
+  eerot[3] = atof(argv[5]);
+  eerot[4] = atof(argv[6]);
+  eerot[5] = atof(argv[7]);
+  eetrans[1] = atof(argv[8]);
+  eerot[6] = atof(argv[9]);
+  eerot[7] = atof(argv[10]);
+  eerot[8] = atof(argv[11]);
+  eetrans[2] = atof(argv[12]);
+  for (std::size_t i = 0; i < vfree.size(); ++i)
+    vfree[i] = atof(argv[13 + i]);
+  bool bSuccess = ComputeIk(eetrans, eerot, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
 
-    if( !bSuccess ) {
-        fprintf(stderr,"Failed to get ik solution\n");
-        return -1;
-    }
+  if (!bSuccess)
+  {
+    fprintf(stderr, "Failed to get ik solution\n");
+    return -1;
+  }
 
-    printf("Found %d ik solutions:\n", (int)solutions.GetNumSolutions());
-    std::vector<IkReal> solvalues(GetNumJoints());
-    for(std::size_t i = 0; i < solutions.GetNumSolutions(); ++i) {
-        const IkSolutionBase<IkReal>& sol = solutions.GetSolution(i);
-        printf("sol%d (free=%d): ", (int)i, (int)sol.GetFree().size());
-        std::vector<IkReal> vsolfree(sol.GetFree().size());
-        sol.GetSolution(&solvalues[0],vsolfree.size()>0?&vsolfree[0]:NULL);
-        for( std::size_t j = 0; j < solvalues.size(); ++j)
-            printf("%.15f, ", solvalues[j]);
-        printf("\n");
-    }
-    return 0;
+  printf("Found %d ik solutions:\n", (int)solutions.GetNumSolutions());
+  std::vector<IkReal> solvalues(GetNumJoints());
+  for (std::size_t i = 0; i < solutions.GetNumSolutions(); ++i)
+  {
+    const IkSolutionBase<IkReal>& sol = solutions.GetSolution(i);
+    printf("sol%d (free=%d): ", (int)i, (int)sol.GetFree().size());
+    std::vector<IkReal> vsolfree(sol.GetFree().size());
+    sol.GetSolution(&solvalues[0], vsolfree.size() > 0 ? &vsolfree[0] : NULL);
+    for (std::size_t j = 0; j < solvalues.size(); ++j)
+      printf("%.15f, ", solvalues[j]);
+    printf("\n");
+  }
+  return 0;
 }
 
 #endif

--- a/kuka_kr210_manipulator_ik_plugin/src/test_kuka_kr210_manipulator_ikfast_moveit_plugin.cpp
+++ b/kuka_kr210_manipulator_ik_plugin/src/test_kuka_kr210_manipulator_ikfast_moveit_plugin.cpp
@@ -2,7 +2,8 @@
  *
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2013, Dave Coleman, CU Boulder; Jeremy Zoss, SwRI; David Butterworth, KAIST; Mathias Lüdtke, Fraunhofer IPA
+ * Copyright (c) 2013, Dave Coleman, CU Boulder; Jeremy Zoss, SwRI; David Butterworth, KAIST; Mathias Lüdtke, Fraunhofer
+ *IPA
  * All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -45,69 +46,94 @@
  *
  */
 
-#include <ros/ros.h>
 #include <moveit/kinematics_base/kinematics_base.h>
-#include <urdf/model.h>
+#include <ros/ros.h>
 #include <tf_conversions/tf_kdl.h>
+#include <urdf/model.h>
 
 // Need a floating point tolerance when checking joint limits, in case the joint starts at limit
 const double LIMIT_TOLERANCE = .0000001;
 /// \brief Search modes for searchPositionIK(), see there
-enum SEARCH_MODE { OPTIMIZE_FREE_JOINT=1, OPTIMIZE_MAX_JOINT=2 };
+enum SEARCH_MODE
+{
+  OPTIMIZE_FREE_JOINT = 1,
+  OPTIMIZE_MAX_JOINT = 2
+};
 
 namespace ikfast_kinematics_plugin
 {
-
-#define IKFAST_NO_MAIN // Don't include main() from IKFast
+#define IKFAST_NO_MAIN  // Don't include main() from IKFast
 
 /// \brief The types of inverse kinematics parameterizations supported.
 ///
 /// The minimum degree of freedoms required is set in the upper 4 bits of each type.
 /// The number of values used to represent the parameterization ( >= dof ) is the next 4 bits.
 /// The lower bits contain a unique id of the type.
-enum IkParameterizationType {
-    IKP_None=0,
-    IKP_Transform6D=0x67000001,     ///< end effector reaches desired 6D transformation
-    IKP_Rotation3D=0x34000002,     ///< end effector reaches desired 3D rotation
-    IKP_Translation3D=0x33000003,     ///< end effector origin reaches desired 3D translation
-    IKP_Direction3D=0x23000004,     ///< direction on end effector coordinate system reaches desired direction
-    IKP_Ray4D=0x46000005,     ///< ray on end effector coordinate system reaches desired global ray
-    IKP_Lookat3D=0x23000006,     ///< direction on end effector coordinate system points to desired 3D position
-    IKP_TranslationDirection5D=0x56000007,     ///< end effector origin and direction reaches desired 3D translation and direction. Can be thought of as Ray IK where the origin of the ray must coincide.
-    IKP_TranslationXY2D=0x22000008,     ///< 2D translation along XY plane
-    IKP_TranslationXYOrientation3D=0x33000009,     ///< 2D translation along XY plane and 1D rotation around Z axis. The offset of the rotation is measured starting at +X, so at +X is it 0, at +Y it is pi/2.
-    IKP_TranslationLocalGlobal6D=0x3600000a,     ///< local point on end effector origin reaches desired 3D global point
+enum IkParameterizationType
+{
+  IKP_None = 0,
+  IKP_Transform6D = 0x67000001,    ///< end effector reaches desired 6D transformation
+  IKP_Rotation3D = 0x34000002,     ///< end effector reaches desired 3D rotation
+  IKP_Translation3D = 0x33000003,  ///< end effector origin reaches desired 3D translation
+  IKP_Direction3D = 0x23000004,    ///< direction on end effector coordinate system reaches desired direction
+  IKP_Ray4D = 0x46000005,          ///< ray on end effector coordinate system reaches desired global ray
+  IKP_Lookat3D = 0x23000006,       ///< direction on end effector coordinate system points to desired 3D position
+  IKP_TranslationDirection5D = 0x56000007,  ///< end effector origin and direction reaches desired 3D translation and
+                                            /// direction. Can be thought of as Ray IK where the origin of the ray must
+  /// coincide.
+  IKP_TranslationXY2D = 0x22000008,             ///< 2D translation along XY plane
+  IKP_TranslationXYOrientation3D = 0x33000009,  ///< 2D translation along XY plane and 1D rotation around Z axis. The
+                                                /// offset of the rotation is measured starting at +X, so at +X is it 0,
+  /// at +Y it is pi/2.
+  IKP_TranslationLocalGlobal6D = 0x3600000a,  ///< local point on end effector origin reaches desired 3D global point
 
-    IKP_TranslationXAxisAngle4D=0x4400000b, ///< end effector origin reaches desired 3D translation, manipulator direction makes a specific angle with x-axis  like a cone, angle is from 0-pi. Axes defined in the manipulator base link's coordinate system)
-    IKP_TranslationYAxisAngle4D=0x4400000c, ///< end effector origin reaches desired 3D translation, manipulator direction makes a specific angle with y-axis  like a cone, angle is from 0-pi. Axes defined in the manipulator base link's coordinate system)
-    IKP_TranslationZAxisAngle4D=0x4400000d, ///< end effector origin reaches desired 3D translation, manipulator direction makes a specific angle with z-axis like a cone, angle is from 0-pi. Axes are defined in the manipulator base link's coordinate system.
+  IKP_TranslationXAxisAngle4D = 0x4400000b,  ///< end effector origin reaches desired 3D translation, manipulator
+  /// direction makes a specific angle with x-axis  like a cone, angle is from
+  /// 0-pi. Axes defined in the manipulator base link's coordinate system)
+  IKP_TranslationYAxisAngle4D = 0x4400000c,  ///< end effector origin reaches desired 3D translation, manipulator
+  /// direction makes a specific angle with y-axis  like a cone, angle is from
+  /// 0-pi. Axes defined in the manipulator base link's coordinate system)
+  IKP_TranslationZAxisAngle4D = 0x4400000d,  ///< end effector origin reaches desired 3D translation, manipulator
+                                             /// direction makes a specific angle with z-axis like a cone, angle is from
+  /// 0-pi. Axes are defined in the manipulator base link's coordinate system.
 
-    IKP_TranslationXAxisAngleZNorm4D=0x4400000e, ///< end effector origin reaches desired 3D translation, manipulator direction needs to be orthogonal to z-axis and be rotated at a certain angle starting from the x-axis (defined in the manipulator base link's coordinate system)
-    IKP_TranslationYAxisAngleXNorm4D=0x4400000f, ///< end effector origin reaches desired 3D translation, manipulator direction needs to be orthogonal to x-axis and be rotated at a certain angle starting from the y-axis (defined in the manipulator base link's coordinate system)
-    IKP_TranslationZAxisAngleYNorm4D=0x44000010, ///< end effector origin reaches desired 3D translation, manipulator direction needs to be orthogonal to y-axis and be rotated at a certain angle starting from the z-axis (defined in the manipulator base link's coordinate system)
+  IKP_TranslationXAxisAngleZNorm4D = 0x4400000e,  ///< end effector origin reaches desired 3D translation, manipulator
+                                                  /// direction needs to be orthogonal to z-axis and be rotated at a
+  /// certain angle starting from the x-axis (defined in the manipulator
+  /// base link's coordinate system)
+  IKP_TranslationYAxisAngleXNorm4D = 0x4400000f,  ///< end effector origin reaches desired 3D translation, manipulator
+                                                  /// direction needs to be orthogonal to x-axis and be rotated at a
+  /// certain angle starting from the y-axis (defined in the manipulator
+  /// base link's coordinate system)
+  IKP_TranslationZAxisAngleYNorm4D = 0x44000010,  ///< end effector origin reaches desired 3D translation, manipulator
+                                                  /// direction needs to be orthogonal to y-axis and be rotated at a
+  /// certain angle starting from the z-axis (defined in the manipulator
+  /// base link's coordinate system)
 
-    IKP_NumberOfParameterizations=16,     ///< number of parameterizations (does not count IKP_None)
+  IKP_NumberOfParameterizations = 16,  ///< number of parameterizations (does not count IKP_None)
 
-    IKP_VelocityDataBit = 0x00008000, ///< bit is set if the data represents the time-derivate velocity of an IkParameterization
-    IKP_Transform6DVelocity = IKP_Transform6D|IKP_VelocityDataBit,
-    IKP_Rotation3DVelocity = IKP_Rotation3D|IKP_VelocityDataBit,
-    IKP_Translation3DVelocity = IKP_Translation3D|IKP_VelocityDataBit,
-    IKP_Direction3DVelocity = IKP_Direction3D|IKP_VelocityDataBit,
-    IKP_Ray4DVelocity = IKP_Ray4D|IKP_VelocityDataBit,
-    IKP_Lookat3DVelocity = IKP_Lookat3D|IKP_VelocityDataBit,
-    IKP_TranslationDirection5DVelocity = IKP_TranslationDirection5D|IKP_VelocityDataBit,
-    IKP_TranslationXY2DVelocity = IKP_TranslationXY2D|IKP_VelocityDataBit,
-    IKP_TranslationXYOrientation3DVelocity = IKP_TranslationXYOrientation3D|IKP_VelocityDataBit,
-    IKP_TranslationLocalGlobal6DVelocity = IKP_TranslationLocalGlobal6D|IKP_VelocityDataBit,
-    IKP_TranslationXAxisAngle4DVelocity = IKP_TranslationXAxisAngle4D|IKP_VelocityDataBit,
-    IKP_TranslationYAxisAngle4DVelocity = IKP_TranslationYAxisAngle4D|IKP_VelocityDataBit,
-    IKP_TranslationZAxisAngle4DVelocity = IKP_TranslationZAxisAngle4D|IKP_VelocityDataBit,
-    IKP_TranslationXAxisAngleZNorm4DVelocity = IKP_TranslationXAxisAngleZNorm4D|IKP_VelocityDataBit,
-    IKP_TranslationYAxisAngleXNorm4DVelocity = IKP_TranslationYAxisAngleXNorm4D|IKP_VelocityDataBit,
-    IKP_TranslationZAxisAngleYNorm4DVelocity = IKP_TranslationZAxisAngleYNorm4D|IKP_VelocityDataBit,
+  IKP_VelocityDataBit =
+      0x00008000,  ///< bit is set if the data represents the time-derivate velocity of an IkParameterization
+  IKP_Transform6DVelocity = IKP_Transform6D | IKP_VelocityDataBit,
+  IKP_Rotation3DVelocity = IKP_Rotation3D | IKP_VelocityDataBit,
+  IKP_Translation3DVelocity = IKP_Translation3D | IKP_VelocityDataBit,
+  IKP_Direction3DVelocity = IKP_Direction3D | IKP_VelocityDataBit,
+  IKP_Ray4DVelocity = IKP_Ray4D | IKP_VelocityDataBit,
+  IKP_Lookat3DVelocity = IKP_Lookat3D | IKP_VelocityDataBit,
+  IKP_TranslationDirection5DVelocity = IKP_TranslationDirection5D | IKP_VelocityDataBit,
+  IKP_TranslationXY2DVelocity = IKP_TranslationXY2D | IKP_VelocityDataBit,
+  IKP_TranslationXYOrientation3DVelocity = IKP_TranslationXYOrientation3D | IKP_VelocityDataBit,
+  IKP_TranslationLocalGlobal6DVelocity = IKP_TranslationLocalGlobal6D | IKP_VelocityDataBit,
+  IKP_TranslationXAxisAngle4DVelocity = IKP_TranslationXAxisAngle4D | IKP_VelocityDataBit,
+  IKP_TranslationYAxisAngle4DVelocity = IKP_TranslationYAxisAngle4D | IKP_VelocityDataBit,
+  IKP_TranslationZAxisAngle4DVelocity = IKP_TranslationZAxisAngle4D | IKP_VelocityDataBit,
+  IKP_TranslationXAxisAngleZNorm4DVelocity = IKP_TranslationXAxisAngleZNorm4D | IKP_VelocityDataBit,
+  IKP_TranslationYAxisAngleXNorm4DVelocity = IKP_TranslationYAxisAngleXNorm4D | IKP_VelocityDataBit,
+  IKP_TranslationZAxisAngleYNorm4DVelocity = IKP_TranslationZAxisAngleYNorm4D | IKP_VelocityDataBit,
 
-    IKP_UniqueIdMask = 0x0000ffff, ///< the mask for the unique ids
-    IKP_CustomDataBit = 0x00010000, ///< bit is set if the ikparameterization contains custom data, this is only used when serializing the ik parameterizations
+  IKP_UniqueIdMask = 0x0000ffff,   ///< the mask for the unique ids
+  IKP_CustomDataBit = 0x00010000,  ///< bit is set if the ikparameterization contains custom data, this is only used
+                                   /// when serializing the ik parameterizations
 };
 
 // Code generated by IKFast56/61
@@ -122,20 +148,24 @@ class IKFastKinematicsPlugin : public kinematics::KinematicsBase
   std::vector<std::string> link_names_;
   size_t num_joints_;
   std::vector<int> free_params_;
-  bool active_; // Internal variable that indicates whether solvers are configured and ready
+  bool active_;  // Internal variable that indicates whether solvers are configured and ready
 
-  const std::vector<std::string>& getJointNames() const { return joint_names_; }
-  const std::vector<std::string>& getLinkNames() const { return link_names_; }
+  const std::vector<std::string>& getJointNames() const
+  {
+    return joint_names_;
+  }
+  const std::vector<std::string>& getLinkNames() const
+  {
+    return link_names_;
+  }
 
 public:
-
   /** @class
    *  @brief Interface for an IKFast kinematics plugin
    */
-  IKFastKinematicsPlugin():
-    active_(false)
+  IKFastKinematicsPlugin() : active_(false)
   {
-    srand( time(NULL) );
+    srand(time(NULL));
     supported_methods_.push_back(kinematics::DiscretizationMethods::NO_DISCRETIZATION);
     supported_methods_.push_back(kinematics::DiscretizationMethods::ALL_DISCRETIZED);
     supported_methods_.push_back(kinematics::DiscretizationMethods::ALL_RANDOM_SAMPLED);
@@ -151,11 +181,9 @@ public:
    */
 
   // Returns the first IK solution that is within joint limits, this is called by get_ik() service
-  bool getPositionIK(const geometry_msgs::Pose &ik_pose,
-                     const std::vector<double> &ik_seed_state,
-                     std::vector<double> &solution,
-                     moveit_msgs::MoveItErrorCodes &error_code,
-                     const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+  bool getPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+                     std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                     const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, compute the set joint angles solutions that are able to reach it.
@@ -172,11 +200,9 @@ public:
    *                other will result in failure.
    * @return True if a valid set of solutions was found, false otherwise.
    */
-  bool getPositionIK(const std::vector<geometry_msgs::Pose> &ik_poses,
-                             const std::vector<double> &ik_seed_state,
-                             std::vector< std::vector<double> >& solutions,
-                             kinematics::KinematicsResult& result,
-                             const kinematics::KinematicsQueryOptions &options) const;
+  bool getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
+                     std::vector<std::vector<double> >& solutions, kinematics::KinematicsResult& result,
+                     const kinematics::KinematicsQueryOptions& options) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -186,12 +212,9 @@ public:
    * @param ik_seed_state an initial guess solution for the inverse kinematics
    * @return True if a valid solution was found, false otherwise
    */
-  bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                        const std::vector<double> &ik_seed_state,
-                        double timeout,
-                        std::vector<double> &solution,
-                        moveit_msgs::MoveItErrorCodes &error_code,
-                        const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                        const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -202,13 +225,10 @@ public:
    * @param the distance that the redundancy can be from the current position
    * @return True if a valid solution was found, false otherwise
    */
-  bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                        const std::vector<double> &ik_seed_state,
-                        double timeout,
-                        const std::vector<double> &consistency_limits,
-                        std::vector<double> &solution,
-                        moveit_msgs::MoveItErrorCodes &error_code,
-                        const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        const std::vector<double>& consistency_limits, std::vector<double>& solution,
+                        moveit_msgs::MoveItErrorCodes& error_code,
+                        const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -218,13 +238,10 @@ public:
    * @param ik_seed_state an initial guess solution for the inverse kinematics
    * @return True if a valid solution was found, false otherwise
    */
-  bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                        const std::vector<double> &ik_seed_state,
-                        double timeout,
-                        std::vector<double> &solution,
-                        const IKCallbackFn &solution_callback,
-                        moveit_msgs::MoveItErrorCodes &error_code,
-                        const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                        moveit_msgs::MoveItErrorCodes& error_code,
+                        const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -236,14 +253,10 @@ public:
    * @param consistency_limit the distance that the redundancy can be from the current position
    * @return True if a valid solution was found, false otherwise
    */
-  bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                        const std::vector<double> &ik_seed_state,
-                        double timeout,
-                        const std::vector<double> &consistency_limits,
-                        std::vector<double> &solution,
-                        const IKCallbackFn &solution_callback,
-                        moveit_msgs::MoveItErrorCodes &error_code,
-                        const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        const std::vector<double>& consistency_limits, std::vector<double>& solution,
+                        const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
+                        const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a set of joint angles and a set of links, compute their pose
@@ -253,79 +266,72 @@ public:
    * @param poses The resultant set of poses (in the frame returned by getBaseFrame())
    * @return True if a valid solution was found, false otherwise
    */
-  bool getPositionFK(const std::vector<std::string> &link_names,
-                     const std::vector<double> &joint_angles,
-                     std::vector<geometry_msgs::Pose> &poses) const;
-
+  bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,
+                     std::vector<geometry_msgs::Pose>& poses) const;
 
   /**
    * @brief Sets the discretization value for the redundant joint.
    *
-   * Since this ikfast implementation allows for one redundant joint then only the first entry will be in the discretization map will be used.
+   * Since this ikfast implementation allows for one redundant joint then only the first entry will be in the
+   * discretization map will be used.
    * Calling this method replaces previous discretization settings.
    *
    * @param discretization a map of joint indices and discretization value pairs.
    */
-  void setSearchDiscretization(const std::map<int,double>& discretization);
+  void setSearchDiscretization(const std::map<int, double>& discretization);
 
   /**
    * @brief Overrides the default method to prevent changing the redundant joints
    */
-  bool setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices);
-
+  bool setRedundantJoints(const std::vector<unsigned int>& redundant_joint_indices);
 
 private:
-
-  bool initialize(const std::string &robot_description,
-                  const std::string& group_name,
-                  const std::string& base_name,
-                  const std::string& tip_name,
-                  double search_discretization);
+  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_name,
+                  const std::string& tip_name, double search_discretization);
 
   /**
    * @brief Calls the IK solver from IKFast
    * @return The number of solutions found
    */
-  int solve(KDL::Frame &pose_frame, const std::vector<double> &vfree, IkSolutionList<IkReal> &solutions) const;
+  int solve(KDL::Frame& pose_frame, const std::vector<double>& vfree, IkSolutionList<IkReal>& solutions) const;
 
   /**
    * @brief Gets a specific solution from the set
    */
-  void getSolution(const IkSolutionList<IkReal> &solutions, int i, std::vector<double>& solution) const;
+  void getSolution(const IkSolutionList<IkReal>& solutions, int i, std::vector<double>& solution) const;
 
-  double harmonize(const std::vector<double> &ik_seed_state, std::vector<double> &solution) const;
-  //void getOrderedSolutions(const std::vector<double> &ik_seed_state, std::vector<std::vector<double> >& solslist);
-  void getClosestSolution(const IkSolutionList<IkReal> &solutions, const std::vector<double> &ik_seed_state, std::vector<double> &solution) const;
-  void fillFreeParams(int count, int *array);
-  bool getCount(int &count, const int &max_count, const int &min_count) const;
+  double harmonize(const std::vector<double>& ik_seed_state, std::vector<double>& solution) const;
+  // void getOrderedSolutions(const std::vector<double> &ik_seed_state, std::vector<std::vector<double> >& solslist);
+  void getClosestSolution(const IkSolutionList<IkReal>& solutions, const std::vector<double>& ik_seed_state,
+                          std::vector<double>& solution) const;
+  void fillFreeParams(int count, int* array);
+  bool getCount(int& count, const int& max_count, const int& min_count) const;
 
   bool sampleRedundantJoint(kinematics::DiscretizationMethod method, std::vector<double>& sampled_joint_vals) const;
 
-}; // end class
+};  // end class
 
-bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
-                                        const std::string& group_name,
-                                        const std::string& base_name,
-                                        const std::string& tip_name,
+bool IKFastKinematicsPlugin::initialize(const std::string& robot_description, const std::string& group_name,
+                                        const std::string& base_name, const std::string& tip_name,
                                         double search_discretization)
 {
   setValues(robot_description, group_name, base_name, tip_name, search_discretization);
 
-  ros::NodeHandle node_handle("~/"+group_name);
+  ros::NodeHandle node_handle("~/" + group_name);
 
   std::string robot;
-  node_handle.param("robot",robot,std::string());
+  node_handle.param("robot", robot, std::string());
 
   // IKFast56/61
-  fillFreeParams( GetNumFreeParameters(), GetFreeParameters() );
+  fillFreeParams(GetNumFreeParameters(), GetFreeParameters());
   num_joints_ = GetNumJoints();
 
-  if(free_params_.size() > 1)
+  if (free_params_.size() > 1)
   {
     ROS_FATAL("Only one free joint parameter supported!");
     return false;
   }
-  else if(free_params_.size() == 1)
+  else if (free_params_.size() == 1)
   {
     redundant_joint_indices_.clear();
     redundant_joint_indices_.push_back(free_params_[0]);
@@ -335,44 +341,46 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
   urdf::Model robot_model;
   std::string xml_string;
 
-  std::string urdf_xml,full_urdf_xml;
-  node_handle.param("urdf_xml",urdf_xml,robot_description);
-  node_handle.searchParam(urdf_xml,full_urdf_xml);
+  std::string urdf_xml, full_urdf_xml;
+  node_handle.param("urdf_xml", urdf_xml, robot_description);
+  node_handle.searchParam(urdf_xml, full_urdf_xml);
 
-  ROS_DEBUG_NAMED("ikfast","Reading xml file from parameter server");
+  ROS_DEBUG_NAMED("ikfast", "Reading xml file from parameter server");
   if (!node_handle.getParam(full_urdf_xml, xml_string))
   {
-    ROS_FATAL_NAMED("ikfast","Could not load the xml from parameter server: %s", urdf_xml.c_str());
+    ROS_FATAL_NAMED("ikfast", "Could not load the xml from parameter server: %s", urdf_xml.c_str());
     return false;
   }
 
-  node_handle.param(full_urdf_xml,xml_string,std::string());
+  node_handle.param(full_urdf_xml, xml_string, std::string());
   robot_model.initString(xml_string);
 
-  ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "Reading joints and links from URDF");
 
   boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
-  while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
+  while (link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
-    ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
+    ROS_DEBUG_NAMED("ikfast", "Link %s", link->name.c_str());
     link_names_.push_back(link->name);
     boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
-    if(joint)
+    if (joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)
       {
-        ROS_DEBUG_STREAM_NAMED("ikfast","Adding joint " << joint->name );
+        ROS_DEBUG_STREAM_NAMED("ikfast", "Adding joint " << joint->name);
 
         joint_names_.push_back(joint->name);
         float lower, upper;
         int hasLimits;
-        if ( joint->type != urdf::Joint::CONTINUOUS )
+        if (joint->type != urdf::Joint::CONTINUOUS)
         {
-          if(joint->safety)
+          if (joint->safety)
           {
             lower = joint->safety->soft_lower_limit;
             upper = joint->safety->soft_upper_limit;
-          } else {
+          }
+          else
+          {
             lower = joint->limits->lower;
             upper = joint->limits->upper;
           }
@@ -384,7 +392,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
           upper = M_PI;
           hasLimits = 0;
         }
-        if(hasLimits)
+        if (hasLimits)
         {
           joint_has_limits_vector_.push_back(true);
           joint_min_vector_.push_back(lower);
@@ -397,80 +405,82 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
           joint_max_vector_.push_back(M_PI);
         }
       }
-    } else
+    }
+    else
     {
-      ROS_WARN_NAMED("ikfast","no joint corresponding to %s",link->name.c_str());
+      ROS_WARN_NAMED("ikfast", "no joint corresponding to %s", link->name.c_str());
     }
     link = link->getParent();
   }
 
-  if(joint_names_.size() != num_joints_)
+  if (joint_names_.size() != num_joints_)
   {
-    ROS_FATAL_STREAM_NAMED("ikfast","Joint numbers mismatch: URDF has " << joint_names_.size() << " and IKFast has " << num_joints_);
+    ROS_FATAL_STREAM_NAMED("ikfast", "Joint numbers mismatch: URDF has " << joint_names_.size() << " and IKFast has "
+                                                                         << num_joints_);
     return false;
   }
 
-  std::reverse(link_names_.begin(),link_names_.end());
-  std::reverse(joint_names_.begin(),joint_names_.end());
-  std::reverse(joint_min_vector_.begin(),joint_min_vector_.end());
-  std::reverse(joint_max_vector_.begin(),joint_max_vector_.end());
+  std::reverse(link_names_.begin(), link_names_.end());
+  std::reverse(joint_names_.begin(), joint_names_.end());
+  std::reverse(joint_min_vector_.begin(), joint_min_vector_.end());
+  std::reverse(joint_max_vector_.begin(), joint_max_vector_.end());
   std::reverse(joint_has_limits_vector_.begin(), joint_has_limits_vector_.end());
 
-  for(size_t i=0; i <num_joints_; ++i)
-    ROS_DEBUG_STREAM_NAMED("ikfast",joint_names_[i] << " " << joint_min_vector_[i] << " " << joint_max_vector_[i] << " " << joint_has_limits_vector_[i]);
+  for (size_t i = 0; i < num_joints_; ++i)
+    ROS_DEBUG_STREAM_NAMED("ikfast", joint_names_[i] << " " << joint_min_vector_[i] << " " << joint_max_vector_[i]
+                                                     << " " << joint_has_limits_vector_[i]);
 
   active_ = true;
   return true;
 }
 
-void IKFastKinematicsPlugin::setSearchDiscretization(const std::map<int,double>& discretization)
+void IKFastKinematicsPlugin::setSearchDiscretization(const std::map<int, double>& discretization)
 {
-
-  if(discretization.empty())
+  if (discretization.empty())
   {
     ROS_ERROR("The 'discretization' map is empty");
     return;
   }
 
-  if(redundant_joint_indices_.empty())
+  if (redundant_joint_indices_.empty())
   {
     ROS_ERROR_STREAM("This group's solver doesn't support redundant joints");
     return;
   }
 
-  if(discretization.begin()->first != redundant_joint_indices_[0])
+  if (discretization.begin()->first != redundant_joint_indices_[0])
   {
     std::string redundant_joint = joint_names_[free_params_[0]];
-    ROS_ERROR_STREAM("Attempted to discretize a non-redundant joint "<<discretization.begin()->first<<", only joint '"<<
-                     redundant_joint<<"' with index " <<redundant_joint_indices_[0]<<" is redundant.");
+    ROS_ERROR_STREAM("Attempted to discretize a non-redundant joint "
+                     << discretization.begin()->first << ", only joint '" << redundant_joint << "' with index "
+                     << redundant_joint_indices_[0] << " is redundant.");
     return;
   }
 
-  if(discretization.begin()->second <= 0.0)
+  if (discretization.begin()->second <= 0.0)
   {
-	  ROS_ERROR_STREAM("Discretization can not takes values that are <= 0");
-	  return;
+    ROS_ERROR_STREAM("Discretization can not takes values that are <= 0");
+    return;
   }
-
 
   redundant_joint_discretization_.clear();
   redundant_joint_discretization_[redundant_joint_indices_[0]] = discretization.begin()->second;
 }
 
-bool IKFastKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices)
+bool IKFastKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& redundant_joint_indices)
 {
-
   ROS_ERROR_STREAM("Changing the redundant joints isn't permitted by this group's solver ");
   return false;
 }
 
-int IKFastKinematicsPlugin::solve(KDL::Frame &pose_frame, const std::vector<double> &vfree, IkSolutionList<IkReal> &solutions) const
+int IKFastKinematicsPlugin::solve(KDL::Frame& pose_frame, const std::vector<double>& vfree,
+                                  IkSolutionList<IkReal>& solutions) const
 {
   // IKFast56/61
   solutions.Clear();
 
   double trans[3];
-  trans[0] = pose_frame.p[0];//-.18;
+  trans[0] = pose_frame.p[0];  //-.18;
   trans[1] = pose_frame.p[1];
   trans[2] = pose_frame.p[2];
 
@@ -486,15 +496,15 @@ int IKFastKinematicsPlugin::solve(KDL::Frame &pose_frame, const std::vector<doub
       mult = pose_frame.M;
 
       double vals[9];
-      vals[0] = mult(0,0);
-      vals[1] = mult(0,1);
-      vals[2] = mult(0,2);
-      vals[3] = mult(1,0);
-      vals[4] = mult(1,1);
-      vals[5] = mult(1,2);
-      vals[6] = mult(2,0);
-      vals[7] = mult(2,1);
-      vals[8] = mult(2,2);
+      vals[0] = mult(0, 0);
+      vals[1] = mult(0, 1);
+      vals[2] = mult(0, 2);
+      vals[3] = mult(1, 0);
+      vals[4] = mult(1, 1);
+      vals[5] = mult(1, 2);
+      vals[6] = mult(2, 0);
+      vals[7] = mult(2, 1);
+      vals[8] = mult(2, 2);
 
       // IKFast56/61
       ComputeIk(trans, vals, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
@@ -503,7 +513,8 @@ int IKFastKinematicsPlugin::solve(KDL::Frame &pose_frame, const std::vector<doub
     case IKP_Direction3D:
     case IKP_Ray4D:
     case IKP_TranslationDirection5D:
-      // For **Direction3D**, **Ray4D**, and **TranslationDirection5D**, the first 3 values represent the target direction.
+      // For **Direction3D**, **Ray4D**, and **TranslationDirection5D**, the first 3 values represent the target
+      // direction.
 
       direction = pose_frame.M * KDL::Vector(0, 0, 1);
       ComputeIk(trans, direction.data, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
@@ -512,12 +523,14 @@ int IKFastKinematicsPlugin::solve(KDL::Frame &pose_frame, const std::vector<doub
     case IKP_TranslationXAxisAngle4D:
     case IKP_TranslationYAxisAngle4D:
     case IKP_TranslationZAxisAngle4D:
-      // For **TranslationXAxisAngle4D**, **TranslationYAxisAngle4D**, and **TranslationZAxisAngle4D**, the first value represents the angle.
+      // For **TranslationXAxisAngle4D**, **TranslationYAxisAngle4D**, and **TranslationZAxisAngle4D**, the first value
+      // represents the angle.
       ROS_ERROR_NAMED("ikfast", "IK for this IkParameterizationType not implemented yet.");
       return 0;
 
     case IKP_TranslationLocalGlobal6D:
-      // For **TranslationLocalGlobal6D**, the diagonal elements ([0],[4],[8]) are the local translation inside the end effector coordinate system.
+      // For **TranslationLocalGlobal6D**, the diagonal elements ([0],[4],[8]) are the local translation inside the end
+      // effector coordinate system.
       ROS_ERROR_NAMED("ikfast", "IK for this IkParameterizationType not implemented yet.");
       return 0;
 
@@ -532,46 +545,52 @@ int IKFastKinematicsPlugin::solve(KDL::Frame &pose_frame, const std::vector<doub
       return 0;
 
     default:
-      ROS_ERROR_NAMED("ikfast", "Unknown IkParameterizationType! Was the solver generated with an incompatible version of Openrave?");
+      ROS_ERROR_NAMED("ikfast", "Unknown IkParameterizationType! Was the solver generated with an incompatible version "
+                                "of Openrave?");
       return 0;
   }
 }
 
-void IKFastKinematicsPlugin::getSolution(const IkSolutionList<IkReal> &solutions, int i, std::vector<double>& solution) const
+void IKFastKinematicsPlugin::getSolution(const IkSolutionList<IkReal>& solutions, int i,
+                                         std::vector<double>& solution) const
 {
   solution.clear();
   solution.resize(num_joints_);
 
   // IKFast56/61
   const IkSolutionBase<IkReal>& sol = solutions.GetSolution(i);
-  std::vector<IkReal> vsolfree( sol.GetFree().size() );
-  sol.GetSolution(&solution[0],vsolfree.size()>0?&vsolfree[0]:NULL);
+  std::vector<IkReal> vsolfree(sol.GetFree().size());
+  sol.GetSolution(&solution[0], vsolfree.size() > 0 ? &vsolfree[0] : NULL);
 
   // std::cout << "solution " << i << ":" ;
   // for(int j=0;j<num_joints_; ++j)
   //   std::cout << " " << solution[j];
   // std::cout << std::endl;
 
-  //ROS_ERROR("%f %d",solution[2],vsolfree.size());
+  // ROS_ERROR("%f %d",solution[2],vsolfree.size());
 }
 
-double IKFastKinematicsPlugin::harmonize(const std::vector<double> &ik_seed_state, std::vector<double> &solution) const
+double IKFastKinematicsPlugin::harmonize(const std::vector<double>& ik_seed_state, std::vector<double>& solution) const
 {
   double dist_sqr = 0;
   std::vector<double> ss = ik_seed_state;
-  for(size_t i=0; i< ik_seed_state.size(); ++i)
+  for (size_t i = 0; i < ik_seed_state.size(); ++i)
   {
-    while(ss[i] > 2*M_PI) {
-      ss[i] -= 2*M_PI;
+    while (ss[i] > 2 * M_PI)
+    {
+      ss[i] -= 2 * M_PI;
     }
-    while(ss[i] < 2*M_PI) {
-      ss[i] += 2*M_PI;
+    while (ss[i] < 2 * M_PI)
+    {
+      ss[i] += 2 * M_PI;
     }
-    while(solution[i] > 2*M_PI) {
-      solution[i] -= 2*M_PI;
+    while (solution[i] > 2 * M_PI)
+    {
+      solution[i] -= 2 * M_PI;
     }
-    while(solution[i] < 2*M_PI) {
-      solution[i] += 2*M_PI;
+    while (solution[i] < 2 * M_PI)
+    {
+      solution[i] += 2 * M_PI;
     }
     dist_sqr += fabs(ik_seed_state[i] - solution[i]);
   }
@@ -601,48 +620,53 @@ double IKFastKinematicsPlugin::harmonize(const std::vector<double> &ik_seed_stat
 //   }
 // }
 
-void IKFastKinematicsPlugin::getClosestSolution(const IkSolutionList<IkReal> &solutions, const std::vector<double> &ik_seed_state, std::vector<double> &solution) const
+void IKFastKinematicsPlugin::getClosestSolution(const IkSolutionList<IkReal>& solutions,
+                                                const std::vector<double>& ik_seed_state,
+                                                std::vector<double>& solution) const
 {
   double mindist = DBL_MAX;
   int minindex = -1;
   std::vector<double> sol;
 
   // IKFast56/61
-  for(size_t i=0; i < solutions.GetNumSolutions(); ++i)
+  for (size_t i = 0; i < solutions.GetNumSolutions(); ++i)
   {
-    getSolution(solutions, i,sol);
+    getSolution(solutions, i, sol);
     double dist = harmonize(ik_seed_state, sol);
-    ROS_INFO_STREAM_NAMED("ikfast","Dist " << i << " dist " << dist);
-    //std::cout << "dist[" << i << "]= " << dist << std::endl;
-    if(minindex == -1 || dist<mindist){
+    ROS_INFO_STREAM_NAMED("ikfast", "Dist " << i << " dist " << dist);
+    // std::cout << "dist[" << i << "]= " << dist << std::endl;
+    if (minindex == -1 || dist < mindist)
+    {
       minindex = i;
       mindist = dist;
     }
   }
-  if(minindex >= 0){
-    getSolution(solutions, minindex,solution);
+  if (minindex >= 0)
+  {
+    getSolution(solutions, minindex, solution);
     harmonize(ik_seed_state, solution);
   }
 }
 
-void IKFastKinematicsPlugin::fillFreeParams(int count, int *array)
+void IKFastKinematicsPlugin::fillFreeParams(int count, int* array)
 {
   free_params_.clear();
-  for(int i=0; i<count;++i) free_params_.push_back(array[i]);
+  for (int i = 0; i < count; ++i)
+    free_params_.push_back(array[i]);
 }
 
-bool IKFastKinematicsPlugin::getCount(int &count, const int &max_count, const int &min_count) const
+bool IKFastKinematicsPlugin::getCount(int& count, const int& max_count, const int& min_count) const
 {
-  if(count > 0)
+  if (count > 0)
   {
-    if(-count >= min_count)
+    if (-count >= min_count)
     {
       count = -count;
       return true;
     }
-    else if(count+1 <= max_count)
+    else if (count + 1 <= max_count)
     {
-      count = count+1;
+      count = count + 1;
       return true;
     }
     else
@@ -652,14 +676,14 @@ bool IKFastKinematicsPlugin::getCount(int &count, const int &max_count, const in
   }
   else
   {
-    if(1-count <= max_count)
+    if (1 - count <= max_count)
     {
-      count = 1-count;
+      count = 1 - count;
       return true;
     }
-    else if(count-1 >= min_count)
+    else if (count - 1 >= min_count)
     {
-      count = count -1;
+      count = count - 1;
       return true;
     }
     else
@@ -667,11 +691,12 @@ bool IKFastKinematicsPlugin::getCount(int &count, const int &max_count, const in
   }
 }
 
-bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string> &link_names,
-                                           const std::vector<double> &joint_angles,
-                                           std::vector<geometry_msgs::Pose> &poses) const
+bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_names,
+                                           const std::vector<double>& joint_angles,
+                                           std::vector<geometry_msgs::Pose>& poses) const
 {
-  if (GetIkType() != IKP_Transform6D) {
+  if (GetIkType() != IKP_Transform6D)
+  {
     // ComputeFk() is the inverse function of ComputeIk(), so the format of
     // eerot differs depending on IK type. The Transform6D IK type is the only
     // one for which a 3x3 rotation matrix is returned, which means we can only
@@ -681,173 +706,150 @@ bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string> &link_
   }
 
   KDL::Frame p_out;
-  if(link_names.size() == 0) {
-    ROS_WARN_STREAM_NAMED("ikfast","Link names with nothing");
+  if (link_names.size() == 0)
+  {
+    ROS_WARN_STREAM_NAMED("ikfast", "Link names with nothing");
     return false;
   }
 
-  if(link_names.size()!=1 || link_names[0]!=getTipFrame()){
-    ROS_ERROR_NAMED("ikfast","Can compute FK for %s only",getTipFrame().c_str());
+  if (link_names.size() != 1 || link_names[0] != getTipFrame())
+  {
+    ROS_ERROR_NAMED("ikfast", "Can compute FK for %s only", getTipFrame().c_str());
     return false;
   }
 
   bool valid = true;
 
-  IkReal eerot[9],eetrans[3];
+  IkReal eerot[9], eetrans[3];
   IkReal angles[joint_angles.size()];
-  for (unsigned char i=0; i < joint_angles.size(); i++)
+  for (unsigned char i = 0; i < joint_angles.size(); i++)
     angles[i] = joint_angles[i];
 
   // IKFast56/61
-  ComputeFk(angles,eetrans,eerot);
+  ComputeFk(angles, eetrans, eerot);
 
-  for(int i=0; i<3;++i)
+  for (int i = 0; i < 3; ++i)
     p_out.p.data[i] = eetrans[i];
 
-  for(int i=0; i<9;++i)
+  for (int i = 0; i < 9; ++i)
     p_out.M.data[i] = eerot[i];
 
   poses.resize(1);
-  tf::poseKDLToMsg(p_out,poses[0]);
+  tf::poseKDLToMsg(p_out, poses[0]);
 
   return valid;
 }
 
-bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                                           const std::vector<double> &ik_seed_state,
-                                           double timeout,
-                                           std::vector<double> &solution,
-                                           moveit_msgs::MoveItErrorCodes &error_code,
-                                           const kinematics::KinematicsQueryOptions &options) const
+bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                              const std::vector<double>& ik_seed_state, double timeout,
+                                              std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                                              const kinematics::KinematicsQueryOptions& options) const
 {
-  const IKCallbackFn solution_callback = 0; 
+  const IKCallbackFn solution_callback = 0;
   std::vector<double> consistency_limits;
 
-  return searchPositionIK(ik_pose,
-                          ik_seed_state,
-                          timeout,
-                          consistency_limits,
-                          solution,
-                          solution_callback,
-                          error_code,
-                          options);
-}
-    
-bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                                           const std::vector<double> &ik_seed_state,
-                                           double timeout,
-                                           const std::vector<double> &consistency_limits,
-                                           std::vector<double> &solution,
-                                           moveit_msgs::MoveItErrorCodes &error_code,
-                                           const kinematics::KinematicsQueryOptions &options) const
-{
-  const IKCallbackFn solution_callback = 0; 
-  return searchPositionIK(ik_pose,
-                          ik_seed_state,
-                          timeout,
-                          consistency_limits,
-                          solution,
-                          solution_callback,
-                          error_code,
+  return searchPositionIK(ik_pose, ik_seed_state, timeout, consistency_limits, solution, solution_callback, error_code,
                           options);
 }
 
-bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                                           const std::vector<double> &ik_seed_state,
-                                           double timeout,
-                                           std::vector<double> &solution,
-                                           const IKCallbackFn &solution_callback,
-                                           moveit_msgs::MoveItErrorCodes &error_code,
-                                           const kinematics::KinematicsQueryOptions &options) const
+bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                              const std::vector<double>& ik_seed_state, double timeout,
+                                              const std::vector<double>& consistency_limits,
+                                              std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                                              const kinematics::KinematicsQueryOptions& options) const
+{
+  const IKCallbackFn solution_callback = 0;
+  return searchPositionIK(ik_pose, ik_seed_state, timeout, consistency_limits, solution, solution_callback, error_code,
+                          options);
+}
+
+bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                              const std::vector<double>& ik_seed_state, double timeout,
+                                              std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                                              moveit_msgs::MoveItErrorCodes& error_code,
+                                              const kinematics::KinematicsQueryOptions& options) const
 {
   std::vector<double> consistency_limits;
-  return searchPositionIK(ik_pose,
-                          ik_seed_state,
-                          timeout,
-                          consistency_limits,
-                          solution,
-                          solution_callback,
-                          error_code,
+  return searchPositionIK(ik_pose, ik_seed_state, timeout, consistency_limits, solution, solution_callback, error_code,
                           options);
 }
 
-bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                                              const std::vector<double> &ik_seed_state,
-                                              double timeout,
-                                              const std::vector<double> &consistency_limits,
-                                              std::vector<double> &solution,
-                                              const IKCallbackFn &solution_callback,
-                                              moveit_msgs::MoveItErrorCodes &error_code,
-                                              const kinematics::KinematicsQueryOptions &options) const
+bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                              const std::vector<double>& ik_seed_state, double timeout,
+                                              const std::vector<double>& consistency_limits,
+                                              std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                                              moveit_msgs::MoveItErrorCodes& error_code,
+                                              const kinematics::KinematicsQueryOptions& options) const
 {
-  ROS_DEBUG_STREAM_NAMED("ikfast","searchPositionIK");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "searchPositionIK");
 
   /// search_mode is currently fixed during code generation
   SEARCH_MODE search_mode = OPTIMIZE_MAX_JOINT;
 
   // Check if there are no redundant joints
-  if(free_params_.size()==0)
+  if (free_params_.size() == 0)
   {
-    ROS_DEBUG_STREAM_NAMED("ikfast","No need to search since no free params/redundant joints");
+    ROS_DEBUG_STREAM_NAMED("ikfast", "No need to search since no free params/redundant joints");
 
     // Find first IK solution, within joint limits
-    if(!getPositionIK(ik_pose, ik_seed_state, solution, error_code))
+    if (!getPositionIK(ik_pose, ik_seed_state, solution, error_code))
     {
-      ROS_DEBUG_STREAM_NAMED("ikfast","No solution whatsoever");
+      ROS_DEBUG_STREAM_NAMED("ikfast", "No solution whatsoever");
       error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
       return false;
     }
 
     // check for collisions if a callback is provided
-    if( !solution_callback.empty() )
+    if (!solution_callback.empty())
     {
       solution_callback(ik_pose, solution, error_code);
-      if(error_code.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
+      if (error_code.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
       {
-        ROS_DEBUG_STREAM_NAMED("ikfast","Solution passes callback");
+        ROS_DEBUG_STREAM_NAMED("ikfast", "Solution passes callback");
         return true;
       }
       else
       {
-        ROS_DEBUG_STREAM_NAMED("ikfast","Solution has error code " << error_code);
+        ROS_DEBUG_STREAM_NAMED("ikfast", "Solution has error code " << error_code);
         return false;
       }
     }
     else
     {
-      return true; // no collision check callback provided
+      return true;  // no collision check callback provided
     }
   }
 
   // -------------------------------------------------------------------------------------------------
   // Error Checking
-  if(!active_)
+  if (!active_)
   {
-    ROS_ERROR_STREAM_NAMED("ikfast","Kinematics not active");
+    ROS_ERROR_STREAM_NAMED("ikfast", "Kinematics not active");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
-  if(ik_seed_state.size() != num_joints_)
+  if (ik_seed_state.size() != num_joints_)
   {
-    ROS_ERROR_STREAM_NAMED("ikfast","Seed state must have size " << num_joints_ << " instead of size " << ik_seed_state.size());
+    ROS_ERROR_STREAM_NAMED("ikfast", "Seed state must have size " << num_joints_ << " instead of size "
+                                                                  << ik_seed_state.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
-  if(!consistency_limits.empty() && consistency_limits.size() != num_joints_)
+  if (!consistency_limits.empty() && consistency_limits.size() != num_joints_)
   {
-    ROS_ERROR_STREAM_NAMED("ikfast","Consistency limits be empty or must have size " << num_joints_ << " instead of size " << consistency_limits.size());
+    ROS_ERROR_STREAM_NAMED("ikfast", "Consistency limits be empty or must have size "
+                                         << num_joints_ << " instead of size " << consistency_limits.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
-
 
   // -------------------------------------------------------------------------------------------------
   // Initialize
 
   KDL::Frame frame;
-  tf::poseMsgToKDL(ik_pose,frame);
+  tf::poseMsgToKDL(ik_pose, frame);
 
   std::vector<double> vfree(free_params_.size());
 
@@ -862,66 +864,69 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
   int num_positive_increments;
   int num_negative_increments;
 
-  if(!consistency_limits.empty())
+  if (!consistency_limits.empty())
   {
     // moveit replaced consistency_limit (scalar) w/ consistency_limits (vector)
     // Assume [0]th free_params element for now.  Probably wrong.
-    double max_limit = fmin(joint_max_vector_[free_params_[0]], initial_guess+consistency_limits[free_params_[0]]);
-    double min_limit = fmax(joint_min_vector_[free_params_[0]], initial_guess-consistency_limits[free_params_[0]]);
+    double max_limit = fmin(joint_max_vector_[free_params_[0]], initial_guess + consistency_limits[free_params_[0]]);
+    double min_limit = fmax(joint_min_vector_[free_params_[0]], initial_guess - consistency_limits[free_params_[0]]);
 
-    num_positive_increments = (int)((max_limit-initial_guess)/search_discretization_);
-    num_negative_increments = (int)((initial_guess-min_limit)/search_discretization_);
+    num_positive_increments = (int)((max_limit - initial_guess) / search_discretization_);
+    num_negative_increments = (int)((initial_guess - min_limit) / search_discretization_);
   }
-  else // no consitency limits provided
+  else  // no consitency limits provided
   {
-    num_positive_increments = (joint_max_vector_[free_params_[0]]-initial_guess)/search_discretization_;
-    num_negative_increments = (initial_guess-joint_min_vector_[free_params_[0]])/search_discretization_;
+    num_positive_increments = (joint_max_vector_[free_params_[0]] - initial_guess) / search_discretization_;
+    num_negative_increments = (initial_guess - joint_min_vector_[free_params_[0]]) / search_discretization_;
   }
 
   // -------------------------------------------------------------------------------------------------
   // Begin searching
 
-  ROS_DEBUG_STREAM_NAMED("ikfast","Free param is " << free_params_[0] << " initial guess is " << initial_guess << ", # positive increments: " << num_positive_increments << ", # negative increments: " << num_negative_increments);
+  ROS_DEBUG_STREAM_NAMED("ikfast", "Free param is " << free_params_[0] << " initial guess is " << initial_guess
+                                                    << ", # positive increments: " << num_positive_increments
+                                                    << ", # negative increments: " << num_negative_increments);
   if ((search_mode & OPTIMIZE_MAX_JOINT) && (num_positive_increments + num_negative_increments) > 1000)
-      ROS_WARN_STREAM_ONCE_NAMED("ikfast", "Large search space, consider increasing the search discretization");
-  
+    ROS_WARN_STREAM_ONCE_NAMED("ikfast", "Large search space, consider increasing the search discretization");
+
   double best_costs = -1.0;
   std::vector<double> best_solution;
   int nattempts = 0, nvalid = 0;
 
-  while(true)
+  while (true)
   {
     IkSolutionList<IkReal> solutions;
-    int numsol = solve(frame,vfree, solutions);
+    int numsol = solve(frame, vfree, solutions);
 
-    ROS_DEBUG_STREAM_NAMED("ikfast","Found " << numsol << " solutions from IKFast");
+    ROS_DEBUG_STREAM_NAMED("ikfast", "Found " << numsol << " solutions from IKFast");
 
-    //ROS_INFO("%f",vfree[0]);
+    // ROS_INFO("%f",vfree[0]);
 
-    if( numsol > 0 )
+    if (numsol > 0)
     {
-      for(int s = 0; s < numsol; ++s)
+      for (int s = 0; s < numsol; ++s)
       {
         nattempts++;
         std::vector<double> sol;
-        getSolution(solutions,s,sol);
+        getSolution(solutions, s, sol);
 
         bool obeys_limits = true;
-        for(unsigned int i = 0; i < sol.size(); i++)
+        for (unsigned int i = 0; i < sol.size(); i++)
         {
-          if(joint_has_limits_vector_[i] && (sol[i] < joint_min_vector_[i] || sol[i] > joint_max_vector_[i]))
+          if (joint_has_limits_vector_[i] && (sol[i] < joint_min_vector_[i] || sol[i] > joint_max_vector_[i]))
           {
             obeys_limits = false;
             break;
           }
-          //ROS_INFO_STREAM_NAMED("ikfast","Num " << i << " value " << sol[i] << " has limits " << joint_has_limits_vector_[i] << " " << joint_min_vector_[i] << " " << joint_max_vector_[i]);
+          // ROS_INFO_STREAM_NAMED("ikfast","Num " << i << " value " << sol[i] << " has limits " <<
+          // joint_has_limits_vector_[i] << " " << joint_min_vector_[i] << " " << joint_max_vector_[i]);
         }
-        if(obeys_limits)
+        if (obeys_limits)
         {
-          getSolution(solutions,s,solution);
+          getSolution(solutions, s, solution);
 
           // This solution is within joint limits, now check if in collision (if callback provided)
-          if(!solution_callback.empty())
+          if (!solution_callback.empty())
           {
             solution_callback(ik_pose, solution, error_code);
           }
@@ -930,14 +935,14 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
             error_code.val = error_code.SUCCESS;
           }
 
-          if(error_code.val == error_code.SUCCESS)
+          if (error_code.val == error_code.SUCCESS)
           {
             nvalid++;
             if (search_mode & OPTIMIZE_MAX_JOINT)
             {
               // Costs for solution: Largest joint motion
               double costs = 0.0;
-              for(unsigned int i = 0; i < solution.size(); i++)
+              for (unsigned int i = 0; i < solution.size(); i++)
               {
                 double d = fabs(ik_seed_state[i] - solution[i]);
                 if (d > costs)
@@ -957,15 +962,15 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
       }
     }
 
-    if(!getCount(counter, num_positive_increments, -num_negative_increments))
+    if (!getCount(counter, num_positive_increments, -num_negative_increments))
     {
       // Everything searched
       error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
       break;
     }
 
-    vfree[0] = initial_guess+search_discretization_*counter;
-    //ROS_DEBUG_STREAM_NAMED("ikfast","Attempt " << counter << " with 0th free joint having value " << vfree[0]);
+    vfree[0] = initial_guess + search_discretization_ * counter;
+    // ROS_DEBUG_STREAM_NAMED("ikfast","Attempt " << counter << " with 0th free joint having value " << vfree[0]);
   }
 
   ROS_DEBUG_STREAM_NAMED("ikfast", "Valid solutions: " << nvalid << "/" << nattempts);
@@ -983,61 +988,62 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
 }
 
 // Used when there are no redundant joints - aka no free params
-bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose &ik_pose,
-                                           const std::vector<double> &ik_seed_state,
-                                           std::vector<double> &solution,
-                                           moveit_msgs::MoveItErrorCodes &error_code,
-                                           const kinematics::KinematicsQueryOptions &options) const
+bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+                                           std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                                           const kinematics::KinematicsQueryOptions& options) const
 {
-  ROS_DEBUG_STREAM_NAMED("ikfast","getPositionIK");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "getPositionIK");
 
-  if(!active_)
+  if (!active_)
   {
-    ROS_ERROR("kinematics not active");    
+    ROS_ERROR("kinematics not active");
     return false;
   }
 
   std::vector<double> vfree(free_params_.size());
-  for(std::size_t i = 0; i < free_params_.size(); ++i)
+  for (std::size_t i = 0; i < free_params_.size(); ++i)
   {
     int p = free_params_[i];
-    ROS_ERROR("%u is %f",p,ik_seed_state[p]);  // DTC
+    ROS_ERROR("%u is %f", p, ik_seed_state[p]);  // DTC
     vfree[i] = ik_seed_state[p];
   }
 
   KDL::Frame frame;
-  tf::poseMsgToKDL(ik_pose,frame);
+  tf::poseMsgToKDL(ik_pose, frame);
 
   IkSolutionList<IkReal> solutions;
-  int numsol = solve(frame,vfree,solutions);
+  int numsol = solve(frame, vfree, solutions);
 
-  ROS_DEBUG_STREAM_NAMED("ikfast","Found " << numsol << " solutions from IKFast");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "Found " << numsol << " solutions from IKFast");
 
-  if(numsol)
+  if (numsol)
   {
-    for(int s = 0; s < numsol; ++s)
+    for (int s = 0; s < numsol; ++s)
     {
       std::vector<double> sol;
-      getSolution(solutions,s,sol);
-      ROS_DEBUG_NAMED("ikfast","Sol %d: %e   %e   %e   %e   %e   %e", s, sol[0], sol[1], sol[2], sol[3], sol[4], sol[5]);
+      getSolution(solutions, s, sol);
+      ROS_DEBUG_NAMED("ikfast", "Sol %d: %e   %e   %e   %e   %e   %e", s, sol[0], sol[1], sol[2], sol[3], sol[4],
+                      sol[5]);
 
       bool obeys_limits = true;
-      for(unsigned int i = 0; i < sol.size(); i++)
+      for (unsigned int i = 0; i < sol.size(); i++)
       {
         // Add tolerance to limit check
-        if(joint_has_limits_vector_[i] && ( (sol[i] < (joint_min_vector_[i]-LIMIT_TOLERANCE)) ||
-                                            (sol[i] > (joint_max_vector_[i]+LIMIT_TOLERANCE)) ) )
+        if (joint_has_limits_vector_[i] && ((sol[i] < (joint_min_vector_[i] - LIMIT_TOLERANCE)) ||
+                                            (sol[i] > (joint_max_vector_[i] + LIMIT_TOLERANCE))))
         {
           // One element of solution is not within limits
           obeys_limits = false;
-          ROS_DEBUG_STREAM_NAMED("ikfast","Not in limits! " << i << " value " << sol[i] << " has limit: " << joint_has_limits_vector_[i] << "  being  " << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
+          ROS_DEBUG_STREAM_NAMED("ikfast", "Not in limits! " << i << " value " << sol[i] << " has limit: "
+                                                             << joint_has_limits_vector_[i] << "  being  "
+                                                             << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
           break;
         }
       }
-      if(obeys_limits)
+      if (obeys_limits)
       {
         // All elements of solution obey limits
-        getSolution(solutions,s,solution);
+        getSolution(solutions, s, solution);
         error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
         return true;
       }
@@ -1045,139 +1051,139 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose &ik_pose,
   }
   else
   {
-    ROS_DEBUG_STREAM_NAMED("ikfast","No IK solution");
+    ROS_DEBUG_STREAM_NAMED("ikfast", "No IK solution");
   }
 
   error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
   return false;
 }
 
-bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose> &ik_poses,
-                                           const std::vector<double> &ik_seed_state,
-                                           std::vector< std::vector<double> >& solutions,
+bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
+                                           const std::vector<double>& ik_seed_state,
+                                           std::vector<std::vector<double> >& solutions,
                                            kinematics::KinematicsResult& result,
-                                           const kinematics::KinematicsQueryOptions &options) const
+                                           const kinematics::KinematicsQueryOptions& options) const
 {
-  ROS_DEBUG_STREAM_NAMED("ikfast","getPositionIK with multiple solutions");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "getPositionIK with multiple solutions");
 
-  if(!active_)
+  if (!active_)
   {
     ROS_ERROR("kinematics not active");
     result.kinematic_error = kinematics::KinematicErrors::SOLVER_NOT_ACTIVE;
     return false;
   }
 
-  if(ik_poses.empty())
+  if (ik_poses.empty())
   {
     ROS_ERROR("ik_poses is empty");
     result.kinematic_error = kinematics::KinematicErrors::EMPTY_TIP_POSES;
     return false;
   }
 
-  if(ik_poses.size() > 1)
+  if (ik_poses.size() > 1)
   {
     ROS_ERROR("ik_poses contains multiple entries, only one is allowed");
     result.kinematic_error = kinematics::KinematicErrors::MULTIPLE_TIPS_NOT_SUPPORTED;
     return false;
   }
 
-  if(ik_seed_state.size() < num_joints_)
+  if (ik_seed_state.size() < num_joints_)
   {
-    ROS_ERROR_STREAM("ik_seed_state only has "<<ik_seed_state.size()<<" entries, this ikfast solver requires "<<num_joints_);
+    ROS_ERROR_STREAM("ik_seed_state only has " << ik_seed_state.size() << " entries, this ikfast solver requires "
+                                               << num_joints_);
     return false;
   }
 
   KDL::Frame frame;
-  tf::poseMsgToKDL(ik_poses[0],frame);
+  tf::poseMsgToKDL(ik_poses[0], frame);
 
   // solving ik
-  std::vector< IkSolutionList<IkReal> > solution_set;
+  std::vector<IkSolutionList<IkReal> > solution_set;
   IkSolutionList<IkReal> ik_solutions;
   std::vector<double> vfree;
   int numsol = 0;
   std::vector<double> sampled_joint_vals;
-  if(!redundant_joint_indices_.empty())
+  if (!redundant_joint_indices_.empty())
   {
     // initializing from seed
     sampled_joint_vals.push_back(ik_seed_state[redundant_joint_indices_[0]]);
 
     // checking joint limits when using no discretization
-    if(options.discretization_method == kinematics::DiscretizationMethods::NO_DISCRETIZATION &&
+    if (options.discretization_method == kinematics::DiscretizationMethods::NO_DISCRETIZATION &&
         joint_has_limits_vector_[redundant_joint_indices_.front()])
     {
       double joint_min = joint_min_vector_[redundant_joint_indices_.front()];
       double joint_max = joint_max_vector_[redundant_joint_indices_.front()];
 
       double jv = sampled_joint_vals[0];
-      if(!( (jv > (joint_min - LIMIT_TOLERANCE)) && (jv < (joint_max + LIMIT_TOLERANCE)) ))
+      if (!((jv > (joint_min - LIMIT_TOLERANCE)) && (jv < (joint_max + LIMIT_TOLERANCE))))
       {
         result.kinematic_error = kinematics::KinematicErrors::IK_SEED_OUTSIDE_LIMITS;
         ROS_ERROR_STREAM("ik seed is out of bounds");
         return false;
       }
-
     }
 
-
     // computing all solutions sets for each sampled value of the redundant joint
-    if(!sampleRedundantJoint(options.discretization_method,sampled_joint_vals))
+    if (!sampleRedundantJoint(options.discretization_method, sampled_joint_vals))
     {
       result.kinematic_error = kinematics::KinematicErrors::UNSUPORTED_DISCRETIZATION_REQUESTED;
       return false;
     }
 
-    for(unsigned int i = 0; i < sampled_joint_vals.size(); i++)
+    for (unsigned int i = 0; i < sampled_joint_vals.size(); i++)
     {
       vfree.clear();
       vfree.push_back(sampled_joint_vals[i]);
-      numsol += solve(frame,vfree,ik_solutions);
+      numsol += solve(frame, vfree, ik_solutions);
       solution_set.push_back(ik_solutions);
     }
   }
   else
   {
     // computing for single solution set
-    numsol = solve(frame,vfree,ik_solutions);
+    numsol = solve(frame, vfree, ik_solutions);
     solution_set.push_back(ik_solutions);
   }
 
-  ROS_DEBUG_STREAM_NAMED("ikfast","Found " << numsol << " solutions from IKFast");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "Found " << numsol << " solutions from IKFast");
   bool solutions_found = false;
   std::stringstream ss;
-  if( numsol > 0 )
+  if (numsol > 0)
   {
-    for(unsigned int r = 0; r < solution_set.size() ; r++)
+    for (unsigned int r = 0; r < solution_set.size(); r++)
     {
-
       ik_solutions = solution_set[r];
       numsol = ik_solutions.GetNumSolutions();
-      for(int s = 0; s < numsol; ++s)
+      for (int s = 0; s < numsol; ++s)
       {
         std::vector<double> sol;
-        getSolution(ik_solutions,s,sol);
+        getSolution(ik_solutions, s, sol);
         ss.str("");
-        ss<<"[";
-        for(unsigned int i = 0 ; i < sol.size() ; i++)
+        ss << "[";
+        for (unsigned int i = 0; i < sol.size(); i++)
         {
-          ss<<sol[i]<<" ";
+          ss << sol[i] << " ";
         }
-        ss<<"]";
-        ROS_DEBUG_NAMED("ikfast","Sol %d: %s", s, ss.str().c_str());
+        ss << "]";
+        ROS_DEBUG_NAMED("ikfast", "Sol %d: %s", s, ss.str().c_str());
 
         bool obeys_limits = true;
-        for(unsigned int i = 0; i < sol.size(); i++)
+        for (unsigned int i = 0; i < sol.size(); i++)
         {
           // Add tolerance to limit check
-          if(joint_has_limits_vector_[i] && ( (sol[i] < (joint_min_vector_[i]-LIMIT_TOLERANCE)) ||
-                                              (sol[i] > (joint_max_vector_[i]+LIMIT_TOLERANCE)) ) )
+          if (joint_has_limits_vector_[i] && ((sol[i] < (joint_min_vector_[i] - LIMIT_TOLERANCE)) ||
+                                              (sol[i] > (joint_max_vector_[i] + LIMIT_TOLERANCE))))
           {
             // One element of solution is not within limits
             obeys_limits = false;
-            ROS_DEBUG_STREAM_NAMED("ikfast","Not in limits! " << i << " value " << sol[i] << " has limit: " << joint_has_limits_vector_[i] << "  being  " << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
+            ROS_DEBUG_STREAM_NAMED(
+                "ikfast", "Not in limits! " << i << " value " << sol[i] << " has limit: " << joint_has_limits_vector_[i]
+                                            << "  being  " << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
             break;
           }
         }
-        if(obeys_limits)
+        if (obeys_limits)
         {
           // All elements of solution obey limits
           solutions_found = true;
@@ -1186,7 +1192,7 @@ bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose
       }
     }
 
-    if(solutions_found)
+    if (solutions_found)
     {
       result.kinematic_error = kinematics::KinematicErrors::OK;
       return true;
@@ -1194,65 +1200,64 @@ bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose
   }
   else
   {
-    ROS_DEBUG_STREAM_NAMED("ikfast","No IK solution");
+    ROS_DEBUG_STREAM_NAMED("ikfast", "No IK solution");
   }
 
   result.kinematic_error = kinematics::KinematicErrors::NO_SOLUTION;
   return false;
 }
 
-bool IKFastKinematicsPlugin::sampleRedundantJoint(kinematics::DiscretizationMethod method, std::vector<double>& sampled_joint_vals) const
+bool IKFastKinematicsPlugin::sampleRedundantJoint(kinematics::DiscretizationMethod method,
+                                                  std::vector<double>& sampled_joint_vals) const
 {
   double joint_min = -M_PI;
   double joint_max = M_PI;
-  int index =  redundant_joint_indices_.front();
+  int index = redundant_joint_indices_.front();
   double joint_dscrt = redundant_joint_discretization_.at(index);
 
-  if(joint_has_limits_vector_[redundant_joint_indices_.front()])
+  if (joint_has_limits_vector_[redundant_joint_indices_.front()])
   {
     joint_min = joint_min_vector_[index];
     joint_max = joint_max_vector_[index];
   }
 
-
-  switch(method)
+  switch (method)
   {
     case kinematics::DiscretizationMethods::ALL_DISCRETIZED:
     {
-      int steps = std::ceil((joint_max - joint_min)/joint_dscrt);
-      for(unsigned int i = 0; i < steps;i++)
+      int steps = std::ceil((joint_max - joint_min) / joint_dscrt);
+      for (unsigned int i = 0; i < steps; i++)
       {
-        sampled_joint_vals.push_back(joint_min + joint_dscrt*i);
+        sampled_joint_vals.push_back(joint_min + joint_dscrt * i);
       }
       sampled_joint_vals.push_back(joint_max);
     }
-      break;
+    break;
     case kinematics::DiscretizationMethods::ALL_RANDOM_SAMPLED:
     {
-      int steps = std::ceil((joint_max - joint_min)/joint_dscrt);
+      int steps = std::ceil((joint_max - joint_min) / joint_dscrt);
       steps = steps > 0 ? steps : 1;
       double diff = joint_max - joint_min;
-      for(int i = 0; i < steps; i++)
+      for (int i = 0; i < steps; i++)
       {
-        sampled_joint_vals.push_back( ((diff*std::rand())/(static_cast<double>(RAND_MAX))) + joint_min );
+        sampled_joint_vals.push_back(((diff * std::rand()) / (static_cast<double>(RAND_MAX))) + joint_min);
       }
     }
 
-      break;
+    break;
     case kinematics::DiscretizationMethods::NO_DISCRETIZATION:
 
       break;
     default:
-      ROS_ERROR_STREAM("Discretization method "<<method<<" is not supported");
+      ROS_ERROR_STREAM("Discretization method " << method << " is not supported");
       return false;
   }
 
   return true;
 }
 
+}  // end namespace
 
-} // end namespace
-
-//register IKFastKinematicsPlugin as a KinematicsBase implementation
+// register IKFastKinematicsPlugin as a KinematicsBase implementation
 #include <pluginlib/class_list_macros.h>
 PLUGINLIB_EXPORT_CLASS(ikfast_kinematics_plugin::IKFastKinematicsPlugin, kinematics::KinematicsBase);

--- a/kuka_kr210_manipulator_ik_plugin/src/test_kuka_kr210_manipulator_ikfast_solver.cpp
+++ b/kuka_kr210_manipulator_ik_plugin/src/test_kuka_kr210_manipulator_ikfast_solver.cpp
@@ -5,7 +5,7 @@
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///     http://www.apache.org/licenses/LICENSE-2.0
-/// 
+///
 /// Unless required by applicable law or agreed to in writing, software
 /// distributed under the License is distributed on an "AS IS" BASIS,
 /// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,26 +18,26 @@
 /// To compile without any main function as a shared object (might need -llapack):
 ///     gcc -fPIC -lstdc++ -DIKFAST_NO_MAIN -DIKFAST_CLIBRARY -shared -Wl,-soname,libik.so -o libik.so ik.cpp
 #define IKFAST_HAS_LIBRARY
-#include "ikfast.h" // found inside share/openrave-X.Y/python/ikfast.h
+#include "ikfast.h"  // found inside share/openrave-X.Y/python/ikfast.h
 using namespace ikfast;
 
 // check if the included ikfast version matches what this file was compiled with
 #define IKFAST_COMPILE_ASSERT(x) extern int __dummy[(int)x]
-IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
+IKFAST_COMPILE_ASSERT(IKFAST_VERSION == 61);
 
-#include <cmath>
-#include <vector>
-#include <limits>
 #include <algorithm>
+#include <cmath>
 #include <complex>
+#include <limits>
+#include <vector>
 
 #define IKFAST_STRINGIZE2(s) #s
 #define IKFAST_STRINGIZE(s) IKFAST_STRINGIZE2(s)
 
 #ifndef IKFAST_ASSERT
-#include <stdexcept>
-#include <sstream>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 
 #ifdef _MSC_VER
 #ifndef __PRETTY_FUNCTION__
@@ -49,7 +49,16 @@ IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
 #define __PRETTY_FUNCTION__ __func__
 #endif
 
-#define IKFAST_ASSERT(b) { if( !(b) ) { std::stringstream ss; ss << "ikfast exception: " << __FILE__ << ":" << __LINE__ << ": " <<__PRETTY_FUNCTION__ << ": Assertion '" << #b << "' failed"; throw std::runtime_error(ss.str()); } }
+#define IKFAST_ASSERT(b)                                                                                               \
+  {                                                                                                                    \
+    if (!(b))                                                                                                          \
+    {                                                                                                                  \
+      std::stringstream ss;                                                                                            \
+      ss << "ikfast exception: " << __FILE__ << ":" << __LINE__ << ": " << __PRETTY_FUNCTION__ << ": Assertion '"      \
+         << #b << "' failed";                                                                                          \
+      throw std::runtime_error(ss.str());                                                                              \
+    }                                                                                                                  \
+  }
 
 #endif
 
@@ -59,40 +68,61 @@ IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
 #define IKFAST_ALIGNED16(x) x __attribute((aligned(16)))
 #endif
 
-#define IK2PI  ((IkReal)6.28318530717959)
-#define IKPI  ((IkReal)3.14159265358979)
-#define IKPI_2  ((IkReal)1.57079632679490)
+#define IK2PI ((IkReal)6.28318530717959)
+#define IKPI ((IkReal)3.14159265358979)
+#define IKPI_2 ((IkReal)1.57079632679490)
 
 #ifdef _MSC_VER
 #ifndef isnan
 #define isnan _isnan
 #endif
-#endif // _MSC_VER
+#endif  // _MSC_VER
 
 // lapack routines
 extern "C" {
-  void dgetrf_ (const int* m, const int* n, double* a, const int* lda, int* ipiv, int* info);
-  void zgetrf_ (const int* m, const int* n, std::complex<double>* a, const int* lda, int* ipiv, int* info);
-  void dgetri_(const int* n, const double* a, const int* lda, int* ipiv, double* work, const int* lwork, int* info);
-  void dgesv_ (const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b, const int* ldb, int* info);
-  void dgetrs_(const char *trans, const int *n, const int *nrhs, double *a, const int *lda, int *ipiv, double *b, const int *ldb, int *info);
-  void dgeev_(const char *jobvl, const char *jobvr, const int *n, double *a, const int *lda, double *wr, double *wi,double *vl, const int *ldvl, double *vr, const int *ldvr, double *work, const int *lwork, int *info);
+void dgetrf_(const int* m, const int* n, double* a, const int* lda, int* ipiv, int* info);
+void zgetrf_(const int* m, const int* n, std::complex<double>* a, const int* lda, int* ipiv, int* info);
+void dgetri_(const int* n, const double* a, const int* lda, int* ipiv, double* work, const int* lwork, int* info);
+void dgesv_(const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b, const int* ldb, int* info);
+void dgetrs_(const char* trans, const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b,
+             const int* ldb, int* info);
+void dgeev_(const char* jobvl, const char* jobvr, const int* n, double* a, const int* lda, double* wr, double* wi,
+            double* vl, const int* ldvl, double* vr, const int* ldvr, double* work, const int* lwork, int* info);
 }
 
-using namespace std; // necessary to get std math routines
+using namespace std;  // necessary to get std math routines
 
 #ifdef IKFAST_NAMESPACE
-namespace IKFAST_NAMESPACE {
+namespace IKFAST_NAMESPACE
+{
 #endif
 
-inline float IKabs(float f) { return fabsf(f); }
-inline double IKabs(double f) { return fabs(f); }
+inline float IKabs(float f)
+{
+  return fabsf(f);
+}
+inline double IKabs(double f)
+{
+  return fabs(f);
+}
 
-inline float IKsqr(float f) { return f*f; }
-inline double IKsqr(double f) { return f*f; }
+inline float IKsqr(float f)
+{
+  return f * f;
+}
+inline double IKsqr(double f)
+{
+  return f * f;
+}
 
-inline float IKlog(float f) { return logf(f); }
-inline double IKlog(double f) { return log(f); }
+inline float IKlog(float f)
+{
+  return logf(f);
+}
+inline double IKlog(double f)
+{
+  return log(f);
+}
 
 // allows asin and acos to exceed 1
 #ifndef IKFAST_SINCOS_THRESH
@@ -111,2706 +141,3668 @@ inline double IKlog(double f) { return log(f); }
 
 inline float IKasin(float f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return float(-IKPI_2);
-else if( f >= 1 ) return float(IKPI_2);
-return asinf(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return float(-IKPI_2);
+  else if (f >= 1)
+    return float(IKPI_2);
+  return asinf(f);
 }
 inline double IKasin(double f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return -IKPI_2;
-else if( f >= 1 ) return IKPI_2;
-return asin(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return -IKPI_2;
+  else if (f >= 1)
+    return IKPI_2;
+  return asin(f);
 }
 
 // return positive value in [0,y)
 inline float IKfmod(float x, float y)
 {
-    while(x < 0) {
-        x += y;
-    }
-    return fmodf(x,y);
+  while (x < 0)
+  {
+    x += y;
+  }
+  return fmodf(x, y);
 }
 
 // return positive value in [0,y)
 inline double IKfmod(double x, double y)
 {
-    while(x < 0) {
-        x += y;
-    }
-    return fmod(x,y);
+  while (x < 0)
+  {
+    x += y;
+  }
+  return fmod(x, y);
 }
 
 inline float IKacos(float f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return float(IKPI);
-else if( f >= 1 ) return float(0);
-return acosf(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return float(IKPI);
+  else if (f >= 1)
+    return float(0);
+  return acosf(f);
 }
 inline double IKacos(double f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return IKPI;
-else if( f >= 1 ) return 0;
-return acos(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return IKPI;
+  else if (f >= 1)
+    return 0;
+  return acos(f);
 }
-inline float IKsin(float f) { return sinf(f); }
-inline double IKsin(double f) { return sin(f); }
-inline float IKcos(float f) { return cosf(f); }
-inline double IKcos(double f) { return cos(f); }
-inline float IKtan(float f) { return tanf(f); }
-inline double IKtan(double f) { return tan(f); }
-inline float IKsqrt(float f) { if( f <= 0.0f ) return 0.0f; return sqrtf(f); }
-inline double IKsqrt(double f) { if( f <= 0.0 ) return 0.0; return sqrt(f); }
-inline float IKatan2(float fy, float fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
-        return float(IKPI_2);
-    }
-    else if( isnan(fx) ) {
-        return 0;
-    }
-    return atan2f(fy,fx);
+inline float IKsin(float f)
+{
+  return sinf(f);
 }
-inline double IKatan2(double fy, double fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
-        return IKPI_2;
-    }
-    else if( isnan(fx) ) {
-        return 0;
-    }
-    return atan2(fy,fx);
+inline double IKsin(double f)
+{
+  return sin(f);
+}
+inline float IKcos(float f)
+{
+  return cosf(f);
+}
+inline double IKcos(double f)
+{
+  return cos(f);
+}
+inline float IKtan(float f)
+{
+  return tanf(f);
+}
+inline double IKtan(double f)
+{
+  return tan(f);
+}
+inline float IKsqrt(float f)
+{
+  if (f <= 0.0f)
+    return 0.0f;
+  return sqrtf(f);
+}
+inline double IKsqrt(double f)
+{
+  if (f <= 0.0)
+    return 0.0;
+  return sqrt(f);
+}
+inline float IKatan2(float fy, float fx)
+{
+  if (isnan(fy))
+  {
+    IKFAST_ASSERT(!isnan(fx));  // if both are nan, probably wrong value will be returned
+    return float(IKPI_2);
+  }
+  else if (isnan(fx))
+  {
+    return 0;
+  }
+  return atan2f(fy, fx);
+}
+inline double IKatan2(double fy, double fx)
+{
+  if (isnan(fy))
+  {
+    IKFAST_ASSERT(!isnan(fx));  // if both are nan, probably wrong value will be returned
+    return IKPI_2;
+  }
+  else if (isnan(fx))
+  {
+    return 0;
+  }
+  return atan2(fy, fx);
 }
 
-inline float IKsign(float f) {
-    if( f > 0 ) {
-        return float(1);
-    }
-    else if( f < 0 ) {
-        return float(-1);
-    }
-    return 0;
+inline float IKsign(float f)
+{
+  if (f > 0)
+  {
+    return float(1);
+  }
+  else if (f < 0)
+  {
+    return float(-1);
+  }
+  return 0;
 }
 
-inline double IKsign(double f) {
-    if( f > 0 ) {
-        return 1.0;
-    }
-    else if( f < 0 ) {
-        return -1.0;
-    }
-    return 0;
+inline double IKsign(double f)
+{
+  if (f > 0)
+  {
+    return 1.0;
+  }
+  else if (f < 0)
+  {
+    return -1.0;
+  }
+  return 0;
 }
 
 /// solves the forward kinematics equations.
 /// \param pfree is an array specifying the free joints of the chain.
-IKFAST_API void ComputeFk(const IkReal* j, IkReal* eetrans, IkReal* eerot) {
-IkReal x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59;
-x0=IKcos(j[0]);
-x1=IKcos(j[1]);
-x2=IKsin(j[2]);
-x3=IKcos(j[2]);
-x4=IKsin(j[1]);
-x5=IKcos(j[4]);
-x6=IKsin(j[4]);
-x7=IKsin(j[3]);
-x8=IKcos(j[3]);
-x9=IKsin(j[0]);
-x10=IKcos(j[5]);
-x11=IKsin(j[5]);
-x12=((IkReal(1.49995000000000))*(x9));
-x13=((IkReal(1.00000000000000))*(x5));
-x14=((IkReal(0.000240000000000000))*(x8));
-x15=((IkReal(0.230000000000000))*(x0));
-x16=((IkReal(0.000100000000000000))*(x1));
-x17=((IkReal(0.230000000000000))*(x8));
-x18=((IkReal(1.00000000000000))*(x9));
-x19=((IkReal(0.000240000000000000))*(x5));
-x20=((IkReal(0.0550600000000000))*(x3));
-x21=((IkReal(1.00000000000000))*(x3));
-x22=((IkReal(1.49995000000000))*(x0));
-x23=((IkReal(1.00000000000000))*(x0));
-x24=((IkReal(0.230000000000000))*(x9));
-x25=((IkReal(1.00000000000000))*(x6));
-x26=((IkReal(0.000240000000000000))*(x6));
-x27=((x1)*(x3));
-x28=((x11)*(x7));
-x29=((x2)*(x4));
-x30=((x1)*(x2));
-x31=((x4)*(x9));
-x32=((x0)*(x4));
-x33=((x7)*(x9));
-x34=((x3)*(x4));
-x35=((x6)*(x8));
-x36=((x18)*(x8));
-x37=((x1)*(x21));
-x38=((x23)*(x29));
-x39=((x18)*(x29));
-x40=((((IkReal(-1.00000000000000))*(x37)))+(x29));
-x41=((((x21)*(x4)))+(((IkReal(1.00000000000000))*(x30))));
-x42=((x40)*(x8));
-x43=((x41)*(x6));
-x44=((((IkReal(-1.00000000000000))*(x0)*(x37)))+(x38));
-x45=((((IkReal(-1.00000000000000))*(x18)*(x27)))+(x39));
-x46=((((x23)*(x30)))+(((x21)*(x32))));
-x47=((IkReal(-1.00000000000000))*(x46));
-x48=((x18)*(((x30)+(x34))));
-x49=((IkReal(-1.00000000000000))*(x48));
-x50=((x47)*(x8));
-x51=((x49)*(x8));
-x52=((x48)*(x7));
-x53=((x46)*(x7));
-x54=((((IkReal(-1.00000000000000))*(x18)*(x7)))+(x50));
-x55=((((x0)*(x7)))+(x51));
-x56=((x5)*(x55));
-x57=((((IkReal(-1.00000000000000))*(x25)*(x41)))+(((IkReal(-1.00000000000000))*(x13)*(x42))));
-x58=((((IkReal(-1.00000000000000))*(x25)*(x44)))+(((IkReal(-1.00000000000000))*(x13)*(x54))));
-x59=((((IkReal(-1.00000000000000))*(x25)*(x45)))+(((IkReal(-1.00000000000000))*(x13)*(x55))));
-eerot[0]=((((x5)*(((((IkReal(-1.00000000000000))*(x38)))+(((x0)*(x27)))))))+(((x54)*(x6))));
-eerot[1]=((((x11)*(x58)))+(((x10)*(((((IkReal(-1.00000000000000))*(x36)))+(x53))))));
-eerot[2]=((((x11)*(((x36)+(((IkReal(-1.00000000000000))*(x53)))))))+(((x10)*(x58))));
-IkReal x60=((IkReal(1.00000000000000))*(x29));
-eetrans[0]=((IkReal(-0.00262000000000000))+(((IkReal(0.000980000000000000))*(x9)))+(((x22)*(x27)))+(((IkReal(-1.00000000000000))*(x20)*(x32)))+(((x5)*(((((IkReal(-1.00000000000000))*(x15)*(x60)))+(((x15)*(x27)))))))+(((IkReal(-1.00000000000000))*(x0)*(x16)))+(((IkReal(-0.0550600000000000))*(x0)*(x30)))+(((x11)*(((((IkReal(-1.00000000000000))*(x14)*(x9)))+(((IkReal(0.000240000000000000))*(x53)))))))+(((IkReal(0.352770000000000))*(x0)))+(((IkReal(1.24990000000000))*(x32)))+(((x6)*(((((x17)*(x47)))+(((IkReal(-1.00000000000000))*(x24)*(x7)))))))+(((IkReal(-1.00000000000000))*(x22)*(x60)))+(((x10)*(((((x26)*(x44)))+(((x19)*(((((IkReal(-1.00000000000000))*(x33)))+(x50))))))))));
-eerot[3]=((((x5)*(((((IkReal(-1.00000000000000))*(x39)))+(((x27)*(x9)))))))+(((x55)*(x6))));
-eerot[4]=((((x11)*(x59)))+(((x10)*(((((x0)*(x8)))+(x52))))));
-eerot[5]=((((x10)*(x59)))+(((x11)*(((((IkReal(-1.00000000000000))*(x23)*(x8)))+(((IkReal(-1.00000000000000))*(x52))))))));
-IkReal x61=((IkReal(1.00000000000000))*(x29));
-eetrans[1]=((IkReal(0.000980000000000000))+(((x6)*(((((x17)*(x49)))+(((x15)*(x7)))))))+(((x5)*(((((IkReal(-1.00000000000000))*(x24)*(x61)))+(((x24)*(x27)))))))+(((x10)*(((((x26)*(x45)))+(((x19)*(x55)))))))+(((IkReal(-0.0550600000000000))*(x30)*(x9)))+(((IkReal(-1.00000000000000))*(x20)*(x31)))+(((IkReal(-0.000980000000000000))*(x0)))+(((IkReal(-1.00000000000000))*(x12)*(x61)))+(((IkReal(-1.00000000000000))*(x16)*(x9)))+(((x11)*(((((x0)*(x14)))+(((IkReal(0.000240000000000000))*(x52)))))))+(((IkReal(0.352770000000000))*(x9)))+(((IkReal(1.24990000000000))*(x31)))+(((x12)*(x27))));
-eerot[6]=((((x35)*(x40)))+(((IkReal(-1.00000000000000))*(x41)*(x5))));
-eerot[7]=((((x10)*(x7)*(((((IkReal(-1.00000000000000))*(x29)))+(x37)))))+(((x11)*(x57))));
-eerot[8]=((((x28)*(x40)))+(((x10)*(x57))));
-eetrans[2]=((IkReal(0.750190000000000))+(((IkReal(0.000100000000000000))*(x4)))+(((x5)*(((((IkReal(-0.230000000000000))*(x30)))+(((IkReal(-0.230000000000000))*(x34)))))))+(((IkReal(-1.49995000000000))*(x30)))+(((IkReal(-1.49995000000000))*(x34)))+(((IkReal(1.24990000000000))*(x1)))+(((IkReal(-1.00000000000000))*(x1)*(x20)))+(((x28)*(((((IkReal(0.000240000000000000))*(x27)))+(((IkReal(-0.000240000000000000))*(x29)))))))+(((x35)*(((((IkReal(0.230000000000000))*(x29)))+(((IkReal(-0.230000000000000))*(x27)))))))+(((x10)*(((((x26)*(x41)))+(((x14)*(x40)*(x5)))))))+(((IkReal(0.0550600000000000))*(x29))));
+IKFAST_API void ComputeFk(const IkReal* j, IkReal* eetrans, IkReal* eerot)
+{
+  IkReal x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23,
+      x24, x25, x26, x27, x28, x29, x30, x31, x32, x33, x34, x35, x36, x37, x38, x39, x40, x41, x42, x43, x44, x45, x46,
+      x47, x48, x49, x50, x51, x52, x53, x54, x55, x56, x57, x58, x59;
+  x0 = IKcos(j[0]);
+  x1 = IKcos(j[1]);
+  x2 = IKsin(j[2]);
+  x3 = IKcos(j[2]);
+  x4 = IKsin(j[1]);
+  x5 = IKcos(j[4]);
+  x6 = IKsin(j[4]);
+  x7 = IKsin(j[3]);
+  x8 = IKcos(j[3]);
+  x9 = IKsin(j[0]);
+  x10 = IKcos(j[5]);
+  x11 = IKsin(j[5]);
+  x12 = ((IkReal(1.49995000000000)) * (x9));
+  x13 = ((IkReal(1.00000000000000)) * (x5));
+  x14 = ((IkReal(0.000240000000000000)) * (x8));
+  x15 = ((IkReal(0.230000000000000)) * (x0));
+  x16 = ((IkReal(0.000100000000000000)) * (x1));
+  x17 = ((IkReal(0.230000000000000)) * (x8));
+  x18 = ((IkReal(1.00000000000000)) * (x9));
+  x19 = ((IkReal(0.000240000000000000)) * (x5));
+  x20 = ((IkReal(0.0550600000000000)) * (x3));
+  x21 = ((IkReal(1.00000000000000)) * (x3));
+  x22 = ((IkReal(1.49995000000000)) * (x0));
+  x23 = ((IkReal(1.00000000000000)) * (x0));
+  x24 = ((IkReal(0.230000000000000)) * (x9));
+  x25 = ((IkReal(1.00000000000000)) * (x6));
+  x26 = ((IkReal(0.000240000000000000)) * (x6));
+  x27 = ((x1) * (x3));
+  x28 = ((x11) * (x7));
+  x29 = ((x2) * (x4));
+  x30 = ((x1) * (x2));
+  x31 = ((x4) * (x9));
+  x32 = ((x0) * (x4));
+  x33 = ((x7) * (x9));
+  x34 = ((x3) * (x4));
+  x35 = ((x6) * (x8));
+  x36 = ((x18) * (x8));
+  x37 = ((x1) * (x21));
+  x38 = ((x23) * (x29));
+  x39 = ((x18) * (x29));
+  x40 = ((((IkReal(-1.00000000000000)) * (x37))) + (x29));
+  x41 = ((((x21) * (x4))) + (((IkReal(1.00000000000000)) * (x30))));
+  x42 = ((x40) * (x8));
+  x43 = ((x41) * (x6));
+  x44 = ((((IkReal(-1.00000000000000)) * (x0) * (x37))) + (x38));
+  x45 = ((((IkReal(-1.00000000000000)) * (x18) * (x27))) + (x39));
+  x46 = ((((x23) * (x30))) + (((x21) * (x32))));
+  x47 = ((IkReal(-1.00000000000000)) * (x46));
+  x48 = ((x18) * (((x30) + (x34))));
+  x49 = ((IkReal(-1.00000000000000)) * (x48));
+  x50 = ((x47) * (x8));
+  x51 = ((x49) * (x8));
+  x52 = ((x48) * (x7));
+  x53 = ((x46) * (x7));
+  x54 = ((((IkReal(-1.00000000000000)) * (x18) * (x7))) + (x50));
+  x55 = ((((x0) * (x7))) + (x51));
+  x56 = ((x5) * (x55));
+  x57 = ((((IkReal(-1.00000000000000)) * (x25) * (x41))) + (((IkReal(-1.00000000000000)) * (x13) * (x42))));
+  x58 = ((((IkReal(-1.00000000000000)) * (x25) * (x44))) + (((IkReal(-1.00000000000000)) * (x13) * (x54))));
+  x59 = ((((IkReal(-1.00000000000000)) * (x25) * (x45))) + (((IkReal(-1.00000000000000)) * (x13) * (x55))));
+  eerot[0] = ((((x5) * (((((IkReal(-1.00000000000000)) * (x38))) + (((x0) * (x27))))))) + (((x54) * (x6))));
+  eerot[1] = ((((x11) * (x58))) + (((x10) * (((((IkReal(-1.00000000000000)) * (x36))) + (x53))))));
+  eerot[2] = ((((x11) * (((x36) + (((IkReal(-1.00000000000000)) * (x53))))))) + (((x10) * (x58))));
+  IkReal x60 = ((IkReal(1.00000000000000)) * (x29));
+  eetrans[0] =
+      ((IkReal(-0.00262000000000000)) + (((IkReal(0.000980000000000000)) * (x9))) + (((x22) * (x27))) +
+       (((IkReal(-1.00000000000000)) * (x20) * (x32))) +
+       (((x5) * (((((IkReal(-1.00000000000000)) * (x15) * (x60))) + (((x15) * (x27))))))) +
+       (((IkReal(-1.00000000000000)) * (x0) * (x16))) + (((IkReal(-0.0550600000000000)) * (x0) * (x30))) +
+       (((x11) * (((((IkReal(-1.00000000000000)) * (x14) * (x9))) + (((IkReal(0.000240000000000000)) * (x53))))))) +
+       (((IkReal(0.352770000000000)) * (x0))) + (((IkReal(1.24990000000000)) * (x32))) +
+       (((x6) * (((((x17) * (x47))) + (((IkReal(-1.00000000000000)) * (x24) * (x7))))))) +
+       (((IkReal(-1.00000000000000)) * (x22) * (x60))) +
+       (((x10) * (((((x26) * (x44))) + (((x19) * (((((IkReal(-1.00000000000000)) * (x33))) + (x50))))))))));
+  eerot[3] = ((((x5) * (((((IkReal(-1.00000000000000)) * (x39))) + (((x27) * (x9))))))) + (((x55) * (x6))));
+  eerot[4] = ((((x11) * (x59))) + (((x10) * (((((x0) * (x8))) + (x52))))));
+  eerot[5] = ((((x10) * (x59))) +
+              (((x11) * (((((IkReal(-1.00000000000000)) * (x23) * (x8))) + (((IkReal(-1.00000000000000)) * (x52))))))));
+  IkReal x61 = ((IkReal(1.00000000000000)) * (x29));
+  eetrans[1] =
+      ((IkReal(0.000980000000000000)) + (((x6) * (((((x17) * (x49))) + (((x15) * (x7))))))) +
+       (((x5) * (((((IkReal(-1.00000000000000)) * (x24) * (x61))) + (((x24) * (x27))))))) +
+       (((x10) * (((((x26) * (x45))) + (((x19) * (x55))))))) + (((IkReal(-0.0550600000000000)) * (x30) * (x9))) +
+       (((IkReal(-1.00000000000000)) * (x20) * (x31))) + (((IkReal(-0.000980000000000000)) * (x0))) +
+       (((IkReal(-1.00000000000000)) * (x12) * (x61))) + (((IkReal(-1.00000000000000)) * (x16) * (x9))) +
+       (((x11) * (((((x0) * (x14))) + (((IkReal(0.000240000000000000)) * (x52))))))) +
+       (((IkReal(0.352770000000000)) * (x9))) + (((IkReal(1.24990000000000)) * (x31))) + (((x12) * (x27))));
+  eerot[6] = ((((x35) * (x40))) + (((IkReal(-1.00000000000000)) * (x41) * (x5))));
+  eerot[7] = ((((x10) * (x7) * (((((IkReal(-1.00000000000000)) * (x29))) + (x37))))) + (((x11) * (x57))));
+  eerot[8] = ((((x28) * (x40))) + (((x10) * (x57))));
+  eetrans[2] =
+      ((IkReal(0.750190000000000)) + (((IkReal(0.000100000000000000)) * (x4))) +
+       (((x5) * (((((IkReal(-0.230000000000000)) * (x30))) + (((IkReal(-0.230000000000000)) * (x34))))))) +
+       (((IkReal(-1.49995000000000)) * (x30))) + (((IkReal(-1.49995000000000)) * (x34))) +
+       (((IkReal(1.24990000000000)) * (x1))) + (((IkReal(-1.00000000000000)) * (x1) * (x20))) +
+       (((x28) * (((((IkReal(0.000240000000000000)) * (x27))) + (((IkReal(-0.000240000000000000)) * (x29))))))) +
+       (((x35) * (((((IkReal(0.230000000000000)) * (x29))) + (((IkReal(-0.230000000000000)) * (x27))))))) +
+       (((x10) * (((((x26) * (x41))) + (((x14) * (x40) * (x5))))))) + (((IkReal(0.0550600000000000)) * (x29))));
 }
 
-IKFAST_API int GetNumFreeParameters() { return 0; }
-IKFAST_API int* GetFreeParameters() { return NULL; }
-IKFAST_API int GetNumJoints() { return 6; }
+IKFAST_API int GetNumFreeParameters()
+{
+  return 0;
+}
+IKFAST_API int* GetFreeParameters()
+{
+  return NULL;
+}
+IKFAST_API int GetNumJoints()
+{
+  return 6;
+}
 
-IKFAST_API int GetIkRealSize() { return sizeof(IkReal); }
+IKFAST_API int GetIkRealSize()
+{
+  return sizeof(IkReal);
+}
 
-IKFAST_API int GetIkType() { return 0x67000001; }
+IKFAST_API int GetIkType()
+{
+  return 0x67000001;
+}
 
-class IKSolver {
+class IKSolver
+{
 public:
-IkReal j0,cj0,sj0,htj0,j1,cj1,sj1,htj1,j2,cj2,sj2,htj2,j3,cj3,sj3,htj3,j4,cj4,sj4,htj4,j5,cj5,sj5,htj5,new_r00,r00,rxp0_0,new_r01,r01,rxp0_1,new_r02,r02,rxp0_2,new_r10,r10,rxp1_0,new_r11,r11,rxp1_1,new_r12,r12,rxp1_2,new_r20,r20,rxp2_0,new_r21,r21,rxp2_1,new_r22,r22,rxp2_2,new_px,px,npx,new_py,py,npy,new_pz,pz,npz,pp;
-unsigned char _ij0[2], _nj0,_ij1[2], _nj1,_ij2[2], _nj2,_ij3[2], _nj3,_ij4[2], _nj4,_ij5[2], _nj5;
-
-bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions) {
-j0=numeric_limits<IkReal>::quiet_NaN(); _ij0[0] = -1; _ij0[1] = -1; _nj0 = -1; j1=numeric_limits<IkReal>::quiet_NaN(); _ij1[0] = -1; _ij1[1] = -1; _nj1 = -1; j2=numeric_limits<IkReal>::quiet_NaN(); _ij2[0] = -1; _ij2[1] = -1; _nj2 = -1; j3=numeric_limits<IkReal>::quiet_NaN(); _ij3[0] = -1; _ij3[1] = -1; _nj3 = -1; j4=numeric_limits<IkReal>::quiet_NaN(); _ij4[0] = -1; _ij4[1] = -1; _nj4 = -1; j5=numeric_limits<IkReal>::quiet_NaN(); _ij5[0] = -1; _ij5[1] = -1; _nj5 = -1; 
-for(int dummyiter = 0; dummyiter < 1; ++dummyiter) {
-    solutions.Clear();
-r00 = eerot[0*3+0];
-r01 = eerot[0*3+1];
-r02 = eerot[0*3+2];
-r10 = eerot[1*3+0];
-r11 = eerot[1*3+1];
-r12 = eerot[1*3+2];
-r20 = eerot[2*3+0];
-r21 = eerot[2*3+1];
-r22 = eerot[2*3+2];
-px = eetrans[0]; py = eetrans[1]; pz = eetrans[2];
-
-new_r00=((IkReal(-1.00000000000000))*(r02));
-new_r01=r01;
-new_r02=r00;
-new_px=((IkReal(0.00262000000000000))+(((IkReal(-0.230000000000000))*(r00)))+(px)+(((IkReal(0.000240000000000000))*(r02))));
-new_r10=((IkReal(-1.00000000000000))*(r12));
-new_r11=r11;
-new_r12=r10;
-new_py=((IkReal(-0.000980000000000000))+(((IkReal(-0.230000000000000))*(r10)))+(py)+(((IkReal(0.000240000000000000))*(r12))));
-new_r20=((IkReal(-1.00000000000000))*(r22));
-new_r21=r21;
-new_r22=r20;
-new_pz=((IkReal(-0.750190000000000))+(pz)+(((IkReal(0.000240000000000000))*(r22)))+(((IkReal(-0.230000000000000))*(r20))));
-r00 = new_r00; r01 = new_r01; r02 = new_r02; r10 = new_r10; r11 = new_r11; r12 = new_r12; r20 = new_r20; r21 = new_r21; r22 = new_r22; px = new_px; py = new_py; pz = new_pz;
-pp=(((px)*(px))+((py)*(py))+((pz)*(pz)));
-npx=((((px)*(r00)))+(((py)*(r10)))+(((pz)*(r20))));
-npy=((((px)*(r01)))+(((py)*(r11)))+(((pz)*(r21))));
-npz=((((px)*(r02)))+(((py)*(r12)))+(((pz)*(r22))));
-rxp0_0=((((IkReal(-1.00000000000000))*(py)*(r20)))+(((pz)*(r10))));
-rxp0_1=((((px)*(r20)))+(((IkReal(-1.00000000000000))*(pz)*(r00))));
-rxp0_2=((((IkReal(-1.00000000000000))*(px)*(r10)))+(((py)*(r00))));
-rxp1_0=((((IkReal(-1.00000000000000))*(py)*(r21)))+(((pz)*(r11))));
-rxp1_1=((((px)*(r21)))+(((IkReal(-1.00000000000000))*(pz)*(r01))));
-rxp1_2=((((IkReal(-1.00000000000000))*(px)*(r11)))+(((py)*(r01))));
-rxp2_0=((((IkReal(-1.00000000000000))*(py)*(r22)))+(((pz)*(r12))));
-rxp2_1=((((px)*(r22)))+(((IkReal(-1.00000000000000))*(pz)*(r02))));
-rxp2_2=((((IkReal(-1.00000000000000))*(px)*(r12)))+(((py)*(r02))));
-{
-IkReal dummyeval[1];
-dummyeval[0]=(((px)*(px))+((py)*(py)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=(((px)*(px))+((py)*(py)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j0array[2], cj0array[2], sj0array[2];
-bool j0valid[2]={false};
-_nj0 = 2;
-if( IKabs(((IkReal(-1.00000000000000))*(py))) < IKFAST_ATAN2_MAGTHRESH && IKabs(px) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x62=((IkReal(1.00000000000000))*(IKatan2(((IkReal(-1.00000000000000))*(py)), px)));
-if( ((((px)*(px))+((py)*(py)))) < (IkReal)-0.00001 )
-    continue;
-if( (((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30)))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30)))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x63=IKasin(((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30))));
-j0array[0]=((x63)+(((IkReal(-1.00000000000000))*(x62))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-j0array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x62)))+(((IkReal(-1.00000000000000))*(x63))));
-sj0array[1]=IKsin(j0array[1]);
-cj0array[1]=IKcos(j0array[1]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-if( j0array[1] > IKPI )
-{
-    j0array[1]-=IK2PI;
-}
-else if( j0array[1] < -IKPI )
-{    j0array[1]+=IK2PI;
-}
-j0valid[1] = true;
-for(int ij0 = 0; ij0 < 2; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 2; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-
-{
-IkReal j2array[2], cj2array[2], sj2array[2];
-bool j2valid[2]={false};
-_nj2 = 2;
-if( (((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0))))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0))))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x64=IKasin(((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0)))));
-j2array[0]=((IkReal(3.10482123119329))+(((IkReal(-1.00000000000000))*(x64))));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-j2array[1]=((IkReal(6.24641388478308))+(x64));
-sj2array[1]=IKsin(j2array[1]);
-cj2array[1]=IKcos(j2array[1]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-if( j2array[1] > IKPI )
-{
-    j2array[1]-=IK2PI;
-}
-else if( j2array[1] < -IKPI )
-{    j2array[1]+=IK2PI;
-}
-j2valid[1] = true;
-for(int ij2 = 0; ij2 < 2; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 2; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-
-{
-IkReal dummyeval[1];
-IkReal gconst0;
-IkReal x65=((py)*(sj0));
-IkReal x66=((IkReal(1.49995000000000))*(sj2));
-IkReal x67=((cj0)*(px));
-IkReal x68=((IkReal(0.0550600000000000))*(cj2));
-gconst0=IKsign(((IkReal(0.440927223000000))+(((IkReal(-1.24990000000000))*(x65)))+(((IkReal(-1.24990000000000))*(x67)))+(((IkReal(0.0550600000000000))*(pz)*(sj2)))+(((x67)*(x68)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((IkReal(-1.49995000000000))*(cj2)*(pz)))+(((x66)*(x67)))+(((IkReal(0.000100000000000000))*(pz)))+(((IkReal(-0.529137361500000))*(sj2)))+(((x65)*(x68)))+(((x65)*(x66)))));
-IkReal x69=((cj0)*(px));
-IkReal x70=((py)*(sj0));
-IkReal x71=((IkReal(550.600000000000))*(cj2));
-IkReal x72=((IkReal(14999.5000000000))*(sj2));
-dummyeval[0]=((IkReal(4409.27223000000))+(((IkReal(-12499.0000000000))*(x69)))+(((IkReal(-5291.37361500000))*(sj2)))+(((IkReal(-194.235162000000))*(cj2)))+(((x69)*(x72)))+(((x69)*(x71)))+(pz)+(((x70)*(x71)))+(((x70)*(x72)))+(((IkReal(-14999.5000000000))*(cj2)*(pz)))+(((IkReal(-12499.0000000000))*(x70)))+(((IkReal(550.600000000000))*(pz)*(sj2))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst1;
-IkReal x73=((cj0)*(px));
-IkReal x74=((py)*(sj0));
-gconst1=IKsign(((IkReal(-0.124446672900000))+(((IkReal(-1.00000000000000))*((x74)*(x74))))+(((IkReal(-2.00000000000000))*(x73)*(x74)))+(((IkReal(-1.00000000000000))*((pz)*(pz))))+(((IkReal(-1.00000000000000))*((x73)*(x73))))+(((IkReal(0.705540000000000))*(x73)))+(((IkReal(0.705540000000000))*(x74)))));
-IkReal x75=((py)*(sj0));
-IkReal x76=((cj0)*(px));
-dummyeval[0]=((IkReal(-1.00000000000000))+(((IkReal(-8.03557039088990))*((x76)*(x76))))+(((IkReal(5.66941633358846))*(x75)))+(((IkReal(5.66941633358846))*(x76)))+(((IkReal(-8.03557039088990))*((pz)*(pz))))+(((IkReal(-8.03557039088990))*((x75)*(x75))))+(((IkReal(-16.0711407817798))*(x75)*(x76))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j1array[1], cj1array[1], sj1array[1];
-bool j1valid[1]={false};
-_nj1 = 1;
-IkReal x77=((py)*(sj0));
-IkReal x78=((IkReal(1.49995000000000))*(pz));
-IkReal x79=((IkReal(0.0550600000000000))*(cj2));
-IkReal x80=((cj0)*(px));
-IkReal x81=((IkReal(0.0550600000000000))*(sj2));
-IkReal x82=((IkReal(1.49995000000000))*(x77));
-IkReal x83=((IkReal(0.0550600000000000))*(x80));
-if( IKabs(((gconst1)*(((IkReal(0.440927223000000))+(((sj2)*(x82)))+(((x79)*(x80)))+(((IkReal(1.49995000000000))*(sj2)*(x80)))+(((IkReal(-1.24990000000000))*(x77)))+(((IkReal(-1.24990000000000))*(x80)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((cj2)*(x78)))+(((IkReal(-0.000100000000000000))*(pz)))+(((x77)*(x79)))+(((IkReal(-1.00000000000000))*(pz)*(x81)))+(((IkReal(-0.529137361500000))*(sj2))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst1)*(((IkReal(-3.52770000000000e-5))+(((x77)*(x81)))+(((IkReal(0.000100000000000000))*(x80)))+(((pz)*(x79)))+(((IkReal(0.000100000000000000))*(x77)))+(((IkReal(-1.24990000000000))*(pz)))+(((IkReal(0.529137361500000))*(cj2)))+(((IkReal(-1.49995000000000))*(cj2)*(x80)))+(((sj2)*(x78)))+(((IkReal(-0.0194235162000000))*(sj2)))+(((x80)*(x81)))+(((IkReal(-1.00000000000000))*(cj2)*(x82))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j1array[0]=IKatan2(((gconst1)*(((IkReal(0.440927223000000))+(((sj2)*(x82)))+(((x79)*(x80)))+(((IkReal(1.49995000000000))*(sj2)*(x80)))+(((IkReal(-1.24990000000000))*(x77)))+(((IkReal(-1.24990000000000))*(x80)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((cj2)*(x78)))+(((IkReal(-0.000100000000000000))*(pz)))+(((x77)*(x79)))+(((IkReal(-1.00000000000000))*(pz)*(x81)))+(((IkReal(-0.529137361500000))*(sj2)))))), ((gconst1)*(((IkReal(-3.52770000000000e-5))+(((x77)*(x81)))+(((IkReal(0.000100000000000000))*(x80)))+(((pz)*(x79)))+(((IkReal(0.000100000000000000))*(x77)))+(((IkReal(-1.24990000000000))*(pz)))+(((IkReal(0.529137361500000))*(cj2)))+(((IkReal(-1.49995000000000))*(cj2)*(x80)))+(((sj2)*(x78)))+(((IkReal(-0.0194235162000000))*(sj2)))+(((x80)*(x81)))+(((IkReal(-1.00000000000000))*(cj2)*(x82)))))));
-sj1array[0]=IKsin(j1array[0]);
-cj1array[0]=IKcos(j1array[0]);
-if( j1array[0] > IKPI )
-{
-    j1array[0]-=IK2PI;
-}
-else if( j1array[0] < -IKPI )
-{    j1array[0]+=IK2PI;
-}
-j1valid[0] = true;
-for(int ij1 = 0; ij1 < 1; ++ij1)
-{
-if( !j1valid[ij1] )
-{
-    continue;
-}
-_ij1[0] = ij1; _ij1[1] = -1;
-for(int iij1 = ij1+1; iij1 < 1; ++iij1)
-{
-if( j1valid[iij1] && IKabs(cj1array[ij1]-cj1array[iij1]) < IKFAST_SOLUTION_THRESH && IKabs(sj1array[ij1]-sj1array[iij1]) < IKFAST_SOLUTION_THRESH )
-{
-    j1valid[iij1]=false; _ij1[1] = iij1; break; 
-}
-}
-j1 = j1array[ij1]; cj1 = cj1array[ij1]; sj1 = sj1array[ij1];
-{
-IkReal evalcond[5];
-IkReal x84=IKsin(j1);
-IkReal x85=IKcos(j1);
-IkReal x86=((IkReal(1.49995000000000))*(sj2));
-IkReal x87=((cj0)*(px));
-IkReal x88=((IkReal(0.0550600000000000))*(cj2));
-IkReal x89=((IkReal(1.49995000000000))*(cj2));
-IkReal x90=((py)*(sj0));
-IkReal x91=((IkReal(0.0550600000000000))*(sj2));
-IkReal x92=((IkReal(1.00000000000000))*(x85));
-IkReal x93=((IkReal(2.49980000000000))*(x84));
-IkReal x94=((pz)*(x85));
-IkReal x95=((pz)*(x84));
-IkReal x96=((IkReal(0.000200000000000000))*(x85));
-evalcond[0]=((IkReal(-1.24990000000000))+(((x84)*(x87)))+(x88)+(x86)+(x94)+(((IkReal(-0.352770000000000))*(x84)))+(((x84)*(x90))));
-evalcond[1]=((IkReal(-0.000100000000000000))+(((IkReal(-1.00000000000000))*(x90)*(x92)))+(((IkReal(-1.00000000000000))*(x87)*(x92)))+(x89)+(x95)+(((IkReal(0.352770000000000))*(x85)))+(((IkReal(-1.00000000000000))*(x91))));
-evalcond[2]=((((x84)*(x89)))+(((x85)*(x88)))+(((x85)*(x86)))+(((IkReal(-1.24990000000000))*(x85)))+(pz)+(((IkReal(-1.00000000000000))*(x84)*(x91)))+(((IkReal(-0.000100000000000000))*(x84))));
-evalcond[3]=((IkReal(0.352770000000000))+(((x85)*(x89)))+(((IkReal(1.24990000000000))*(x84)))+(((IkReal(-1.00000000000000))*(x87)))+(((IkReal(-1.00000000000000))*(x84)*(x86)))+(((IkReal(-1.00000000000000))*(x84)*(x88)))+(((IkReal(-1.00000000000000))*(x90)))+(((IkReal(-0.000100000000000000))*(x85)))+(((IkReal(-1.00000000000000))*(x85)*(x91))));
-evalcond[4]=((IkReal(0.566185873600000))+(((x87)*(x93)))+(((IkReal(-0.881854446000000))*(x84)))+(((IkReal(-1.00000000000000))*(x90)*(x96)))+(((IkReal(-1.00000000000000))*(x87)*(x96)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(7.05540000000000e-5))*(x85)))+(((x90)*(x93)))+(((IkReal(2.49980000000000))*(x94)))+(((IkReal(0.705540000000000))*(x90)))+(((IkReal(0.000200000000000000))*(x95)))+(((IkReal(0.705540000000000))*(x87))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j1array[1], cj1array[1], sj1array[1];
-bool j1valid[1]={false};
-_nj1 = 1;
-IkReal x236=(cj2)*(cj2);
-IkReal x237=(sj2)*(sj2);
-IkReal x238=((cj2)*(sj2));
-IkReal x239=((IkReal(1.00000000000000))*(pz));
-if( IKabs(((gconst0)*(((IkReal(-1.56225001000000))+(((IkReal(3.74957501000000))*(sj2)))+(((IkReal(-0.00303160360000000))*(x236)))+((pz)*(pz))+(((IkReal(0.137638988000000))*(cj2)))+(((IkReal(-0.165174494000000))*(x238)))+(((IkReal(-2.24985000250000))*(x237))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst0)*(((IkReal(0.000124990000000000))+(((IkReal(-1.00000000000000))*(py)*(sj0)*(x239)))+(((IkReal(-1.87479301100000))*(cj2)))+(((IkReal(0.352770000000000))*(pz)))+(((IkReal(-0.0825872470000000))*(x237)))+(((IkReal(2.24681839890000))*(x238)))+(((IkReal(-1.00000000000000))*(cj0)*(px)*(x239)))+(((IkReal(0.0686694990000000))*(sj2)))+(((IkReal(0.0825872470000000))*(x236))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j1array[0]=IKatan2(((gconst0)*(((IkReal(-1.56225001000000))+(((IkReal(3.74957501000000))*(sj2)))+(((IkReal(-0.00303160360000000))*(x236)))+((pz)*(pz))+(((IkReal(0.137638988000000))*(cj2)))+(((IkReal(-0.165174494000000))*(x238)))+(((IkReal(-2.24985000250000))*(x237)))))), ((gconst0)*(((IkReal(0.000124990000000000))+(((IkReal(-1.00000000000000))*(py)*(sj0)*(x239)))+(((IkReal(-1.87479301100000))*(cj2)))+(((IkReal(0.352770000000000))*(pz)))+(((IkReal(-0.0825872470000000))*(x237)))+(((IkReal(2.24681839890000))*(x238)))+(((IkReal(-1.00000000000000))*(cj0)*(px)*(x239)))+(((IkReal(0.0686694990000000))*(sj2)))+(((IkReal(0.0825872470000000))*(x236)))))));
-sj1array[0]=IKsin(j1array[0]);
-cj1array[0]=IKcos(j1array[0]);
-if( j1array[0] > IKPI )
-{
-    j1array[0]-=IK2PI;
-}
-else if( j1array[0] < -IKPI )
-{    j1array[0]+=IK2PI;
-}
-j1valid[0] = true;
-for(int ij1 = 0; ij1 < 1; ++ij1)
-{
-if( !j1valid[ij1] )
-{
-    continue;
-}
-_ij1[0] = ij1; _ij1[1] = -1;
-for(int iij1 = ij1+1; iij1 < 1; ++iij1)
-{
-if( j1valid[iij1] && IKabs(cj1array[ij1]-cj1array[iij1]) < IKFAST_SOLUTION_THRESH && IKabs(sj1array[ij1]-sj1array[iij1]) < IKFAST_SOLUTION_THRESH )
-{
-    j1valid[iij1]=false; _ij1[1] = iij1; break; 
-}
-}
-j1 = j1array[ij1]; cj1 = cj1array[ij1]; sj1 = sj1array[ij1];
-{
-IkReal evalcond[5];
-IkReal x240=IKsin(j1);
-IkReal x241=IKcos(j1);
-IkReal x242=((IkReal(1.49995000000000))*(sj2));
-IkReal x243=((cj0)*(px));
-IkReal x244=((IkReal(0.0550600000000000))*(cj2));
-IkReal x245=((IkReal(1.49995000000000))*(cj2));
-IkReal x246=((py)*(sj0));
-IkReal x247=((IkReal(0.0550600000000000))*(sj2));
-IkReal x248=((IkReal(1.00000000000000))*(x241));
-IkReal x249=((IkReal(2.49980000000000))*(x240));
-IkReal x250=((pz)*(x241));
-IkReal x251=((pz)*(x240));
-IkReal x252=((IkReal(0.000200000000000000))*(x241));
-evalcond[0]=((IkReal(-1.24990000000000))+(((x240)*(x243)))+(((x240)*(x246)))+(((IkReal(-0.352770000000000))*(x240)))+(x250)+(x242)+(x244));
-evalcond[1]=((IkReal(-0.000100000000000000))+(((IkReal(0.352770000000000))*(x241)))+(((IkReal(-1.00000000000000))*(x243)*(x248)))+(x251)+(x245)+(((IkReal(-1.00000000000000))*(x247)))+(((IkReal(-1.00000000000000))*(x246)*(x248))));
-evalcond[2]=((((x240)*(x245)))+(((IkReal(-1.24990000000000))*(x241)))+(pz)+(((x241)*(x244)))+(((x241)*(x242)))+(((IkReal(-1.00000000000000))*(x240)*(x247)))+(((IkReal(-0.000100000000000000))*(x240))));
-evalcond[3]=((IkReal(0.352770000000000))+(((IkReal(-1.00000000000000))*(x246)))+(((IkReal(-1.00000000000000))*(x243)))+(((IkReal(-1.00000000000000))*(x241)*(x247)))+(((x241)*(x245)))+(((IkReal(-1.00000000000000))*(x240)*(x242)))+(((IkReal(-1.00000000000000))*(x240)*(x244)))+(((IkReal(1.24990000000000))*(x240)))+(((IkReal(-0.000100000000000000))*(x241))));
-evalcond[4]=((IkReal(0.566185873600000))+(((IkReal(2.49980000000000))*(x250)))+(((IkReal(-1.00000000000000))*(x246)*(x252)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(0.000200000000000000))*(x251)))+(((IkReal(-0.881854446000000))*(x240)))+(((IkReal(0.705540000000000))*(x243)))+(((IkReal(0.705540000000000))*(x246)))+(((x246)*(x249)))+(((x243)*(x249)))+(((IkReal(-1.00000000000000))*(x243)*(x252)))+(((IkReal(7.05540000000000e-5))*(x241))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-}
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[2], cj0array[2], sj0array[2];
-bool j0valid[2]={false};
-_nj0 = 2;
-if( IKabs(((IkReal(-1.00000000000000))*(py))) < IKFAST_ATAN2_MAGTHRESH && IKabs(px) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x253=((IkReal(1.00000000000000))*(IKatan2(((IkReal(-1.00000000000000))*(py)), px)));
-if( ((((px)*(px))+((py)*(py)))) < (IkReal)-0.00001 )
-    continue;
-if( (((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30)))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30)))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x254=IKasin(((IkReal(0.000980000000000000))*(((IKabs(IKabs(IKsqrt((((px)*(px))+((py)*(py)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((px)*(px))+((py)*(py))))))):(IkReal)1.0e30))));
-j0array[0]=((x254)+(((IkReal(-1.00000000000000))*(x253))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-j0array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x254)))+(((IkReal(-1.00000000000000))*(x253))));
-sj0array[1]=IKsin(j0array[1]);
-cj0array[1]=IKcos(j0array[1]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-if( j0array[1] > IKPI )
-{
-    j0array[1]-=IK2PI;
-}
-else if( j0array[1] < -IKPI )
-{    j0array[1]+=IK2PI;
-}
-j0valid[1] = true;
-for(int ij0 = 0; ij0 < 2; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 2; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-
-{
-IkReal j2array[2], cj2array[2], sj2array[2];
-bool j2valid[2]={false};
-_nj2 = 2;
-if( (((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0))))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0))))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x255=IKasin(((IkReal(0.983631974086230))+(((IkReal(-0.266517389209847))*(pp)))+(((IkReal(0.188038678783115))*(cj0)*(px)))+(((IkReal(0.188038678783115))*(py)*(sj0)))));
-j2array[0]=((IkReal(3.10482123119329))+(((IkReal(-1.00000000000000))*(x255))));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-j2array[1]=((IkReal(6.24641388478308))+(x255));
-sj2array[1]=IKsin(j2array[1]);
-cj2array[1]=IKcos(j2array[1]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-if( j2array[1] > IKPI )
-{
-    j2array[1]-=IK2PI;
-}
-else if( j2array[1] < -IKPI )
-{    j2array[1]+=IK2PI;
-}
-j2valid[1] = true;
-for(int ij2 = 0; ij2 < 2; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 2; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-
-{
-IkReal dummyeval[1];
-IkReal gconst0;
-IkReal x256=((py)*(sj0));
-IkReal x257=((IkReal(1.49995000000000))*(sj2));
-IkReal x258=((cj0)*(px));
-IkReal x259=((IkReal(0.0550600000000000))*(cj2));
-gconst0=IKsign(((IkReal(0.440927223000000))+(((x256)*(x257)))+(((x256)*(x259)))+(((x257)*(x258)))+(((IkReal(0.0550600000000000))*(pz)*(sj2)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((IkReal(-1.49995000000000))*(cj2)*(pz)))+(((IkReal(-1.24990000000000))*(x258)))+(((IkReal(-1.24990000000000))*(x256)))+(((x258)*(x259)))+(((IkReal(0.000100000000000000))*(pz)))+(((IkReal(-0.529137361500000))*(sj2)))));
-IkReal x260=((cj0)*(px));
-IkReal x261=((py)*(sj0));
-IkReal x262=((IkReal(550.600000000000))*(cj2));
-IkReal x263=((IkReal(14999.5000000000))*(sj2));
-dummyeval[0]=((IkReal(4409.27223000000))+(((x260)*(x262)))+(((x260)*(x263)))+(((IkReal(-5291.37361500000))*(sj2)))+(((IkReal(-194.235162000000))*(cj2)))+(((IkReal(-12499.0000000000))*(x261)))+(((IkReal(-12499.0000000000))*(x260)))+(pz)+(((x261)*(x263)))+(((x261)*(x262)))+(((IkReal(-14999.5000000000))*(cj2)*(pz)))+(((IkReal(550.600000000000))*(pz)*(sj2))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst1;
-IkReal x264=((cj0)*(px));
-IkReal x265=((py)*(sj0));
-gconst1=IKsign(((IkReal(-0.124446672900000))+(((IkReal(-1.00000000000000))*((x264)*(x264))))+(((IkReal(-1.00000000000000))*((pz)*(pz))))+(((IkReal(-2.00000000000000))*(x264)*(x265)))+(((IkReal(-1.00000000000000))*((x265)*(x265))))+(((IkReal(0.705540000000000))*(x264)))+(((IkReal(0.705540000000000))*(x265)))));
-IkReal x266=((py)*(sj0));
-IkReal x267=((cj0)*(px));
-dummyeval[0]=((IkReal(-1.00000000000000))+(((IkReal(-8.03557039088990))*((x266)*(x266))))+(((IkReal(-16.0711407817798))*(x266)*(x267)))+(((IkReal(-8.03557039088990))*((pz)*(pz))))+(((IkReal(5.66941633358846))*(x266)))+(((IkReal(5.66941633358846))*(x267)))+(((IkReal(-8.03557039088990))*((x267)*(x267)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j1array[1], cj1array[1], sj1array[1];
-bool j1valid[1]={false};
-_nj1 = 1;
-IkReal x268=((py)*(sj0));
-IkReal x269=((IkReal(1.49995000000000))*(pz));
-IkReal x270=((IkReal(0.0550600000000000))*(cj2));
-IkReal x271=((cj0)*(px));
-IkReal x272=((IkReal(0.0550600000000000))*(sj2));
-IkReal x273=((IkReal(1.49995000000000))*(x268));
-IkReal x274=((IkReal(0.0550600000000000))*(x271));
-if( IKabs(((gconst1)*(((IkReal(0.440927223000000))+(((IkReal(-1.00000000000000))*(pz)*(x272)))+(((sj2)*(x273)))+(((x270)*(x271)))+(((IkReal(-1.24990000000000))*(x271)))+(((IkReal(-1.24990000000000))*(x268)))+(((IkReal(1.49995000000000))*(sj2)*(x271)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((IkReal(-0.000100000000000000))*(pz)))+(((cj2)*(x269)))+(((IkReal(-0.529137361500000))*(sj2)))+(((x268)*(x270))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst1)*(((IkReal(-3.52770000000000e-5))+(((IkReal(0.000100000000000000))*(x268)))+(((x271)*(x272)))+(((IkReal(0.000100000000000000))*(x271)))+(((IkReal(-1.24990000000000))*(pz)))+(((IkReal(0.529137361500000))*(cj2)))+(((sj2)*(x269)))+(((IkReal(-1.49995000000000))*(cj2)*(x271)))+(((IkReal(-1.00000000000000))*(cj2)*(x273)))+(((IkReal(-0.0194235162000000))*(sj2)))+(((pz)*(x270)))+(((x268)*(x272))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j1array[0]=IKatan2(((gconst1)*(((IkReal(0.440927223000000))+(((IkReal(-1.00000000000000))*(pz)*(x272)))+(((sj2)*(x273)))+(((x270)*(x271)))+(((IkReal(-1.24990000000000))*(x271)))+(((IkReal(-1.24990000000000))*(x268)))+(((IkReal(1.49995000000000))*(sj2)*(x271)))+(((IkReal(-0.0194235162000000))*(cj2)))+(((IkReal(-0.000100000000000000))*(pz)))+(((cj2)*(x269)))+(((IkReal(-0.529137361500000))*(sj2)))+(((x268)*(x270)))))), ((gconst1)*(((IkReal(-3.52770000000000e-5))+(((IkReal(0.000100000000000000))*(x268)))+(((x271)*(x272)))+(((IkReal(0.000100000000000000))*(x271)))+(((IkReal(-1.24990000000000))*(pz)))+(((IkReal(0.529137361500000))*(cj2)))+(((sj2)*(x269)))+(((IkReal(-1.49995000000000))*(cj2)*(x271)))+(((IkReal(-1.00000000000000))*(cj2)*(x273)))+(((IkReal(-0.0194235162000000))*(sj2)))+(((pz)*(x270)))+(((x268)*(x272)))))));
-sj1array[0]=IKsin(j1array[0]);
-cj1array[0]=IKcos(j1array[0]);
-if( j1array[0] > IKPI )
-{
-    j1array[0]-=IK2PI;
-}
-else if( j1array[0] < -IKPI )
-{    j1array[0]+=IK2PI;
-}
-j1valid[0] = true;
-for(int ij1 = 0; ij1 < 1; ++ij1)
-{
-if( !j1valid[ij1] )
-{
-    continue;
-}
-_ij1[0] = ij1; _ij1[1] = -1;
-for(int iij1 = ij1+1; iij1 < 1; ++iij1)
-{
-if( j1valid[iij1] && IKabs(cj1array[ij1]-cj1array[iij1]) < IKFAST_SOLUTION_THRESH && IKabs(sj1array[ij1]-sj1array[iij1]) < IKFAST_SOLUTION_THRESH )
-{
-    j1valid[iij1]=false; _ij1[1] = iij1; break; 
-}
-}
-j1 = j1array[ij1]; cj1 = cj1array[ij1]; sj1 = sj1array[ij1];
-{
-IkReal evalcond[5];
-IkReal x275=IKsin(j1);
-IkReal x276=IKcos(j1);
-IkReal x277=((IkReal(1.49995000000000))*(sj2));
-IkReal x278=((cj0)*(px));
-IkReal x279=((IkReal(0.0550600000000000))*(cj2));
-IkReal x280=((IkReal(1.49995000000000))*(cj2));
-IkReal x281=((py)*(sj0));
-IkReal x282=((IkReal(0.0550600000000000))*(sj2));
-IkReal x283=((IkReal(1.00000000000000))*(x276));
-IkReal x284=((IkReal(2.49980000000000))*(x275));
-IkReal x285=((pz)*(x276));
-IkReal x286=((pz)*(x275));
-IkReal x287=((IkReal(0.000200000000000000))*(x276));
-evalcond[0]=((IkReal(-1.24990000000000))+(((x275)*(x278)))+(((IkReal(-0.352770000000000))*(x275)))+(x277)+(x279)+(x285)+(((x275)*(x281))));
-evalcond[1]=((IkReal(-0.000100000000000000))+(((IkReal(0.352770000000000))*(x276)))+(((IkReal(-1.00000000000000))*(x281)*(x283)))+(x286)+(x280)+(((IkReal(-1.00000000000000))*(x282)))+(((IkReal(-1.00000000000000))*(x278)*(x283))));
-evalcond[2]=((((IkReal(-1.24990000000000))*(x276)))+(((x275)*(x280)))+(pz)+(((x276)*(x277)))+(((x276)*(x279)))+(((IkReal(-1.00000000000000))*(x275)*(x282)))+(((IkReal(-0.000100000000000000))*(x275))));
-evalcond[3]=((IkReal(0.352770000000000))+(((IkReal(-1.00000000000000))*(x278)))+(((IkReal(-1.00000000000000))*(x276)*(x282)))+(((IkReal(-1.00000000000000))*(x281)))+(((IkReal(1.24990000000000))*(x275)))+(((IkReal(-1.00000000000000))*(x275)*(x277)))+(((IkReal(-1.00000000000000))*(x275)*(x279)))+(((x276)*(x280)))+(((IkReal(-0.000100000000000000))*(x276))));
-evalcond[4]=((IkReal(0.566185873600000))+(((x278)*(x284)))+(((IkReal(2.49980000000000))*(x285)))+(((IkReal(-1.00000000000000))*(x281)*(x287)))+(((IkReal(0.000200000000000000))*(x286)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-0.881854446000000))*(x275)))+(((IkReal(0.705540000000000))*(x281)))+(((x281)*(x284)))+(((IkReal(0.705540000000000))*(x278)))+(((IkReal(7.05540000000000e-5))*(x276)))+(((IkReal(-1.00000000000000))*(x278)*(x287))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j1array[1], cj1array[1], sj1array[1];
-bool j1valid[1]={false};
-_nj1 = 1;
-IkReal x288=(cj2)*(cj2);
-IkReal x289=(sj2)*(sj2);
-IkReal x290=((cj2)*(sj2));
-IkReal x291=((IkReal(1.00000000000000))*(pz));
-if( IKabs(((gconst0)*(((IkReal(-1.56225001000000))+(((IkReal(3.74957501000000))*(sj2)))+(((IkReal(-0.165174494000000))*(x290)))+(((IkReal(-0.00303160360000000))*(x288)))+((pz)*(pz))+(((IkReal(0.137638988000000))*(cj2)))+(((IkReal(-2.24985000250000))*(x289))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst0)*(((IkReal(0.000124990000000000))+(((IkReal(-1.00000000000000))*(cj0)*(px)*(x291)))+(((IkReal(0.0825872470000000))*(x288)))+(((IkReal(-1.87479301100000))*(cj2)))+(((IkReal(0.352770000000000))*(pz)))+(((IkReal(-0.0825872470000000))*(x289)))+(((IkReal(-1.00000000000000))*(py)*(sj0)*(x291)))+(((IkReal(2.24681839890000))*(x290)))+(((IkReal(0.0686694990000000))*(sj2))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j1array[0]=IKatan2(((gconst0)*(((IkReal(-1.56225001000000))+(((IkReal(3.74957501000000))*(sj2)))+(((IkReal(-0.165174494000000))*(x290)))+(((IkReal(-0.00303160360000000))*(x288)))+((pz)*(pz))+(((IkReal(0.137638988000000))*(cj2)))+(((IkReal(-2.24985000250000))*(x289)))))), ((gconst0)*(((IkReal(0.000124990000000000))+(((IkReal(-1.00000000000000))*(cj0)*(px)*(x291)))+(((IkReal(0.0825872470000000))*(x288)))+(((IkReal(-1.87479301100000))*(cj2)))+(((IkReal(0.352770000000000))*(pz)))+(((IkReal(-0.0825872470000000))*(x289)))+(((IkReal(-1.00000000000000))*(py)*(sj0)*(x291)))+(((IkReal(2.24681839890000))*(x290)))+(((IkReal(0.0686694990000000))*(sj2)))))));
-sj1array[0]=IKsin(j1array[0]);
-cj1array[0]=IKcos(j1array[0]);
-if( j1array[0] > IKPI )
-{
-    j1array[0]-=IK2PI;
-}
-else if( j1array[0] < -IKPI )
-{    j1array[0]+=IK2PI;
-}
-j1valid[0] = true;
-for(int ij1 = 0; ij1 < 1; ++ij1)
-{
-if( !j1valid[ij1] )
-{
-    continue;
-}
-_ij1[0] = ij1; _ij1[1] = -1;
-for(int iij1 = ij1+1; iij1 < 1; ++iij1)
-{
-if( j1valid[iij1] && IKabs(cj1array[ij1]-cj1array[iij1]) < IKFAST_SOLUTION_THRESH && IKabs(sj1array[ij1]-sj1array[iij1]) < IKFAST_SOLUTION_THRESH )
-{
-    j1valid[iij1]=false; _ij1[1] = iij1; break; 
-}
-}
-j1 = j1array[ij1]; cj1 = cj1array[ij1]; sj1 = sj1array[ij1];
-{
-IkReal evalcond[5];
-IkReal x292=IKsin(j1);
-IkReal x293=IKcos(j1);
-IkReal x294=((IkReal(1.49995000000000))*(sj2));
-IkReal x295=((cj0)*(px));
-IkReal x296=((IkReal(0.0550600000000000))*(cj2));
-IkReal x297=((IkReal(1.49995000000000))*(cj2));
-IkReal x298=((py)*(sj0));
-IkReal x299=((IkReal(0.0550600000000000))*(sj2));
-IkReal x300=((IkReal(1.00000000000000))*(x293));
-IkReal x301=((IkReal(2.49980000000000))*(x292));
-IkReal x302=((pz)*(x293));
-IkReal x303=((pz)*(x292));
-IkReal x304=((IkReal(0.000200000000000000))*(x293));
-evalcond[0]=((IkReal(-1.24990000000000))+(x302)+(x294)+(x296)+(((x292)*(x298)))+(((x292)*(x295)))+(((IkReal(-0.352770000000000))*(x292))));
-evalcond[1]=((IkReal(-0.000100000000000000))+(((IkReal(-1.00000000000000))*(x298)*(x300)))+(((IkReal(-1.00000000000000))*(x299)))+(((IkReal(-1.00000000000000))*(x295)*(x300)))+(x303)+(x297)+(((IkReal(0.352770000000000))*(x293))));
-evalcond[2]=((((IkReal(-1.24990000000000))*(x293)))+(pz)+(((IkReal(-0.000100000000000000))*(x292)))+(((x293)*(x296)))+(((x293)*(x294)))+(((x292)*(x297)))+(((IkReal(-1.00000000000000))*(x292)*(x299))));
-evalcond[3]=((IkReal(0.352770000000000))+(((IkReal(-1.00000000000000))*(x295)))+(((IkReal(-1.00000000000000))*(x298)))+(((IkReal(-1.00000000000000))*(x293)*(x299)))+(((IkReal(1.24990000000000))*(x292)))+(((IkReal(-0.000100000000000000))*(x293)))+(((x293)*(x297)))+(((IkReal(-1.00000000000000))*(x292)*(x294)))+(((IkReal(-1.00000000000000))*(x292)*(x296))));
-evalcond[4]=((IkReal(0.566185873600000))+(((IkReal(-1.00000000000000))*(x298)*(x304)))+(((IkReal(0.000200000000000000))*(x303)))+(((IkReal(0.705540000000000))*(x298)))+(((IkReal(0.705540000000000))*(x295)))+(((IkReal(-1.00000000000000))*(x295)*(x304)))+(((IkReal(-1.00000000000000))*(pp)))+(((x298)*(x301)))+(((IkReal(7.05540000000000e-5))*(x293)))+(((x295)*(x301)))+(((IkReal(2.49980000000000))*(x302)))+(((IkReal(-0.881854446000000))*(x292))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-}
-}
-}
-}
-
-}
-
-}
-}
-return solutions.GetNumSolutions()>0;
-}
-inline void rotationfunction0(IkSolutionListBase<IkReal>& solutions) {
-for(int rotationiter = 0; rotationiter < 1; ++rotationiter) {
-IkReal x97=((cj0)*(r00));
-IkReal x98=((cj0)*(r01));
-IkReal x99=((sj1)*(sj2));
-IkReal x100=((IkReal(1.00000000000000))*(sj0));
-IkReal x101=((r10)*(sj0));
-IkReal x102=((IkReal(1.00000000000000))*(cj2));
-IkReal x103=((r11)*(sj0));
-IkReal x104=((cj0)*(r02));
-IkReal x105=((r12)*(sj0));
-IkReal x106=((((IkReal(-1.00000000000000))*(cj1)*(x102)))+(x99));
-IkReal x107=((((IkReal(-1.00000000000000))*(x99)))+(((cj1)*(cj2))));
-IkReal x108=((cj0)*(x107));
-IkReal x109=((((IkReal(-1.00000000000000))*(cj1)*(sj2)))+(((IkReal(-1.00000000000000))*(sj1)*(x102))));
-IkReal x110=((sj0)*(x109));
-new_r00=((((r20)*(x106)))+(((x109)*(x97)))+(((x101)*(x109))));
-new_r01=((((r21)*(x106)))+(((x103)*(x109)))+(((x109)*(x98))));
-new_r02=((((r22)*(x106)))+(((x105)*(x109)))+(((x104)*(x109))));
-new_r10=((((IkReal(-1.00000000000000))*(r00)*(x100)))+(((cj0)*(r10))));
-new_r11=((((IkReal(-1.00000000000000))*(r01)*(x100)))+(((cj0)*(r11))));
-new_r12=((((IkReal(-1.00000000000000))*(r02)*(x100)))+(((cj0)*(r12))));
-new_r20=((((x107)*(x97)))+(((r20)*(x109)))+(((x101)*(x107))));
-new_r21=((((x107)*(x98)))+(((r21)*(x109)))+(((x103)*(x107))));
-new_r22=((((r22)*(x109)))+(((x105)*(x107)))+(((x104)*(x107))));
-{
-IkReal j4array[2], cj4array[2], sj4array[2];
-bool j4valid[2]={false};
-_nj4 = 2;
-cj4array[0]=new_r22;
-if( cj4array[0] >= -1-IKFAST_SINCOS_THRESH && cj4array[0] <= 1+IKFAST_SINCOS_THRESH )
-{
-    j4valid[0] = j4valid[1] = true;
-    j4array[0] = IKacos(cj4array[0]);
-    sj4array[0] = IKsin(j4array[0]);
-    cj4array[1] = cj4array[0];
-    j4array[1] = -j4array[0];
-    sj4array[1] = -sj4array[0];
-}
-else if( isnan(cj4array[0]) )
-{
-    // probably any value will work
-    j4valid[0] = true;
-    cj4array[0] = 1; sj4array[0] = 0; j4array[0] = 0;
-}
-for(int ij4 = 0; ij4 < 2; ++ij4)
-{
-if( !j4valid[ij4] )
-{
-    continue;
-}
-_ij4[0] = ij4; _ij4[1] = -1;
-for(int iij4 = ij4+1; iij4 < 2; ++iij4)
-{
-if( j4valid[iij4] && IKabs(cj4array[ij4]-cj4array[iij4]) < IKFAST_SOLUTION_THRESH && IKabs(sj4array[ij4]-sj4array[iij4]) < IKFAST_SOLUTION_THRESH )
-{
-    j4valid[iij4]=false; _ij4[1] = iij4; break; 
-}
-}
-j4 = j4array[ij4]; cj4 = cj4array[ij4]; sj4 = sj4array[ij4];
-
-{
-IkReal dummyeval[1];
-IkReal gconst4;
-gconst4=IKsign(sj4);
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst2;
-gconst2=IKsign((((new_r12)*(new_r12))+((new_r02)*(new_r02))));
-dummyeval[0]=(((new_r12)*(new_r12))+((new_r02)*(new_r02)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst3;
-gconst3=IKsign(((((new_r10)*(new_r12)*(sj4)))+(((new_r00)*(new_r02)*(sj4)))));
-dummyeval[0]=((((new_r10)*(new_r12)*(sj4)))+(((new_r00)*(new_r02)*(sj4))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[7];
-IkReal x111=((IkReal(-1.00000000000000))+(new_r22));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=x111;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=new_r20;
-evalcond[5]=new_r21;
-evalcond[6]=x111;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  )
-{
-{
-IkReal j3array[2], cj3array[2], sj3array[2];
-bool j3valid[2]={false};
-_nj3 = 2;
-if( IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x112=IKatan2(new_r02, new_r12);
-j3array[0]=((IkReal(-1.00000000000000))*(x112));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-j3array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x112))));
-sj3array[1]=IKsin(j3array[1]);
-cj3array[1]=IKcos(j3array[1]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-if( j3array[1] > IKPI )
-{
-    j3array[1]-=IK2PI;
-}
-else if( j3array[1] < -IKPI )
-{    j3array[1]+=IK2PI;
-}
-j3valid[1] = true;
-for(int ij3 = 0; ij3 < 2; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 2; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[1];
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r02)*(IKsin(j3))))+(((new_r12)*(IKcos(j3)))));
-if( IKabs(evalcond[0]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r10)*(sj3)))+(((cj3)*(new_r00))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))))+IKsqr(((((new_r10)*(sj3)))+(((cj3)*(new_r00)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))), ((((new_r10)*(sj3)))+(((cj3)*(new_r00)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x113=IKsin(j5);
-IkReal x114=((IkReal(1.00000000000000))*(sj3));
-IkReal x115=((IkReal(1.00000000000000))*(IKcos(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r00)*(x114)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(x113))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(new_r01)*(x114)))+(((IkReal(-1.00000000000000))*(x115)))+(((cj3)*(new_r11))));
-evalcond[2]=((((new_r11)*(sj3)))+(x113)+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(((IkReal(-1.00000000000000))*(x115)))+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-}
-}
-
-} else
-{
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[5]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[6]=((IkReal(-1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  )
-{
-{
-IkReal j3array[2], cj3array[2], sj3array[2];
-bool j3valid[2]={false};
-_nj3 = 2;
-if( IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x116=IKatan2(new_r02, new_r12);
-j3array[0]=((IkReal(-1.00000000000000))*(x116));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-j3array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x116))));
-sj3array[1]=IKsin(j3array[1]);
-cj3array[1]=IKcos(j3array[1]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-if( j3array[1] > IKPI )
-{
-    j3array[1]-=IK2PI;
-}
-else if( j3array[1] < -IKPI )
-{    j3array[1]+=IK2PI;
-}
-j3valid[1] = true;
-for(int ij3 = 0; ij3 < 2; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 2; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[1];
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r02)*(IKsin(j3))))+(((new_r12)*(IKcos(j3)))));
-if( IKabs(evalcond[0]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((new_r11)*(sj3)))+(((cj3)*(new_r01))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))))+IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))), ((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x117=IKcos(j5);
-IkReal x118=((IkReal(1.00000000000000))*(sj3));
-IkReal x119=((IkReal(1.00000000000000))*(IKsin(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r00)*(x118)))+(((IkReal(-1.00000000000000))*(x119)))+(((cj3)*(new_r10))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(new_r01)*(x118)))+(((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(x117))));
-evalcond[2]=((((new_r11)*(sj3)))+(((IkReal(-1.00000000000000))*(x119)))+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(x117)+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j3array[1], cj3array[1], sj3array[1];
-bool j3valid[1]={false};
-_nj3 = 1;
-IkReal x120=((IkReal(-1.00000000000000))*(cj4)*(gconst3)*(new_r20));
-if( IKabs(((new_r12)*(x120))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r02)*(x120))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j3array[0]=IKatan2(((new_r12)*(x120)), ((new_r02)*(x120)));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-for(int ij3 = 0; ij3 < 1; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 1; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[6];
-IkReal x121=IKsin(j3);
-IkReal x122=IKcos(j3);
-IkReal x123=((IkReal(1.00000000000000))*(sj4));
-IkReal x124=((sj4)*(x121));
-IkReal x125=((sj4)*(x122));
-IkReal x126=((new_r02)*(x122));
-IkReal x127=((new_r12)*(x121));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r02)*(x121)))+(((new_r12)*(x122))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x123)))+(x126)+(x127));
-evalcond[2]=((((new_r00)*(x125)))+(((cj4)*(new_r20)))+(((new_r10)*(x124))));
-evalcond[3]=((((cj4)*(new_r21)))+(((new_r01)*(x125)))+(((new_r11)*(x124))));
-evalcond[4]=((IkReal(-1.00000000000000))+(((cj4)*(new_r22)))+(((new_r02)*(x125)))+(((new_r12)*(x124))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r22)*(x123)))+(((cj4)*(x126)))+(((cj4)*(x127))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst5;
-gconst5=IKsign(sj4);
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[11];
-IkReal x128=((IkReal(-1.00000000000000))+(new_r22));
-IkReal x129=((((IkReal(-1.00000000000000))*(new_r02)*(sj3)))+(((cj3)*(new_r12))));
-IkReal x130=((((new_r12)*(sj3)))+(((cj3)*(new_r02))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=x128;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x129;
-evalcond[5]=x129;
-evalcond[6]=x130;
-evalcond[7]=new_r20;
-evalcond[8]=new_r21;
-evalcond[9]=x128;
-evalcond[10]=x130;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r10)*(sj3)))+(((cj3)*(new_r00))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))))+IKsqr(((((new_r10)*(sj3)))+(((cj3)*(new_r00)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))), ((((new_r10)*(sj3)))+(((cj3)*(new_r00)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x131=IKsin(j5);
-IkReal x132=((IkReal(1.00000000000000))*(sj3));
-IkReal x133=((IkReal(1.00000000000000))*(IKcos(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r00)*(x132)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(x131))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(new_r01)*(x132)))+(((IkReal(-1.00000000000000))*(x133)))+(((cj3)*(new_r11))));
-evalcond[2]=((((new_r11)*(sj3)))+(x131)+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(((IkReal(-1.00000000000000))*(x133)))+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-IkReal x134=((new_r12)*(sj3));
-IkReal x135=((IkReal(1.00000000000000))*(new_r02));
-IkReal x136=((((IkReal(-1.00000000000000))*(sj3)*(x135)))+(((cj3)*(new_r12))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x136;
-evalcond[5]=x136;
-evalcond[6]=((x134)+(((cj3)*(new_r02))));
-evalcond[7]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[8]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[9]=((IkReal(-1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-evalcond[10]=((((IkReal(-1.00000000000000))*(cj3)*(x135)))+(((IkReal(-1.00000000000000))*(x134))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((new_r11)*(sj3)))+(((cj3)*(new_r01))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))))+IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))), ((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x137=IKcos(j5);
-IkReal x138=((IkReal(1.00000000000000))*(sj3));
-IkReal x139=((IkReal(1.00000000000000))*(IKsin(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r00)*(x138)))+(((IkReal(-1.00000000000000))*(x139)))+(((cj3)*(new_r10))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(new_r01)*(x138)))+(((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(x137))));
-evalcond[2]=((((new_r11)*(sj3)))+(((IkReal(-1.00000000000000))*(x139)))+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(x137)+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3)))))+IKsqr(((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3)))), ((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x140=IKsin(j5);
-IkReal x141=IKcos(j5);
-IkReal x142=((IkReal(1.00000000000000))*(sj3));
-IkReal x143=((new_r11)*(sj3));
-IkReal x144=((new_r10)*(sj3));
-IkReal x145=((cj3)*(cj4));
-IkReal x146=((IkReal(1.00000000000000))*(sj4));
-IkReal x147=((IkReal(1.00000000000000))*(x141));
-IkReal x148=((IkReal(1.00000000000000))*(x140));
-evalcond[0]=((((sj4)*(x141)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x140)*(x146)))+(new_r21));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x148)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x142))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r01)*(x142)))+(((IkReal(-1.00000000000000))*(x147)))+(((cj3)*(new_r11))));
-evalcond[4]=((x143)+(((cj3)*(new_r01)))+(((cj4)*(x140))));
-evalcond[5]=((x144)+(((cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(cj4)*(x147))));
-evalcond[6]=((((new_r01)*(x145)))+(((IkReal(-1.00000000000000))*(new_r21)*(x146)))+(x140)+(((cj4)*(x143))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x147)))+(((IkReal(-1.00000000000000))*(new_r20)*(x146)))+(((new_r00)*(x145)))+(((cj4)*(x144))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))))+IKsqr(((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))), ((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x149=IKsin(j5);
-IkReal x150=IKcos(j5);
-IkReal x151=((IkReal(1.00000000000000))*(sj3));
-IkReal x152=((new_r11)*(sj3));
-IkReal x153=((new_r10)*(sj3));
-IkReal x154=((cj3)*(cj4));
-IkReal x155=((IkReal(1.00000000000000))*(sj4));
-IkReal x156=((IkReal(1.00000000000000))*(x150));
-IkReal x157=((IkReal(1.00000000000000))*(x149));
-evalcond[0]=((((sj4)*(x150)))+(new_r20));
-evalcond[1]=((new_r21)+(((IkReal(-1.00000000000000))*(x149)*(x155))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x157)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x151))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x156)))+(((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(new_r01)*(x151))));
-evalcond[4]=((x152)+(((cj3)*(new_r01)))+(((cj4)*(x149))));
-evalcond[5]=((x153)+(((cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(cj4)*(x156))));
-evalcond[6]=((((cj4)*(x152)))+(((new_r01)*(x154)))+(((IkReal(-1.00000000000000))*(new_r21)*(x155)))+(x149));
-evalcond[7]=((((cj4)*(x153)))+(((IkReal(-1.00000000000000))*(new_r20)*(x155)))+(((IkReal(-1.00000000000000))*(x156)))+(((new_r00)*(x154))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((gconst5)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(gconst5)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst5)*(new_r21)), ((IkReal(-1.00000000000000))*(gconst5)*(new_r20)));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x158=IKsin(j5);
-IkReal x159=IKcos(j5);
-IkReal x160=((IkReal(1.00000000000000))*(sj3));
-IkReal x161=((new_r11)*(sj3));
-IkReal x162=((new_r10)*(sj3));
-IkReal x163=((cj3)*(cj4));
-IkReal x164=((IkReal(1.00000000000000))*(sj4));
-IkReal x165=((IkReal(1.00000000000000))*(x159));
-IkReal x166=((IkReal(1.00000000000000))*(x158));
-evalcond[0]=((((sj4)*(x159)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x158)*(x164)))+(new_r21));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r00)*(x160)))+(((IkReal(-1.00000000000000))*(x166)))+(((cj3)*(new_r10))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x165)))+(((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(new_r01)*(x160))));
-evalcond[4]=((((cj4)*(x158)))+(x161)+(((cj3)*(new_r01))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(cj4)*(x165)))+(x162)+(((cj3)*(new_r00))));
-evalcond[6]=((((new_r01)*(x163)))+(((cj4)*(x161)))+(((IkReal(-1.00000000000000))*(new_r21)*(x164)))+(x158));
-evalcond[7]=((((new_r00)*(x163)))+(((cj4)*(x162)))+(((IkReal(-1.00000000000000))*(x165)))+(((IkReal(-1.00000000000000))*(new_r20)*(x164))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j3array[1], cj3array[1], sj3array[1];
-bool j3valid[1]={false};
-_nj3 = 1;
-IkReal x167=((gconst2)*(sj4));
-if( IKabs(((new_r12)*(x167))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r02)*(x167))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j3array[0]=IKatan2(((new_r12)*(x167)), ((new_r02)*(x167)));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-for(int ij3 = 0; ij3 < 1; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 1; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[6];
-IkReal x168=IKsin(j3);
-IkReal x169=IKcos(j3);
-IkReal x170=((IkReal(1.00000000000000))*(sj4));
-IkReal x171=((sj4)*(x168));
-IkReal x172=((sj4)*(x169));
-IkReal x173=((new_r02)*(x169));
-IkReal x174=((new_r12)*(x168));
-evalcond[0]=((((new_r12)*(x169)))+(((IkReal(-1.00000000000000))*(new_r02)*(x168))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x170)))+(x173)+(x174));
-evalcond[2]=((((new_r00)*(x172)))+(((new_r10)*(x171)))+(((cj4)*(new_r20))));
-evalcond[3]=((((new_r01)*(x172)))+(((new_r11)*(x171)))+(((cj4)*(new_r21))));
-evalcond[4]=((IkReal(-1.00000000000000))+(((new_r02)*(x172)))+(((cj4)*(new_r22)))+(((new_r12)*(x171))));
-evalcond[5]=((((cj4)*(x174)))+(((cj4)*(x173)))+(((IkReal(-1.00000000000000))*(new_r22)*(x170))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst5;
-gconst5=IKsign(sj4);
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj4;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[11];
-IkReal x175=((IkReal(-1.00000000000000))+(new_r22));
-IkReal x176=((((IkReal(-1.00000000000000))*(new_r02)*(sj3)))+(((cj3)*(new_r12))));
-IkReal x177=((((new_r12)*(sj3)))+(((cj3)*(new_r02))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=x175;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x176;
-evalcond[5]=x176;
-evalcond[6]=x177;
-evalcond[7]=new_r20;
-evalcond[8]=new_r21;
-evalcond[9]=x175;
-evalcond[10]=x177;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r10)*(sj3)))+(((cj3)*(new_r00))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))))+IKsqr(((((new_r10)*(sj3)))+(((cj3)*(new_r00)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj3)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj3)))), ((((new_r10)*(sj3)))+(((cj3)*(new_r00)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x178=IKsin(j5);
-IkReal x179=((IkReal(1.00000000000000))*(sj3));
-IkReal x180=((IkReal(1.00000000000000))*(IKcos(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x178)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x179))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x180)))+(((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(new_r01)*(x179))));
-evalcond[2]=((((new_r11)*(sj3)))+(x178)+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(((IkReal(-1.00000000000000))*(x180)))+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-IkReal x181=((new_r12)*(sj3));
-IkReal x182=((IkReal(1.00000000000000))*(new_r02));
-IkReal x183=((((cj3)*(new_r12)))+(((IkReal(-1.00000000000000))*(sj3)*(x182))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x183;
-evalcond[5]=x183;
-evalcond[6]=((x181)+(((cj3)*(new_r02))));
-evalcond[7]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[8]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[9]=((IkReal(-1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-evalcond[10]=((((IkReal(-1.00000000000000))*(x181)))+(((IkReal(-1.00000000000000))*(cj3)*(x182))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((new_r11)*(sj3)))+(((cj3)*(new_r01))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))))+IKsqr(((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((new_r11)*(sj3)))+(((cj3)*(new_r01)))), ((((IkReal(-1.00000000000000))*(cj3)*(new_r00)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj3)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[4];
-IkReal x184=IKcos(j5);
-IkReal x185=((IkReal(1.00000000000000))*(sj3));
-IkReal x186=((IkReal(1.00000000000000))*(IKsin(j5)));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x186)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x185))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x184)))+(((IkReal(-1.00000000000000))*(new_r01)*(x185)))+(((cj3)*(new_r11))));
-evalcond[2]=((((new_r11)*(sj3)))+(((IkReal(-1.00000000000000))*(x186)))+(((cj3)*(new_r01))));
-evalcond[3]=((((new_r10)*(sj3)))+(x184)+(((cj3)*(new_r00))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3)))))+IKsqr(((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj3)))), ((IkReal(-1.00000000000000))*(new_r20)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x187=IKsin(j5);
-IkReal x188=IKcos(j5);
-IkReal x189=((IkReal(1.00000000000000))*(sj3));
-IkReal x190=((new_r11)*(sj3));
-IkReal x191=((new_r10)*(sj3));
-IkReal x192=((cj3)*(cj4));
-IkReal x193=((IkReal(1.00000000000000))*(sj4));
-IkReal x194=((IkReal(1.00000000000000))*(x188));
-IkReal x195=((IkReal(1.00000000000000))*(x187));
-evalcond[0]=((((sj4)*(x188)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x187)*(x193)))+(new_r21));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x195)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x189))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x194)))+(((IkReal(-1.00000000000000))*(new_r01)*(x189)))+(((cj3)*(new_r11))));
-evalcond[4]=((x190)+(((cj3)*(new_r01)))+(((cj4)*(x187))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(cj4)*(x194)))+(x191)+(((cj3)*(new_r00))));
-evalcond[6]=((((cj4)*(x190)))+(((new_r01)*(x192)))+(((IkReal(-1.00000000000000))*(new_r21)*(x193)))+(x187));
-evalcond[7]=((((cj4)*(x191)))+(((new_r00)*(x192)))+(((IkReal(-1.00000000000000))*(x194)))+(((IkReal(-1.00000000000000))*(new_r20)*(x193))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))))+IKsqr(((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j5array[0]=IKatan2(((new_r21)*(((IKabs(sj4) != 0)?((IkReal)1/(sj4)):(IkReal)1.0e30))), ((((IkReal(-1.00000000000000))*(new_r01)*(sj3)))+(((cj3)*(new_r11)))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x196=IKsin(j5);
-IkReal x197=IKcos(j5);
-IkReal x198=((IkReal(1.00000000000000))*(sj3));
-IkReal x199=((new_r11)*(sj3));
-IkReal x200=((new_r10)*(sj3));
-IkReal x201=((cj3)*(cj4));
-IkReal x202=((IkReal(1.00000000000000))*(sj4));
-IkReal x203=((IkReal(1.00000000000000))*(x197));
-IkReal x204=((IkReal(1.00000000000000))*(x196));
-evalcond[0]=((((sj4)*(x197)))+(new_r20));
-evalcond[1]=((new_r21)+(((IkReal(-1.00000000000000))*(x196)*(x202))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x204)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(x198))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x203)))+(((IkReal(-1.00000000000000))*(new_r01)*(x198)))+(((cj3)*(new_r11))));
-evalcond[4]=((((cj4)*(x196)))+(x199)+(((cj3)*(new_r01))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(cj4)*(x203)))+(x200)+(((cj3)*(new_r00))));
-evalcond[6]=((((cj4)*(x199)))+(((IkReal(-1.00000000000000))*(new_r21)*(x202)))+(((new_r01)*(x201)))+(x196));
-evalcond[7]=((((new_r00)*(x201)))+(((IkReal(-1.00000000000000))*(new_r20)*(x202)))+(((IkReal(-1.00000000000000))*(x203)))+(((cj4)*(x200))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((gconst5)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(gconst5)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst5)*(new_r21)), ((IkReal(-1.00000000000000))*(gconst5)*(new_r20)));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[8];
-IkReal x205=IKsin(j5);
-IkReal x206=IKcos(j5);
-IkReal x207=((IkReal(1.00000000000000))*(sj3));
-IkReal x208=((new_r11)*(sj3));
-IkReal x209=((new_r10)*(sj3));
-IkReal x210=((cj3)*(cj4));
-IkReal x211=((IkReal(1.00000000000000))*(sj4));
-IkReal x212=((IkReal(1.00000000000000))*(x206));
-IkReal x213=((IkReal(1.00000000000000))*(x205));
-evalcond[0]=((((sj4)*(x206)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x205)*(x211)))+(new_r21));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r00)*(x207)))+(((cj3)*(new_r10)))+(((IkReal(-1.00000000000000))*(x213))));
-evalcond[3]=((((cj3)*(new_r11)))+(((IkReal(-1.00000000000000))*(x212)))+(((IkReal(-1.00000000000000))*(new_r01)*(x207))));
-evalcond[4]=((((cj4)*(x205)))+(x208)+(((cj3)*(new_r01))));
-evalcond[5]=((x209)+(((IkReal(-1.00000000000000))*(cj4)*(x212)))+(((cj3)*(new_r00))));
-evalcond[6]=((((cj4)*(x208)))+(x205)+(((IkReal(-1.00000000000000))*(new_r21)*(x211)))+(((new_r01)*(x210))));
-evalcond[7]=((((cj4)*(x209)))+(((new_r00)*(x210)))+(((IkReal(-1.00000000000000))*(new_r20)*(x211)))+(((IkReal(-1.00000000000000))*(x212))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-if( IKabs(((gconst4)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(gconst4)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst4)*(new_r21)), ((IkReal(-1.00000000000000))*(gconst4)*(new_r20)));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[2];
-evalcond[0]=((((sj4)*(IKcos(j5))))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(sj4)*(IKsin(j5))))+(new_r21));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst6;
-gconst6=IKsign((((new_r12)*(new_r12))+((new_r02)*(new_r02))));
-dummyeval[0]=(((new_r12)*(new_r12))+((new_r02)*(new_r02)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst7;
-gconst7=IKsign(((((IkReal(-1.00000000000000))*(new_r11)*(new_r12)))+(((IkReal(-1.00000000000000))*(new_r01)*(new_r02)))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*(new_r11)*(new_r12)))+(((IkReal(-1.00000000000000))*(new_r01)*(new_r02))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j3array[1], cj3array[1], sj3array[1];
-bool j3valid[1]={false};
-_nj3 = 1;
-IkReal x214=((cj4)*(gconst7)*(sj5));
-if( IKabs(((new_r12)*(x214))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r02)*(x214))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j3array[0]=IKatan2(((new_r12)*(x214)), ((new_r02)*(x214)));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-for(int ij3 = 0; ij3 < 1; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 1; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[12];
-IkReal x215=IKsin(j3);
-IkReal x216=IKcos(j3);
-IkReal x217=((IkReal(1.00000000000000))*(cj5));
-IkReal x218=((IkReal(1.00000000000000))*(sj4));
-IkReal x219=((cj4)*(x216));
-IkReal x220=((sj4)*(x216));
-IkReal x221=((cj4)*(x215));
-IkReal x222=((new_r11)*(x215));
-IkReal x223=((sj4)*(x215));
-IkReal x224=((IkReal(1.00000000000000))*(x215));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r02)*(x224)))+(((new_r12)*(x216))));
-evalcond[1]=((((new_r02)*(x216)))+(((IkReal(-1.00000000000000))*(x218)))+(((new_r12)*(x215))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(sj5)))+(((new_r10)*(x216)))+(((IkReal(-1.00000000000000))*(new_r00)*(x224))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r01)*(x224)))+(((IkReal(-1.00000000000000))*(x217)))+(((new_r11)*(x216))));
-evalcond[4]=((((cj4)*(sj5)))+(x222)+(((new_r01)*(x216))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(cj4)*(x217)))+(((new_r00)*(x216)))+(((new_r10)*(x215))));
-evalcond[6]=((((new_r00)*(x220)))+(((cj4)*(new_r20)))+(((new_r10)*(x223))));
-evalcond[7]=((((sj4)*(x222)))+(((new_r01)*(x220)))+(((cj4)*(new_r21))));
-evalcond[8]=((IkReal(-1.00000000000000))+(((new_r02)*(x220)))+(((cj4)*(new_r22)))+(((new_r12)*(x223))));
-evalcond[9]=((((new_r12)*(x221)))+(((new_r02)*(x219)))+(((IkReal(-1.00000000000000))*(new_r22)*(x218))));
-evalcond[10]=((sj5)+(((IkReal(-1.00000000000000))*(new_r21)*(x218)))+(((new_r11)*(x221)))+(((new_r01)*(x219))));
-evalcond[11]=((((new_r00)*(x219)))+(((IkReal(-1.00000000000000))*(new_r20)*(x218)))+(((new_r10)*(x221)))+(((IkReal(-1.00000000000000))*(x217))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  || IKabs(evalcond[8]) > 0.000001  || IKabs(evalcond[9]) > 0.000001  || IKabs(evalcond[10]) > 0.000001  || IKabs(evalcond[11]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j3array[1], cj3array[1], sj3array[1];
-bool j3valid[1]={false};
-_nj3 = 1;
-IkReal x225=((gconst6)*(sj4));
-if( IKabs(((new_r12)*(x225))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r02)*(x225))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j3array[0]=IKatan2(((new_r12)*(x225)), ((new_r02)*(x225)));
-sj3array[0]=IKsin(j3array[0]);
-cj3array[0]=IKcos(j3array[0]);
-if( j3array[0] > IKPI )
-{
-    j3array[0]-=IK2PI;
-}
-else if( j3array[0] < -IKPI )
-{    j3array[0]+=IK2PI;
-}
-j3valid[0] = true;
-for(int ij3 = 0; ij3 < 1; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 1; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-{
-IkReal evalcond[12];
-IkReal x226=IKsin(j3);
-IkReal x227=IKcos(j3);
-IkReal x228=((IkReal(1.00000000000000))*(cj5));
-IkReal x229=((IkReal(1.00000000000000))*(sj4));
-IkReal x230=((cj4)*(x227));
-IkReal x231=((sj4)*(x227));
-IkReal x232=((cj4)*(x226));
-IkReal x233=((new_r11)*(x226));
-IkReal x234=((sj4)*(x226));
-IkReal x235=((IkReal(1.00000000000000))*(x226));
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r02)*(x235)))+(((new_r12)*(x227))));
-evalcond[1]=((((new_r02)*(x227)))+(((new_r12)*(x226)))+(((IkReal(-1.00000000000000))*(x229))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(sj5)))+(((new_r10)*(x227)))+(((IkReal(-1.00000000000000))*(new_r00)*(x235))));
-evalcond[3]=((((new_r11)*(x227)))+(((IkReal(-1.00000000000000))*(new_r01)*(x235)))+(((IkReal(-1.00000000000000))*(x228))));
-evalcond[4]=((((new_r01)*(x227)))+(((cj4)*(sj5)))+(x233));
-evalcond[5]=((((new_r00)*(x227)))+(((IkReal(-1.00000000000000))*(cj4)*(x228)))+(((new_r10)*(x226))));
-evalcond[6]=((((new_r10)*(x234)))+(((cj4)*(new_r20)))+(((new_r00)*(x231))));
-evalcond[7]=((((new_r01)*(x231)))+(((cj4)*(new_r21)))+(((sj4)*(x233))));
-evalcond[8]=((IkReal(-1.00000000000000))+(((new_r02)*(x231)))+(((cj4)*(new_r22)))+(((new_r12)*(x234))));
-evalcond[9]=((((new_r02)*(x230)))+(((new_r12)*(x232)))+(((IkReal(-1.00000000000000))*(new_r22)*(x229))));
-evalcond[10]=((sj5)+(((new_r11)*(x232)))+(((new_r01)*(x230)))+(((IkReal(-1.00000000000000))*(new_r21)*(x229))));
-evalcond[11]=((((new_r10)*(x232)))+(((new_r00)*(x230)))+(((IkReal(-1.00000000000000))*(new_r20)*(x229)))+(((IkReal(-1.00000000000000))*(x228))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  || IKabs(evalcond[8]) > 0.000001  || IKabs(evalcond[9]) > 0.000001  || IKabs(evalcond[10]) > 0.000001  || IKabs(evalcond[11]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-}
-}
-}
-}};
-
+  IkReal j0, cj0, sj0, htj0, j1, cj1, sj1, htj1, j2, cj2, sj2, htj2, j3, cj3, sj3, htj3, j4, cj4, sj4, htj4, j5, cj5,
+      sj5, htj5, new_r00, r00, rxp0_0, new_r01, r01, rxp0_1, new_r02, r02, rxp0_2, new_r10, r10, rxp1_0, new_r11, r11,
+      rxp1_1, new_r12, r12, rxp1_2, new_r20, r20, rxp2_0, new_r21, r21, rxp2_1, new_r22, r22, rxp2_2, new_px, px, npx,
+      new_py, py, npy, new_pz, pz, npz, pp;
+  unsigned char _ij0[2], _nj0, _ij1[2], _nj1, _ij2[2], _nj2, _ij3[2], _nj3, _ij4[2], _nj4, _ij5[2], _nj5;
+
+  bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions)
+  {
+    j0 = numeric_limits<IkReal>::quiet_NaN();
+    _ij0[0] = -1;
+    _ij0[1] = -1;
+    _nj0 = -1;
+    j1 = numeric_limits<IkReal>::quiet_NaN();
+    _ij1[0] = -1;
+    _ij1[1] = -1;
+    _nj1 = -1;
+    j2 = numeric_limits<IkReal>::quiet_NaN();
+    _ij2[0] = -1;
+    _ij2[1] = -1;
+    _nj2 = -1;
+    j3 = numeric_limits<IkReal>::quiet_NaN();
+    _ij3[0] = -1;
+    _ij3[1] = -1;
+    _nj3 = -1;
+    j4 = numeric_limits<IkReal>::quiet_NaN();
+    _ij4[0] = -1;
+    _ij4[1] = -1;
+    _nj4 = -1;
+    j5 = numeric_limits<IkReal>::quiet_NaN();
+    _ij5[0] = -1;
+    _ij5[1] = -1;
+    _nj5 = -1;
+    for (int dummyiter = 0; dummyiter < 1; ++dummyiter)
+    {
+      solutions.Clear();
+      r00 = eerot[0 * 3 + 0];
+      r01 = eerot[0 * 3 + 1];
+      r02 = eerot[0 * 3 + 2];
+      r10 = eerot[1 * 3 + 0];
+      r11 = eerot[1 * 3 + 1];
+      r12 = eerot[1 * 3 + 2];
+      r20 = eerot[2 * 3 + 0];
+      r21 = eerot[2 * 3 + 1];
+      r22 = eerot[2 * 3 + 2];
+      px = eetrans[0];
+      py = eetrans[1];
+      pz = eetrans[2];
+
+      new_r00 = ((IkReal(-1.00000000000000)) * (r02));
+      new_r01 = r01;
+      new_r02 = r00;
+      new_px = ((IkReal(0.00262000000000000)) + (((IkReal(-0.230000000000000)) * (r00))) + (px) +
+                (((IkReal(0.000240000000000000)) * (r02))));
+      new_r10 = ((IkReal(-1.00000000000000)) * (r12));
+      new_r11 = r11;
+      new_r12 = r10;
+      new_py = ((IkReal(-0.000980000000000000)) + (((IkReal(-0.230000000000000)) * (r10))) + (py) +
+                (((IkReal(0.000240000000000000)) * (r12))));
+      new_r20 = ((IkReal(-1.00000000000000)) * (r22));
+      new_r21 = r21;
+      new_r22 = r20;
+      new_pz = ((IkReal(-0.750190000000000)) + (pz) + (((IkReal(0.000240000000000000)) * (r22))) +
+                (((IkReal(-0.230000000000000)) * (r20))));
+      r00 = new_r00;
+      r01 = new_r01;
+      r02 = new_r02;
+      r10 = new_r10;
+      r11 = new_r11;
+      r12 = new_r12;
+      r20 = new_r20;
+      r21 = new_r21;
+      r22 = new_r22;
+      px = new_px;
+      py = new_py;
+      pz = new_pz;
+      pp = (((px) * (px)) + ((py) * (py)) + ((pz) * (pz)));
+      npx = ((((px) * (r00))) + (((py) * (r10))) + (((pz) * (r20))));
+      npy = ((((px) * (r01))) + (((py) * (r11))) + (((pz) * (r21))));
+      npz = ((((px) * (r02))) + (((py) * (r12))) + (((pz) * (r22))));
+      rxp0_0 = ((((IkReal(-1.00000000000000)) * (py) * (r20))) + (((pz) * (r10))));
+      rxp0_1 = ((((px) * (r20))) + (((IkReal(-1.00000000000000)) * (pz) * (r00))));
+      rxp0_2 = ((((IkReal(-1.00000000000000)) * (px) * (r10))) + (((py) * (r00))));
+      rxp1_0 = ((((IkReal(-1.00000000000000)) * (py) * (r21))) + (((pz) * (r11))));
+      rxp1_1 = ((((px) * (r21))) + (((IkReal(-1.00000000000000)) * (pz) * (r01))));
+      rxp1_2 = ((((IkReal(-1.00000000000000)) * (px) * (r11))) + (((py) * (r01))));
+      rxp2_0 = ((((IkReal(-1.00000000000000)) * (py) * (r22))) + (((pz) * (r12))));
+      rxp2_1 = ((((px) * (r22))) + (((IkReal(-1.00000000000000)) * (pz) * (r02))));
+      rxp2_2 = ((((IkReal(-1.00000000000000)) * (px) * (r12))) + (((py) * (r02))));
+      {
+        IkReal dummyeval[1];
+        dummyeval[0] = (((px) * (px)) + ((py) * (py)));
+        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+        {
+          {
+            IkReal dummyeval[1];
+            dummyeval[0] = (((px) * (px)) + ((py) * (py)));
+            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+            {
+              continue;
+            }
+            else
+            {
+              {
+                IkReal j0array[2], cj0array[2], sj0array[2];
+                bool j0valid[2] = { false };
+                _nj0 = 2;
+                if (IKabs(((IkReal(-1.00000000000000)) * (py))) < IKFAST_ATAN2_MAGTHRESH &&
+                    IKabs(px) < IKFAST_ATAN2_MAGTHRESH)
+                  continue;
+                IkReal x62 = ((IkReal(1.00000000000000)) * (IKatan2(((IkReal(-1.00000000000000)) * (py)), px)));
+                if (((((px) * (px)) + ((py) * (py)))) < (IkReal)-0.00001)
+                  continue;
+                if ((((IkReal(0.000980000000000000)) *
+                      (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                            ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                            (IkReal)1.0e30)))) < -1 - IKFAST_SINCOS_THRESH ||
+                    (((IkReal(0.000980000000000000)) *
+                      (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                            ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                            (IkReal)1.0e30)))) > 1 + IKFAST_SINCOS_THRESH)
+                  continue;
+                IkReal x63 = IKasin(((IkReal(0.000980000000000000)) *
+                                     (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                                           ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                                           (IkReal)1.0e30))));
+                j0array[0] = ((x63) + (((IkReal(-1.00000000000000)) * (x62))));
+                sj0array[0] = IKsin(j0array[0]);
+                cj0array[0] = IKcos(j0array[0]);
+                j0array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x62))) +
+                              (((IkReal(-1.00000000000000)) * (x63))));
+                sj0array[1] = IKsin(j0array[1]);
+                cj0array[1] = IKcos(j0array[1]);
+                if (j0array[0] > IKPI)
+                {
+                  j0array[0] -= IK2PI;
+                }
+                else if (j0array[0] < -IKPI)
+                {
+                  j0array[0] += IK2PI;
+                }
+                j0valid[0] = true;
+                if (j0array[1] > IKPI)
+                {
+                  j0array[1] -= IK2PI;
+                }
+                else if (j0array[1] < -IKPI)
+                {
+                  j0array[1] += IK2PI;
+                }
+                j0valid[1] = true;
+                for (int ij0 = 0; ij0 < 2; ++ij0)
+                {
+                  if (!j0valid[ij0])
+                  {
+                    continue;
+                  }
+                  _ij0[0] = ij0;
+                  _ij0[1] = -1;
+                  for (int iij0 = ij0 + 1; iij0 < 2; ++iij0)
+                  {
+                    if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                        IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                    {
+                      j0valid[iij0] = false;
+                      _ij0[1] = iij0;
+                      break;
+                    }
+                  }
+                  j0 = j0array[ij0];
+                  cj0 = cj0array[ij0];
+                  sj0 = sj0array[ij0];
+
+                  {
+                    IkReal j2array[2], cj2array[2], sj2array[2];
+                    bool j2valid[2] = { false };
+                    _nj2 = 2;
+                    if ((((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                          (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                          (((IkReal(0.188038678783115)) * (py) * (sj0))))) < -1 - IKFAST_SINCOS_THRESH ||
+                        (((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                          (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                          (((IkReal(0.188038678783115)) * (py) * (sj0))))) > 1 + IKFAST_SINCOS_THRESH)
+                      continue;
+                    IkReal x64 = IKasin(((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                                         (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                                         (((IkReal(0.188038678783115)) * (py) * (sj0)))));
+                    j2array[0] = ((IkReal(3.10482123119329)) + (((IkReal(-1.00000000000000)) * (x64))));
+                    sj2array[0] = IKsin(j2array[0]);
+                    cj2array[0] = IKcos(j2array[0]);
+                    j2array[1] = ((IkReal(6.24641388478308)) + (x64));
+                    sj2array[1] = IKsin(j2array[1]);
+                    cj2array[1] = IKcos(j2array[1]);
+                    if (j2array[0] > IKPI)
+                    {
+                      j2array[0] -= IK2PI;
+                    }
+                    else if (j2array[0] < -IKPI)
+                    {
+                      j2array[0] += IK2PI;
+                    }
+                    j2valid[0] = true;
+                    if (j2array[1] > IKPI)
+                    {
+                      j2array[1] -= IK2PI;
+                    }
+                    else if (j2array[1] < -IKPI)
+                    {
+                      j2array[1] += IK2PI;
+                    }
+                    j2valid[1] = true;
+                    for (int ij2 = 0; ij2 < 2; ++ij2)
+                    {
+                      if (!j2valid[ij2])
+                      {
+                        continue;
+                      }
+                      _ij2[0] = ij2;
+                      _ij2[1] = -1;
+                      for (int iij2 = ij2 + 1; iij2 < 2; ++iij2)
+                      {
+                        if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                            IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                        {
+                          j2valid[iij2] = false;
+                          _ij2[1] = iij2;
+                          break;
+                        }
+                      }
+                      j2 = j2array[ij2];
+                      cj2 = cj2array[ij2];
+                      sj2 = sj2array[ij2];
+
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst0;
+                        IkReal x65 = ((py) * (sj0));
+                        IkReal x66 = ((IkReal(1.49995000000000)) * (sj2));
+                        IkReal x67 = ((cj0) * (px));
+                        IkReal x68 = ((IkReal(0.0550600000000000)) * (cj2));
+                        gconst0 = IKsign(
+                            ((IkReal(0.440927223000000)) + (((IkReal(-1.24990000000000)) * (x65))) +
+                             (((IkReal(-1.24990000000000)) * (x67))) + (((IkReal(0.0550600000000000)) * (pz) * (sj2))) +
+                             (((x67) * (x68))) + (((IkReal(-0.0194235162000000)) * (cj2))) +
+                             (((IkReal(-1.49995000000000)) * (cj2) * (pz))) + (((x66) * (x67))) +
+                             (((IkReal(0.000100000000000000)) * (pz))) + (((IkReal(-0.529137361500000)) * (sj2))) +
+                             (((x65) * (x68))) + (((x65) * (x66)))));
+                        IkReal x69 = ((cj0) * (px));
+                        IkReal x70 = ((py) * (sj0));
+                        IkReal x71 = ((IkReal(550.600000000000)) * (cj2));
+                        IkReal x72 = ((IkReal(14999.5000000000)) * (sj2));
+                        dummyeval[0] =
+                            ((IkReal(4409.27223000000)) + (((IkReal(-12499.0000000000)) * (x69))) +
+                             (((IkReal(-5291.37361500000)) * (sj2))) + (((IkReal(-194.235162000000)) * (cj2))) +
+                             (((x69) * (x72))) + (((x69) * (x71))) + (pz) + (((x70) * (x71))) + (((x70) * (x72))) +
+                             (((IkReal(-14999.5000000000)) * (cj2) * (pz))) + (((IkReal(-12499.0000000000)) * (x70))) +
+                             (((IkReal(550.600000000000)) * (pz) * (sj2))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal dummyeval[1];
+                            IkReal gconst1;
+                            IkReal x73 = ((cj0) * (px));
+                            IkReal x74 = ((py) * (sj0));
+                            gconst1 = IKsign(
+                                ((IkReal(-0.124446672900000)) + (((IkReal(-1.00000000000000)) * ((x74) * (x74)))) +
+                                 (((IkReal(-2.00000000000000)) * (x73) * (x74))) +
+                                 (((IkReal(-1.00000000000000)) * ((pz) * (pz)))) +
+                                 (((IkReal(-1.00000000000000)) * ((x73) * (x73)))) +
+                                 (((IkReal(0.705540000000000)) * (x73))) + (((IkReal(0.705540000000000)) * (x74)))));
+                            IkReal x75 = ((py) * (sj0));
+                            IkReal x76 = ((cj0) * (px));
+                            dummyeval[0] =
+                                ((IkReal(-1.00000000000000)) + (((IkReal(-8.03557039088990)) * ((x76) * (x76)))) +
+                                 (((IkReal(5.66941633358846)) * (x75))) + (((IkReal(5.66941633358846)) * (x76))) +
+                                 (((IkReal(-8.03557039088990)) * ((pz) * (pz)))) +
+                                 (((IkReal(-8.03557039088990)) * ((x75) * (x75)))) +
+                                 (((IkReal(-16.0711407817798)) * (x75) * (x76))));
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              continue;
+                            }
+                            else
+                            {
+                              {
+                                IkReal j1array[1], cj1array[1], sj1array[1];
+                                bool j1valid[1] = { false };
+                                _nj1 = 1;
+                                IkReal x77 = ((py) * (sj0));
+                                IkReal x78 = ((IkReal(1.49995000000000)) * (pz));
+                                IkReal x79 = ((IkReal(0.0550600000000000)) * (cj2));
+                                IkReal x80 = ((cj0) * (px));
+                                IkReal x81 = ((IkReal(0.0550600000000000)) * (sj2));
+                                IkReal x82 = ((IkReal(1.49995000000000)) * (x77));
+                                IkReal x83 = ((IkReal(0.0550600000000000)) * (x80));
+                                if (IKabs(((gconst1) *
+                                           (((IkReal(0.440927223000000)) + (((sj2) * (x82))) + (((x79) * (x80))) +
+                                             (((IkReal(1.49995000000000)) * (sj2) * (x80))) +
+                                             (((IkReal(-1.24990000000000)) * (x77))) +
+                                             (((IkReal(-1.24990000000000)) * (x80))) +
+                                             (((IkReal(-0.0194235162000000)) * (cj2))) + (((cj2) * (x78))) +
+                                             (((IkReal(-0.000100000000000000)) * (pz))) + (((x77) * (x79))) +
+                                             (((IkReal(-1.00000000000000)) * (pz) * (x81))) +
+                                             (((IkReal(-0.529137361500000)) * (sj2))))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((gconst1) *
+                                           (((IkReal(-3.52770000000000e-5)) + (((x77) * (x81))) +
+                                             (((IkReal(0.000100000000000000)) * (x80))) + (((pz) * (x79))) +
+                                             (((IkReal(0.000100000000000000)) * (x77))) +
+                                             (((IkReal(-1.24990000000000)) * (pz))) +
+                                             (((IkReal(0.529137361500000)) * (cj2))) +
+                                             (((IkReal(-1.49995000000000)) * (cj2) * (x80))) + (((sj2) * (x78))) +
+                                             (((IkReal(-0.0194235162000000)) * (sj2))) + (((x80) * (x81))) +
+                                             (((IkReal(-1.00000000000000)) * (cj2) * (x82))))))) <
+                                        IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                j1array[0] = IKatan2(
+                                    ((gconst1) * (((IkReal(0.440927223000000)) + (((sj2) * (x82))) + (((x79) * (x80))) +
+                                                   (((IkReal(1.49995000000000)) * (sj2) * (x80))) +
+                                                   (((IkReal(-1.24990000000000)) * (x77))) +
+                                                   (((IkReal(-1.24990000000000)) * (x80))) +
+                                                   (((IkReal(-0.0194235162000000)) * (cj2))) + (((cj2) * (x78))) +
+                                                   (((IkReal(-0.000100000000000000)) * (pz))) + (((x77) * (x79))) +
+                                                   (((IkReal(-1.00000000000000)) * (pz) * (x81))) +
+                                                   (((IkReal(-0.529137361500000)) * (sj2)))))),
+                                    ((gconst1) * (((IkReal(-3.52770000000000e-5)) + (((x77) * (x81))) +
+                                                   (((IkReal(0.000100000000000000)) * (x80))) + (((pz) * (x79))) +
+                                                   (((IkReal(0.000100000000000000)) * (x77))) +
+                                                   (((IkReal(-1.24990000000000)) * (pz))) +
+                                                   (((IkReal(0.529137361500000)) * (cj2))) +
+                                                   (((IkReal(-1.49995000000000)) * (cj2) * (x80))) + (((sj2) * (x78))) +
+                                                   (((IkReal(-0.0194235162000000)) * (sj2))) + (((x80) * (x81))) +
+                                                   (((IkReal(-1.00000000000000)) * (cj2) * (x82)))))));
+                                sj1array[0] = IKsin(j1array[0]);
+                                cj1array[0] = IKcos(j1array[0]);
+                                if (j1array[0] > IKPI)
+                                {
+                                  j1array[0] -= IK2PI;
+                                }
+                                else if (j1array[0] < -IKPI)
+                                {
+                                  j1array[0] += IK2PI;
+                                }
+                                j1valid[0] = true;
+                                for (int ij1 = 0; ij1 < 1; ++ij1)
+                                {
+                                  if (!j1valid[ij1])
+                                  {
+                                    continue;
+                                  }
+                                  _ij1[0] = ij1;
+                                  _ij1[1] = -1;
+                                  for (int iij1 = ij1 + 1; iij1 < 1; ++iij1)
+                                  {
+                                    if (j1valid[iij1] &&
+                                        IKabs(cj1array[ij1] - cj1array[iij1]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj1array[ij1] - sj1array[iij1]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j1valid[iij1] = false;
+                                      _ij1[1] = iij1;
+                                      break;
+                                    }
+                                  }
+                                  j1 = j1array[ij1];
+                                  cj1 = cj1array[ij1];
+                                  sj1 = sj1array[ij1];
+                                  {
+                                    IkReal evalcond[5];
+                                    IkReal x84 = IKsin(j1);
+                                    IkReal x85 = IKcos(j1);
+                                    IkReal x86 = ((IkReal(1.49995000000000)) * (sj2));
+                                    IkReal x87 = ((cj0) * (px));
+                                    IkReal x88 = ((IkReal(0.0550600000000000)) * (cj2));
+                                    IkReal x89 = ((IkReal(1.49995000000000)) * (cj2));
+                                    IkReal x90 = ((py) * (sj0));
+                                    IkReal x91 = ((IkReal(0.0550600000000000)) * (sj2));
+                                    IkReal x92 = ((IkReal(1.00000000000000)) * (x85));
+                                    IkReal x93 = ((IkReal(2.49980000000000)) * (x84));
+                                    IkReal x94 = ((pz) * (x85));
+                                    IkReal x95 = ((pz) * (x84));
+                                    IkReal x96 = ((IkReal(0.000200000000000000)) * (x85));
+                                    evalcond[0] =
+                                        ((IkReal(-1.24990000000000)) + (((x84) * (x87))) + (x88) + (x86) + (x94) +
+                                         (((IkReal(-0.352770000000000)) * (x84))) + (((x84) * (x90))));
+                                    evalcond[1] = ((IkReal(-0.000100000000000000)) +
+                                                   (((IkReal(-1.00000000000000)) * (x90) * (x92))) +
+                                                   (((IkReal(-1.00000000000000)) * (x87) * (x92))) + (x89) + (x95) +
+                                                   (((IkReal(0.352770000000000)) * (x85))) +
+                                                   (((IkReal(-1.00000000000000)) * (x91))));
+                                    evalcond[2] = ((((x84) * (x89))) + (((x85) * (x88))) + (((x85) * (x86))) +
+                                                   (((IkReal(-1.24990000000000)) * (x85))) + (pz) +
+                                                   (((IkReal(-1.00000000000000)) * (x84) * (x91))) +
+                                                   (((IkReal(-0.000100000000000000)) * (x84))));
+                                    evalcond[3] = ((IkReal(0.352770000000000)) + (((x85) * (x89))) +
+                                                   (((IkReal(1.24990000000000)) * (x84))) +
+                                                   (((IkReal(-1.00000000000000)) * (x87))) +
+                                                   (((IkReal(-1.00000000000000)) * (x84) * (x86))) +
+                                                   (((IkReal(-1.00000000000000)) * (x84) * (x88))) +
+                                                   (((IkReal(-1.00000000000000)) * (x90))) +
+                                                   (((IkReal(-0.000100000000000000)) * (x85))) +
+                                                   (((IkReal(-1.00000000000000)) * (x85) * (x91))));
+                                    evalcond[4] = ((IkReal(0.566185873600000)) + (((x87) * (x93))) +
+                                                   (((IkReal(-0.881854446000000)) * (x84))) +
+                                                   (((IkReal(-1.00000000000000)) * (x90) * (x96))) +
+                                                   (((IkReal(-1.00000000000000)) * (x87) * (x96))) +
+                                                   (((IkReal(-1.00000000000000)) * (pp))) +
+                                                   (((IkReal(7.05540000000000e-5)) * (x85))) + (((x90) * (x93))) +
+                                                   (((IkReal(2.49980000000000)) * (x94))) +
+                                                   (((IkReal(0.705540000000000)) * (x90))) +
+                                                   (((IkReal(0.000200000000000000)) * (x95))) +
+                                                   (((IkReal(0.705540000000000)) * (x87))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  rotationfunction0(solutions);
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          {
+                            IkReal j1array[1], cj1array[1], sj1array[1];
+                            bool j1valid[1] = { false };
+                            _nj1 = 1;
+                            IkReal x236 = (cj2) * (cj2);
+                            IkReal x237 = (sj2) * (sj2);
+                            IkReal x238 = ((cj2) * (sj2));
+                            IkReal x239 = ((IkReal(1.00000000000000)) * (pz));
+                            if (IKabs(((gconst0) *
+                                       (((IkReal(-1.56225001000000)) + (((IkReal(3.74957501000000)) * (sj2))) +
+                                         (((IkReal(-0.00303160360000000)) * (x236))) + ((pz) * (pz)) +
+                                         (((IkReal(0.137638988000000)) * (cj2))) +
+                                         (((IkReal(-0.165174494000000)) * (x238))) +
+                                         (((IkReal(-2.24985000250000)) * (x237))))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((gconst0) * (((IkReal(0.000124990000000000)) +
+                                                     (((IkReal(-1.00000000000000)) * (py) * (sj0) * (x239))) +
+                                                     (((IkReal(-1.87479301100000)) * (cj2))) +
+                                                     (((IkReal(0.352770000000000)) * (pz))) +
+                                                     (((IkReal(-0.0825872470000000)) * (x237))) +
+                                                     (((IkReal(2.24681839890000)) * (x238))) +
+                                                     (((IkReal(-1.00000000000000)) * (cj0) * (px) * (x239))) +
+                                                     (((IkReal(0.0686694990000000)) * (sj2))) +
+                                                     (((IkReal(0.0825872470000000)) * (x236))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j1array[0] = IKatan2(
+                                ((gconst0) *
+                                 (((IkReal(-1.56225001000000)) + (((IkReal(3.74957501000000)) * (sj2))) +
+                                   (((IkReal(-0.00303160360000000)) * (x236))) + ((pz) * (pz)) +
+                                   (((IkReal(0.137638988000000)) * (cj2))) + (((IkReal(-0.165174494000000)) * (x238))) +
+                                   (((IkReal(-2.24985000250000)) * (x237)))))),
+                                ((gconst0) *
+                                 (((IkReal(0.000124990000000000)) +
+                                   (((IkReal(-1.00000000000000)) * (py) * (sj0) * (x239))) +
+                                   (((IkReal(-1.87479301100000)) * (cj2))) + (((IkReal(0.352770000000000)) * (pz))) +
+                                   (((IkReal(-0.0825872470000000)) * (x237))) +
+                                   (((IkReal(2.24681839890000)) * (x238))) +
+                                   (((IkReal(-1.00000000000000)) * (cj0) * (px) * (x239))) +
+                                   (((IkReal(0.0686694990000000)) * (sj2))) +
+                                   (((IkReal(0.0825872470000000)) * (x236)))))));
+                            sj1array[0] = IKsin(j1array[0]);
+                            cj1array[0] = IKcos(j1array[0]);
+                            if (j1array[0] > IKPI)
+                            {
+                              j1array[0] -= IK2PI;
+                            }
+                            else if (j1array[0] < -IKPI)
+                            {
+                              j1array[0] += IK2PI;
+                            }
+                            j1valid[0] = true;
+                            for (int ij1 = 0; ij1 < 1; ++ij1)
+                            {
+                              if (!j1valid[ij1])
+                              {
+                                continue;
+                              }
+                              _ij1[0] = ij1;
+                              _ij1[1] = -1;
+                              for (int iij1 = ij1 + 1; iij1 < 1; ++iij1)
+                              {
+                                if (j1valid[iij1] && IKabs(cj1array[ij1] - cj1array[iij1]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj1array[ij1] - sj1array[iij1]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j1valid[iij1] = false;
+                                  _ij1[1] = iij1;
+                                  break;
+                                }
+                              }
+                              j1 = j1array[ij1];
+                              cj1 = cj1array[ij1];
+                              sj1 = sj1array[ij1];
+                              {
+                                IkReal evalcond[5];
+                                IkReal x240 = IKsin(j1);
+                                IkReal x241 = IKcos(j1);
+                                IkReal x242 = ((IkReal(1.49995000000000)) * (sj2));
+                                IkReal x243 = ((cj0) * (px));
+                                IkReal x244 = ((IkReal(0.0550600000000000)) * (cj2));
+                                IkReal x245 = ((IkReal(1.49995000000000)) * (cj2));
+                                IkReal x246 = ((py) * (sj0));
+                                IkReal x247 = ((IkReal(0.0550600000000000)) * (sj2));
+                                IkReal x248 = ((IkReal(1.00000000000000)) * (x241));
+                                IkReal x249 = ((IkReal(2.49980000000000)) * (x240));
+                                IkReal x250 = ((pz) * (x241));
+                                IkReal x251 = ((pz) * (x240));
+                                IkReal x252 = ((IkReal(0.000200000000000000)) * (x241));
+                                evalcond[0] = ((IkReal(-1.24990000000000)) + (((x240) * (x243))) + (((x240) * (x246))) +
+                                               (((IkReal(-0.352770000000000)) * (x240))) + (x250) + (x242) + (x244));
+                                evalcond[1] =
+                                    ((IkReal(-0.000100000000000000)) + (((IkReal(0.352770000000000)) * (x241))) +
+                                     (((IkReal(-1.00000000000000)) * (x243) * (x248))) + (x251) + (x245) +
+                                     (((IkReal(-1.00000000000000)) * (x247))) +
+                                     (((IkReal(-1.00000000000000)) * (x246) * (x248))));
+                                evalcond[2] = ((((x240) * (x245))) + (((IkReal(-1.24990000000000)) * (x241))) + (pz) +
+                                               (((x241) * (x244))) + (((x241) * (x242))) +
+                                               (((IkReal(-1.00000000000000)) * (x240) * (x247))) +
+                                               (((IkReal(-0.000100000000000000)) * (x240))));
+                                evalcond[3] = ((IkReal(0.352770000000000)) + (((IkReal(-1.00000000000000)) * (x246))) +
+                                               (((IkReal(-1.00000000000000)) * (x243))) +
+                                               (((IkReal(-1.00000000000000)) * (x241) * (x247))) + (((x241) * (x245))) +
+                                               (((IkReal(-1.00000000000000)) * (x240) * (x242))) +
+                                               (((IkReal(-1.00000000000000)) * (x240) * (x244))) +
+                                               (((IkReal(1.24990000000000)) * (x240))) +
+                                               (((IkReal(-0.000100000000000000)) * (x241))));
+                                evalcond[4] = ((IkReal(0.566185873600000)) + (((IkReal(2.49980000000000)) * (x250))) +
+                                               (((IkReal(-1.00000000000000)) * (x246) * (x252))) +
+                                               (((IkReal(-1.00000000000000)) * (pp))) +
+                                               (((IkReal(0.000200000000000000)) * (x251))) +
+                                               (((IkReal(-0.881854446000000)) * (x240))) +
+                                               (((IkReal(0.705540000000000)) * (x243))) +
+                                               (((IkReal(0.705540000000000)) * (x246))) + (((x246) * (x249))) +
+                                               (((x243) * (x249))) + (((IkReal(-1.00000000000000)) * (x243) * (x252))) +
+                                               (((IkReal(7.05540000000000e-5)) * (x241))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              rotationfunction0(solutions);
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        else
+        {
+          {
+            IkReal j0array[2], cj0array[2], sj0array[2];
+            bool j0valid[2] = { false };
+            _nj0 = 2;
+            if (IKabs(((IkReal(-1.00000000000000)) * (py))) < IKFAST_ATAN2_MAGTHRESH &&
+                IKabs(px) < IKFAST_ATAN2_MAGTHRESH)
+              continue;
+            IkReal x253 = ((IkReal(1.00000000000000)) * (IKatan2(((IkReal(-1.00000000000000)) * (py)), px)));
+            if (((((px) * (px)) + ((py) * (py)))) < (IkReal)-0.00001)
+              continue;
+            if ((((IkReal(0.000980000000000000)) *
+                  (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                        ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                        (IkReal)1.0e30)))) < -1 - IKFAST_SINCOS_THRESH ||
+                (((IkReal(0.000980000000000000)) *
+                  (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                        ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                        (IkReal)1.0e30)))) > 1 + IKFAST_SINCOS_THRESH)
+              continue;
+            IkReal x254 = IKasin(
+                ((IkReal(0.000980000000000000)) * (((IKabs(IKabs(IKsqrt((((px) * (px)) + ((py) * (py)))))) != 0) ?
+                                                        ((IkReal)1 / (IKabs(IKsqrt((((px) * (px)) + ((py) * (py))))))) :
+                                                        (IkReal)1.0e30))));
+            j0array[0] = ((x254) + (((IkReal(-1.00000000000000)) * (x253))));
+            sj0array[0] = IKsin(j0array[0]);
+            cj0array[0] = IKcos(j0array[0]);
+            j0array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x254))) +
+                          (((IkReal(-1.00000000000000)) * (x253))));
+            sj0array[1] = IKsin(j0array[1]);
+            cj0array[1] = IKcos(j0array[1]);
+            if (j0array[0] > IKPI)
+            {
+              j0array[0] -= IK2PI;
+            }
+            else if (j0array[0] < -IKPI)
+            {
+              j0array[0] += IK2PI;
+            }
+            j0valid[0] = true;
+            if (j0array[1] > IKPI)
+            {
+              j0array[1] -= IK2PI;
+            }
+            else if (j0array[1] < -IKPI)
+            {
+              j0array[1] += IK2PI;
+            }
+            j0valid[1] = true;
+            for (int ij0 = 0; ij0 < 2; ++ij0)
+            {
+              if (!j0valid[ij0])
+              {
+                continue;
+              }
+              _ij0[0] = ij0;
+              _ij0[1] = -1;
+              for (int iij0 = ij0 + 1; iij0 < 2; ++iij0)
+              {
+                if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                    IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                {
+                  j0valid[iij0] = false;
+                  _ij0[1] = iij0;
+                  break;
+                }
+              }
+              j0 = j0array[ij0];
+              cj0 = cj0array[ij0];
+              sj0 = sj0array[ij0];
+
+              {
+                IkReal j2array[2], cj2array[2], sj2array[2];
+                bool j2valid[2] = { false };
+                _nj2 = 2;
+                if ((((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                      (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                      (((IkReal(0.188038678783115)) * (py) * (sj0))))) < -1 - IKFAST_SINCOS_THRESH ||
+                    (((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                      (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                      (((IkReal(0.188038678783115)) * (py) * (sj0))))) > 1 + IKFAST_SINCOS_THRESH)
+                  continue;
+                IkReal x255 = IKasin(((IkReal(0.983631974086230)) + (((IkReal(-0.266517389209847)) * (pp))) +
+                                      (((IkReal(0.188038678783115)) * (cj0) * (px))) +
+                                      (((IkReal(0.188038678783115)) * (py) * (sj0)))));
+                j2array[0] = ((IkReal(3.10482123119329)) + (((IkReal(-1.00000000000000)) * (x255))));
+                sj2array[0] = IKsin(j2array[0]);
+                cj2array[0] = IKcos(j2array[0]);
+                j2array[1] = ((IkReal(6.24641388478308)) + (x255));
+                sj2array[1] = IKsin(j2array[1]);
+                cj2array[1] = IKcos(j2array[1]);
+                if (j2array[0] > IKPI)
+                {
+                  j2array[0] -= IK2PI;
+                }
+                else if (j2array[0] < -IKPI)
+                {
+                  j2array[0] += IK2PI;
+                }
+                j2valid[0] = true;
+                if (j2array[1] > IKPI)
+                {
+                  j2array[1] -= IK2PI;
+                }
+                else if (j2array[1] < -IKPI)
+                {
+                  j2array[1] += IK2PI;
+                }
+                j2valid[1] = true;
+                for (int ij2 = 0; ij2 < 2; ++ij2)
+                {
+                  if (!j2valid[ij2])
+                  {
+                    continue;
+                  }
+                  _ij2[0] = ij2;
+                  _ij2[1] = -1;
+                  for (int iij2 = ij2 + 1; iij2 < 2; ++iij2)
+                  {
+                    if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                        IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                    {
+                      j2valid[iij2] = false;
+                      _ij2[1] = iij2;
+                      break;
+                    }
+                  }
+                  j2 = j2array[ij2];
+                  cj2 = cj2array[ij2];
+                  sj2 = sj2array[ij2];
+
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst0;
+                    IkReal x256 = ((py) * (sj0));
+                    IkReal x257 = ((IkReal(1.49995000000000)) * (sj2));
+                    IkReal x258 = ((cj0) * (px));
+                    IkReal x259 = ((IkReal(0.0550600000000000)) * (cj2));
+                    gconst0 = IKsign(
+                        ((IkReal(0.440927223000000)) + (((x256) * (x257))) + (((x256) * (x259))) + (((x257) * (x258))) +
+                         (((IkReal(0.0550600000000000)) * (pz) * (sj2))) + (((IkReal(-0.0194235162000000)) * (cj2))) +
+                         (((IkReal(-1.49995000000000)) * (cj2) * (pz))) + (((IkReal(-1.24990000000000)) * (x258))) +
+                         (((IkReal(-1.24990000000000)) * (x256))) + (((x258) * (x259))) +
+                         (((IkReal(0.000100000000000000)) * (pz))) + (((IkReal(-0.529137361500000)) * (sj2)))));
+                    IkReal x260 = ((cj0) * (px));
+                    IkReal x261 = ((py) * (sj0));
+                    IkReal x262 = ((IkReal(550.600000000000)) * (cj2));
+                    IkReal x263 = ((IkReal(14999.5000000000)) * (sj2));
+                    dummyeval[0] =
+                        ((IkReal(4409.27223000000)) + (((x260) * (x262))) + (((x260) * (x263))) +
+                         (((IkReal(-5291.37361500000)) * (sj2))) + (((IkReal(-194.235162000000)) * (cj2))) +
+                         (((IkReal(-12499.0000000000)) * (x261))) + (((IkReal(-12499.0000000000)) * (x260))) + (pz) +
+                         (((x261) * (x263))) + (((x261) * (x262))) + (((IkReal(-14999.5000000000)) * (cj2) * (pz))) +
+                         (((IkReal(550.600000000000)) * (pz) * (sj2))));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst1;
+                        IkReal x264 = ((cj0) * (px));
+                        IkReal x265 = ((py) * (sj0));
+                        gconst1 = IKsign(
+                            ((IkReal(-0.124446672900000)) + (((IkReal(-1.00000000000000)) * ((x264) * (x264)))) +
+                             (((IkReal(-1.00000000000000)) * ((pz) * (pz)))) +
+                             (((IkReal(-2.00000000000000)) * (x264) * (x265))) +
+                             (((IkReal(-1.00000000000000)) * ((x265) * (x265)))) +
+                             (((IkReal(0.705540000000000)) * (x264))) + (((IkReal(0.705540000000000)) * (x265)))));
+                        IkReal x266 = ((py) * (sj0));
+                        IkReal x267 = ((cj0) * (px));
+                        dummyeval[0] =
+                            ((IkReal(-1.00000000000000)) + (((IkReal(-8.03557039088990)) * ((x266) * (x266)))) +
+                             (((IkReal(-16.0711407817798)) * (x266) * (x267))) +
+                             (((IkReal(-8.03557039088990)) * ((pz) * (pz)))) + (((IkReal(5.66941633358846)) * (x266))) +
+                             (((IkReal(5.66941633358846)) * (x267))) +
+                             (((IkReal(-8.03557039088990)) * ((x267) * (x267)))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          continue;
+                        }
+                        else
+                        {
+                          {
+                            IkReal j1array[1], cj1array[1], sj1array[1];
+                            bool j1valid[1] = { false };
+                            _nj1 = 1;
+                            IkReal x268 = ((py) * (sj0));
+                            IkReal x269 = ((IkReal(1.49995000000000)) * (pz));
+                            IkReal x270 = ((IkReal(0.0550600000000000)) * (cj2));
+                            IkReal x271 = ((cj0) * (px));
+                            IkReal x272 = ((IkReal(0.0550600000000000)) * (sj2));
+                            IkReal x273 = ((IkReal(1.49995000000000)) * (x268));
+                            IkReal x274 = ((IkReal(0.0550600000000000)) * (x271));
+                            if (IKabs(((gconst1) *
+                                       (((IkReal(0.440927223000000)) + (((IkReal(-1.00000000000000)) * (pz) * (x272))) +
+                                         (((sj2) * (x273))) + (((x270) * (x271))) +
+                                         (((IkReal(-1.24990000000000)) * (x271))) +
+                                         (((IkReal(-1.24990000000000)) * (x268))) +
+                                         (((IkReal(1.49995000000000)) * (sj2) * (x271))) +
+                                         (((IkReal(-0.0194235162000000)) * (cj2))) +
+                                         (((IkReal(-0.000100000000000000)) * (pz))) + (((cj2) * (x269))) +
+                                         (((IkReal(-0.529137361500000)) * (sj2))) + (((x268) * (x270))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs((
+                                    (gconst1) *
+                                    (((IkReal(-3.52770000000000e-5)) + (((IkReal(0.000100000000000000)) * (x268))) +
+                                      (((x271) * (x272))) + (((IkReal(0.000100000000000000)) * (x271))) +
+                                      (((IkReal(-1.24990000000000)) * (pz))) + (((IkReal(0.529137361500000)) * (cj2))) +
+                                      (((sj2) * (x269))) + (((IkReal(-1.49995000000000)) * (cj2) * (x271))) +
+                                      (((IkReal(-1.00000000000000)) * (cj2) * (x273))) +
+                                      (((IkReal(-0.0194235162000000)) * (sj2))) + (((pz) * (x270))) +
+                                      (((x268) * (x272))))))) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j1array[0] = IKatan2(
+                                ((gconst1) *
+                                 (((IkReal(0.440927223000000)) + (((IkReal(-1.00000000000000)) * (pz) * (x272))) +
+                                   (((sj2) * (x273))) + (((x270) * (x271))) + (((IkReal(-1.24990000000000)) * (x271))) +
+                                   (((IkReal(-1.24990000000000)) * (x268))) +
+                                   (((IkReal(1.49995000000000)) * (sj2) * (x271))) +
+                                   (((IkReal(-0.0194235162000000)) * (cj2))) +
+                                   (((IkReal(-0.000100000000000000)) * (pz))) + (((cj2) * (x269))) +
+                                   (((IkReal(-0.529137361500000)) * (sj2))) + (((x268) * (x270)))))),
+                                ((gconst1) *
+                                 (((IkReal(-3.52770000000000e-5)) + (((IkReal(0.000100000000000000)) * (x268))) +
+                                   (((x271) * (x272))) + (((IkReal(0.000100000000000000)) * (x271))) +
+                                   (((IkReal(-1.24990000000000)) * (pz))) + (((IkReal(0.529137361500000)) * (cj2))) +
+                                   (((sj2) * (x269))) + (((IkReal(-1.49995000000000)) * (cj2) * (x271))) +
+                                   (((IkReal(-1.00000000000000)) * (cj2) * (x273))) +
+                                   (((IkReal(-0.0194235162000000)) * (sj2))) + (((pz) * (x270))) +
+                                   (((x268) * (x272)))))));
+                            sj1array[0] = IKsin(j1array[0]);
+                            cj1array[0] = IKcos(j1array[0]);
+                            if (j1array[0] > IKPI)
+                            {
+                              j1array[0] -= IK2PI;
+                            }
+                            else if (j1array[0] < -IKPI)
+                            {
+                              j1array[0] += IK2PI;
+                            }
+                            j1valid[0] = true;
+                            for (int ij1 = 0; ij1 < 1; ++ij1)
+                            {
+                              if (!j1valid[ij1])
+                              {
+                                continue;
+                              }
+                              _ij1[0] = ij1;
+                              _ij1[1] = -1;
+                              for (int iij1 = ij1 + 1; iij1 < 1; ++iij1)
+                              {
+                                if (j1valid[iij1] && IKabs(cj1array[ij1] - cj1array[iij1]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj1array[ij1] - sj1array[iij1]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j1valid[iij1] = false;
+                                  _ij1[1] = iij1;
+                                  break;
+                                }
+                              }
+                              j1 = j1array[ij1];
+                              cj1 = cj1array[ij1];
+                              sj1 = sj1array[ij1];
+                              {
+                                IkReal evalcond[5];
+                                IkReal x275 = IKsin(j1);
+                                IkReal x276 = IKcos(j1);
+                                IkReal x277 = ((IkReal(1.49995000000000)) * (sj2));
+                                IkReal x278 = ((cj0) * (px));
+                                IkReal x279 = ((IkReal(0.0550600000000000)) * (cj2));
+                                IkReal x280 = ((IkReal(1.49995000000000)) * (cj2));
+                                IkReal x281 = ((py) * (sj0));
+                                IkReal x282 = ((IkReal(0.0550600000000000)) * (sj2));
+                                IkReal x283 = ((IkReal(1.00000000000000)) * (x276));
+                                IkReal x284 = ((IkReal(2.49980000000000)) * (x275));
+                                IkReal x285 = ((pz) * (x276));
+                                IkReal x286 = ((pz) * (x275));
+                                IkReal x287 = ((IkReal(0.000200000000000000)) * (x276));
+                                evalcond[0] = ((IkReal(-1.24990000000000)) + (((x275) * (x278))) +
+                                               (((IkReal(-0.352770000000000)) * (x275))) + (x277) + (x279) + (x285) +
+                                               (((x275) * (x281))));
+                                evalcond[1] =
+                                    ((IkReal(-0.000100000000000000)) + (((IkReal(0.352770000000000)) * (x276))) +
+                                     (((IkReal(-1.00000000000000)) * (x281) * (x283))) + (x286) + (x280) +
+                                     (((IkReal(-1.00000000000000)) * (x282))) +
+                                     (((IkReal(-1.00000000000000)) * (x278) * (x283))));
+                                evalcond[2] = ((((IkReal(-1.24990000000000)) * (x276))) + (((x275) * (x280))) + (pz) +
+                                               (((x276) * (x277))) + (((x276) * (x279))) +
+                                               (((IkReal(-1.00000000000000)) * (x275) * (x282))) +
+                                               (((IkReal(-0.000100000000000000)) * (x275))));
+                                evalcond[3] = ((IkReal(0.352770000000000)) + (((IkReal(-1.00000000000000)) * (x278))) +
+                                               (((IkReal(-1.00000000000000)) * (x276) * (x282))) +
+                                               (((IkReal(-1.00000000000000)) * (x281))) +
+                                               (((IkReal(1.24990000000000)) * (x275))) +
+                                               (((IkReal(-1.00000000000000)) * (x275) * (x277))) +
+                                               (((IkReal(-1.00000000000000)) * (x275) * (x279))) + (((x276) * (x280))) +
+                                               (((IkReal(-0.000100000000000000)) * (x276))));
+                                evalcond[4] = ((IkReal(0.566185873600000)) + (((x278) * (x284))) +
+                                               (((IkReal(2.49980000000000)) * (x285))) +
+                                               (((IkReal(-1.00000000000000)) * (x281) * (x287))) +
+                                               (((IkReal(0.000200000000000000)) * (x286))) +
+                                               (((IkReal(-1.00000000000000)) * (pp))) +
+                                               (((IkReal(-0.881854446000000)) * (x275))) +
+                                               (((IkReal(0.705540000000000)) * (x281))) + (((x281) * (x284))) +
+                                               (((IkReal(0.705540000000000)) * (x278))) +
+                                               (((IkReal(7.05540000000000e-5)) * (x276))) +
+                                               (((IkReal(-1.00000000000000)) * (x278) * (x287))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              rotationfunction0(solutions);
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j1array[1], cj1array[1], sj1array[1];
+                        bool j1valid[1] = { false };
+                        _nj1 = 1;
+                        IkReal x288 = (cj2) * (cj2);
+                        IkReal x289 = (sj2) * (sj2);
+                        IkReal x290 = ((cj2) * (sj2));
+                        IkReal x291 = ((IkReal(1.00000000000000)) * (pz));
+                        if (IKabs(((gconst0) * (((IkReal(-1.56225001000000)) + (((IkReal(3.74957501000000)) * (sj2))) +
+                                                 (((IkReal(-0.165174494000000)) * (x290))) +
+                                                 (((IkReal(-0.00303160360000000)) * (x288))) + ((pz) * (pz)) +
+                                                 (((IkReal(0.137638988000000)) * (cj2))) +
+                                                 (((IkReal(-2.24985000250000)) * (x289))))))) <
+                                IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(
+                                ((gconst0) *
+                                 (((IkReal(0.000124990000000000)) +
+                                   (((IkReal(-1.00000000000000)) * (cj0) * (px) * (x291))) +
+                                   (((IkReal(0.0825872470000000)) * (x288))) + (((IkReal(-1.87479301100000)) * (cj2))) +
+                                   (((IkReal(0.352770000000000)) * (pz))) + (((IkReal(-0.0825872470000000)) * (x289))) +
+                                   (((IkReal(-1.00000000000000)) * (py) * (sj0) * (x291))) +
+                                   (((IkReal(2.24681839890000)) * (x290))) +
+                                   (((IkReal(0.0686694990000000)) * (sj2))))))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j1array[0] = IKatan2(
+                            ((gconst0) *
+                             (((IkReal(-1.56225001000000)) + (((IkReal(3.74957501000000)) * (sj2))) +
+                               (((IkReal(-0.165174494000000)) * (x290))) + (((IkReal(-0.00303160360000000)) * (x288))) +
+                               ((pz) * (pz)) + (((IkReal(0.137638988000000)) * (cj2))) +
+                               (((IkReal(-2.24985000250000)) * (x289)))))),
+                            ((gconst0) *
+                             (((IkReal(0.000124990000000000)) +
+                               (((IkReal(-1.00000000000000)) * (cj0) * (px) * (x291))) +
+                               (((IkReal(0.0825872470000000)) * (x288))) + (((IkReal(-1.87479301100000)) * (cj2))) +
+                               (((IkReal(0.352770000000000)) * (pz))) + (((IkReal(-0.0825872470000000)) * (x289))) +
+                               (((IkReal(-1.00000000000000)) * (py) * (sj0) * (x291))) +
+                               (((IkReal(2.24681839890000)) * (x290))) + (((IkReal(0.0686694990000000)) * (sj2)))))));
+                        sj1array[0] = IKsin(j1array[0]);
+                        cj1array[0] = IKcos(j1array[0]);
+                        if (j1array[0] > IKPI)
+                        {
+                          j1array[0] -= IK2PI;
+                        }
+                        else if (j1array[0] < -IKPI)
+                        {
+                          j1array[0] += IK2PI;
+                        }
+                        j1valid[0] = true;
+                        for (int ij1 = 0; ij1 < 1; ++ij1)
+                        {
+                          if (!j1valid[ij1])
+                          {
+                            continue;
+                          }
+                          _ij1[0] = ij1;
+                          _ij1[1] = -1;
+                          for (int iij1 = ij1 + 1; iij1 < 1; ++iij1)
+                          {
+                            if (j1valid[iij1] && IKabs(cj1array[ij1] - cj1array[iij1]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj1array[ij1] - sj1array[iij1]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j1valid[iij1] = false;
+                              _ij1[1] = iij1;
+                              break;
+                            }
+                          }
+                          j1 = j1array[ij1];
+                          cj1 = cj1array[ij1];
+                          sj1 = sj1array[ij1];
+                          {
+                            IkReal evalcond[5];
+                            IkReal x292 = IKsin(j1);
+                            IkReal x293 = IKcos(j1);
+                            IkReal x294 = ((IkReal(1.49995000000000)) * (sj2));
+                            IkReal x295 = ((cj0) * (px));
+                            IkReal x296 = ((IkReal(0.0550600000000000)) * (cj2));
+                            IkReal x297 = ((IkReal(1.49995000000000)) * (cj2));
+                            IkReal x298 = ((py) * (sj0));
+                            IkReal x299 = ((IkReal(0.0550600000000000)) * (sj2));
+                            IkReal x300 = ((IkReal(1.00000000000000)) * (x293));
+                            IkReal x301 = ((IkReal(2.49980000000000)) * (x292));
+                            IkReal x302 = ((pz) * (x293));
+                            IkReal x303 = ((pz) * (x292));
+                            IkReal x304 = ((IkReal(0.000200000000000000)) * (x293));
+                            evalcond[0] =
+                                ((IkReal(-1.24990000000000)) + (x302) + (x294) + (x296) + (((x292) * (x298))) +
+                                 (((x292) * (x295))) + (((IkReal(-0.352770000000000)) * (x292))));
+                            evalcond[1] =
+                                ((IkReal(-0.000100000000000000)) + (((IkReal(-1.00000000000000)) * (x298) * (x300))) +
+                                 (((IkReal(-1.00000000000000)) * (x299))) +
+                                 (((IkReal(-1.00000000000000)) * (x295) * (x300))) + (x303) + (x297) +
+                                 (((IkReal(0.352770000000000)) * (x293))));
+                            evalcond[2] = ((((IkReal(-1.24990000000000)) * (x293))) + (pz) +
+                                           (((IkReal(-0.000100000000000000)) * (x292))) + (((x293) * (x296))) +
+                                           (((x293) * (x294))) + (((x292) * (x297))) +
+                                           (((IkReal(-1.00000000000000)) * (x292) * (x299))));
+                            evalcond[3] = ((IkReal(0.352770000000000)) + (((IkReal(-1.00000000000000)) * (x295))) +
+                                           (((IkReal(-1.00000000000000)) * (x298))) +
+                                           (((IkReal(-1.00000000000000)) * (x293) * (x299))) +
+                                           (((IkReal(1.24990000000000)) * (x292))) +
+                                           (((IkReal(-0.000100000000000000)) * (x293))) + (((x293) * (x297))) +
+                                           (((IkReal(-1.00000000000000)) * (x292) * (x294))) +
+                                           (((IkReal(-1.00000000000000)) * (x292) * (x296))));
+                            evalcond[4] =
+                                ((IkReal(0.566185873600000)) + (((IkReal(-1.00000000000000)) * (x298) * (x304))) +
+                                 (((IkReal(0.000200000000000000)) * (x303))) +
+                                 (((IkReal(0.705540000000000)) * (x298))) + (((IkReal(0.705540000000000)) * (x295))) +
+                                 (((IkReal(-1.00000000000000)) * (x295) * (x304))) +
+                                 (((IkReal(-1.00000000000000)) * (pp))) + (((x298) * (x301))) +
+                                 (((IkReal(7.05540000000000e-5)) * (x293))) + (((x295) * (x301))) +
+                                 (((IkReal(2.49980000000000)) * (x302))) + (((IkReal(-0.881854446000000)) * (x292))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          rotationfunction0(solutions);
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return solutions.GetNumSolutions() > 0;
+  }
+  inline void rotationfunction0(IkSolutionListBase<IkReal>& solutions)
+  {
+    for (int rotationiter = 0; rotationiter < 1; ++rotationiter)
+    {
+      IkReal x97 = ((cj0) * (r00));
+      IkReal x98 = ((cj0) * (r01));
+      IkReal x99 = ((sj1) * (sj2));
+      IkReal x100 = ((IkReal(1.00000000000000)) * (sj0));
+      IkReal x101 = ((r10) * (sj0));
+      IkReal x102 = ((IkReal(1.00000000000000)) * (cj2));
+      IkReal x103 = ((r11) * (sj0));
+      IkReal x104 = ((cj0) * (r02));
+      IkReal x105 = ((r12) * (sj0));
+      IkReal x106 = ((((IkReal(-1.00000000000000)) * (cj1) * (x102))) + (x99));
+      IkReal x107 = ((((IkReal(-1.00000000000000)) * (x99))) + (((cj1) * (cj2))));
+      IkReal x108 = ((cj0) * (x107));
+      IkReal x109 =
+          ((((IkReal(-1.00000000000000)) * (cj1) * (sj2))) + (((IkReal(-1.00000000000000)) * (sj1) * (x102))));
+      IkReal x110 = ((sj0) * (x109));
+      new_r00 = ((((r20) * (x106))) + (((x109) * (x97))) + (((x101) * (x109))));
+      new_r01 = ((((r21) * (x106))) + (((x103) * (x109))) + (((x109) * (x98))));
+      new_r02 = ((((r22) * (x106))) + (((x105) * (x109))) + (((x104) * (x109))));
+      new_r10 = ((((IkReal(-1.00000000000000)) * (r00) * (x100))) + (((cj0) * (r10))));
+      new_r11 = ((((IkReal(-1.00000000000000)) * (r01) * (x100))) + (((cj0) * (r11))));
+      new_r12 = ((((IkReal(-1.00000000000000)) * (r02) * (x100))) + (((cj0) * (r12))));
+      new_r20 = ((((x107) * (x97))) + (((r20) * (x109))) + (((x101) * (x107))));
+      new_r21 = ((((x107) * (x98))) + (((r21) * (x109))) + (((x103) * (x107))));
+      new_r22 = ((((r22) * (x109))) + (((x105) * (x107))) + (((x104) * (x107))));
+      {
+        IkReal j4array[2], cj4array[2], sj4array[2];
+        bool j4valid[2] = { false };
+        _nj4 = 2;
+        cj4array[0] = new_r22;
+        if (cj4array[0] >= -1 - IKFAST_SINCOS_THRESH && cj4array[0] <= 1 + IKFAST_SINCOS_THRESH)
+        {
+          j4valid[0] = j4valid[1] = true;
+          j4array[0] = IKacos(cj4array[0]);
+          sj4array[0] = IKsin(j4array[0]);
+          cj4array[1] = cj4array[0];
+          j4array[1] = -j4array[0];
+          sj4array[1] = -sj4array[0];
+        }
+        else if (isnan(cj4array[0]))
+        {
+          // probably any value will work
+          j4valid[0] = true;
+          cj4array[0] = 1;
+          sj4array[0] = 0;
+          j4array[0] = 0;
+        }
+        for (int ij4 = 0; ij4 < 2; ++ij4)
+        {
+          if (!j4valid[ij4])
+          {
+            continue;
+          }
+          _ij4[0] = ij4;
+          _ij4[1] = -1;
+          for (int iij4 = ij4 + 1; iij4 < 2; ++iij4)
+          {
+            if (j4valid[iij4] && IKabs(cj4array[ij4] - cj4array[iij4]) < IKFAST_SOLUTION_THRESH &&
+                IKabs(sj4array[ij4] - sj4array[iij4]) < IKFAST_SOLUTION_THRESH)
+            {
+              j4valid[iij4] = false;
+              _ij4[1] = iij4;
+              break;
+            }
+          }
+          j4 = j4array[ij4];
+          cj4 = cj4array[ij4];
+          sj4 = sj4array[ij4];
+
+          {
+            IkReal dummyeval[1];
+            IkReal gconst4;
+            gconst4 = IKsign(sj4);
+            dummyeval[0] = sj4;
+            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+            {
+              {
+                IkReal dummyeval[1];
+                IkReal gconst2;
+                gconst2 = IKsign((((new_r12) * (new_r12)) + ((new_r02) * (new_r02))));
+                dummyeval[0] = (((new_r12) * (new_r12)) + ((new_r02) * (new_r02)));
+                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                {
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst3;
+                    gconst3 = IKsign(((((new_r10) * (new_r12) * (sj4))) + (((new_r00) * (new_r02) * (sj4)))));
+                    dummyeval[0] = ((((new_r10) * (new_r12) * (sj4))) + (((new_r00) * (new_r02) * (sj4))));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal evalcond[7];
+                        IkReal x111 = ((IkReal(-1.00000000000000)) + (new_r22));
+                        evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                       (IKfmod(((IkReal(3.14159265358979)) + (j4)), IkReal(6.28318530717959))));
+                        evalcond[1] = x111;
+                        evalcond[2] = new_r20;
+                        evalcond[3] = new_r21;
+                        evalcond[4] = new_r20;
+                        evalcond[5] = new_r21;
+                        evalcond[6] = x111;
+                        if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                            IKabs(evalcond[2]) < 0.0000010000000000 && IKabs(evalcond[3]) < 0.0000010000000000 &&
+                            IKabs(evalcond[4]) < 0.0000010000000000 && IKabs(evalcond[5]) < 0.0000010000000000 &&
+                            IKabs(evalcond[6]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal j3array[2], cj3array[2], sj3array[2];
+                            bool j3valid[2] = { false };
+                            _nj3 = 2;
+                            if (IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            IkReal x112 = IKatan2(new_r02, new_r12);
+                            j3array[0] = ((IkReal(-1.00000000000000)) * (x112));
+                            sj3array[0] = IKsin(j3array[0]);
+                            cj3array[0] = IKcos(j3array[0]);
+                            j3array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x112))));
+                            sj3array[1] = IKsin(j3array[1]);
+                            cj3array[1] = IKcos(j3array[1]);
+                            if (j3array[0] > IKPI)
+                            {
+                              j3array[0] -= IK2PI;
+                            }
+                            else if (j3array[0] < -IKPI)
+                            {
+                              j3array[0] += IK2PI;
+                            }
+                            j3valid[0] = true;
+                            if (j3array[1] > IKPI)
+                            {
+                              j3array[1] -= IK2PI;
+                            }
+                            else if (j3array[1] < -IKPI)
+                            {
+                              j3array[1] += IK2PI;
+                            }
+                            j3valid[1] = true;
+                            for (int ij3 = 0; ij3 < 2; ++ij3)
+                            {
+                              if (!j3valid[ij3])
+                              {
+                                continue;
+                              }
+                              _ij3[0] = ij3;
+                              _ij3[1] = -1;
+                              for (int iij3 = ij3 + 1; iij3 < 2; ++iij3)
+                              {
+                                if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j3valid[iij3] = false;
+                                  _ij3[1] = iij3;
+                                  break;
+                                }
+                              }
+                              j3 = j3array[ij3];
+                              cj3 = cj3array[ij3];
+                              sj3 = sj3array[ij3];
+                              {
+                                IkReal evalcond[1];
+                                evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r02) * (IKsin(j3)))) +
+                                               (((new_r12) * (IKcos(j3)))));
+                                if (IKabs(evalcond[0]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                IkReal j5array[1], cj5array[1], sj5array[1];
+                                bool j5valid[1] = { false };
+                                _nj5 = 1;
+                                if (IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) <
+                                        IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                 (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) +
+                                          IKsqr(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) - 1) <=
+                                        IKFAST_SINCOS_THRESH)
+                                  continue;
+                                j5array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                      (((IkReal(-1.00000000000000)) * (new_r11) * (sj3)))),
+                                                     ((((new_r10) * (sj3))) + (((cj3) * (new_r00)))));
+                                sj5array[0] = IKsin(j5array[0]);
+                                cj5array[0] = IKcos(j5array[0]);
+                                if (j5array[0] > IKPI)
+                                {
+                                  j5array[0] -= IK2PI;
+                                }
+                                else if (j5array[0] < -IKPI)
+                                {
+                                  j5array[0] += IK2PI;
+                                }
+                                j5valid[0] = true;
+                                for (int ij5 = 0; ij5 < 1; ++ij5)
+                                {
+                                  if (!j5valid[ij5])
+                                  {
+                                    continue;
+                                  }
+                                  _ij5[0] = ij5;
+                                  _ij5[1] = -1;
+                                  for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                  {
+                                    if (j5valid[iij5] &&
+                                        IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j5valid[iij5] = false;
+                                      _ij5[1] = iij5;
+                                      break;
+                                    }
+                                  }
+                                  j5 = j5array[ij5];
+                                  cj5 = cj5array[ij5];
+                                  sj5 = sj5array[ij5];
+                                  {
+                                    IkReal evalcond[4];
+                                    IkReal x113 = IKsin(j5);
+                                    IkReal x114 = ((IkReal(1.00000000000000)) * (sj3));
+                                    IkReal x115 = ((IkReal(1.00000000000000)) * (IKcos(j5)));
+                                    evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r00) * (x114))) +
+                                                   (((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (x113))));
+                                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (new_r01) * (x114))) +
+                                                   (((IkReal(-1.00000000000000)) * (x115))) + (((cj3) * (new_r11))));
+                                    evalcond[2] = ((((new_r11) * (sj3))) + (x113) + (((cj3) * (new_r01))));
+                                    evalcond[3] = ((((new_r10) * (sj3))) + (((IkReal(-1.00000000000000)) * (x115))) +
+                                                   (((cj3) * (new_r00))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                    vinfos[0].jointtype = 1;
+                                    vinfos[0].foffset = j0;
+                                    vinfos[0].indices[0] = _ij0[0];
+                                    vinfos[0].indices[1] = _ij0[1];
+                                    vinfos[0].maxsolutions = _nj0;
+                                    vinfos[1].jointtype = 1;
+                                    vinfos[1].foffset = j1;
+                                    vinfos[1].indices[0] = _ij1[0];
+                                    vinfos[1].indices[1] = _ij1[1];
+                                    vinfos[1].maxsolutions = _nj1;
+                                    vinfos[2].jointtype = 1;
+                                    vinfos[2].foffset = j2;
+                                    vinfos[2].indices[0] = _ij2[0];
+                                    vinfos[2].indices[1] = _ij2[1];
+                                    vinfos[2].maxsolutions = _nj2;
+                                    vinfos[3].jointtype = 1;
+                                    vinfos[3].foffset = j3;
+                                    vinfos[3].indices[0] = _ij3[0];
+                                    vinfos[3].indices[1] = _ij3[1];
+                                    vinfos[3].maxsolutions = _nj3;
+                                    vinfos[4].jointtype = 1;
+                                    vinfos[4].foffset = j4;
+                                    vinfos[4].indices[0] = _ij4[0];
+                                    vinfos[4].indices[1] = _ij4[1];
+                                    vinfos[4].maxsolutions = _nj4;
+                                    vinfos[5].jointtype = 1;
+                                    vinfos[5].foffset = j5;
+                                    vinfos[5].indices[0] = _ij5[0];
+                                    vinfos[5].indices[1] = _ij5[1];
+                                    vinfos[5].maxsolutions = _nj5;
+                                    std::vector<int> vfree(0);
+                                    solutions.AddSolution(vinfos, vfree);
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                         (IKfmod(((IkReal(1.11022302462516e-16)) + (j4)), IkReal(6.28318530717959))));
+                          evalcond[1] = ((IkReal(1.00000000000000)) + (new_r22));
+                          evalcond[2] = new_r20;
+                          evalcond[3] = new_r21;
+                          evalcond[4] = ((IkReal(-1.00000000000000)) * (new_r20));
+                          evalcond[5] = ((IkReal(-1.00000000000000)) * (new_r21));
+                          evalcond[6] = ((IkReal(-1.00000000000000)) + (((IkReal(-1.00000000000000)) * (new_r22))));
+                          if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                              IKabs(evalcond[2]) < 0.0000010000000000 && IKabs(evalcond[3]) < 0.0000010000000000 &&
+                              IKabs(evalcond[4]) < 0.0000010000000000 && IKabs(evalcond[5]) < 0.0000010000000000 &&
+                              IKabs(evalcond[6]) < 0.0000010000000000)
+                          {
+                            {
+                              IkReal j3array[2], cj3array[2], sj3array[2];
+                              bool j3valid[2] = { false };
+                              _nj3 = 2;
+                              if (IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH)
+                                continue;
+                              IkReal x116 = IKatan2(new_r02, new_r12);
+                              j3array[0] = ((IkReal(-1.00000000000000)) * (x116));
+                              sj3array[0] = IKsin(j3array[0]);
+                              cj3array[0] = IKcos(j3array[0]);
+                              j3array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x116))));
+                              sj3array[1] = IKsin(j3array[1]);
+                              cj3array[1] = IKcos(j3array[1]);
+                              if (j3array[0] > IKPI)
+                              {
+                                j3array[0] -= IK2PI;
+                              }
+                              else if (j3array[0] < -IKPI)
+                              {
+                                j3array[0] += IK2PI;
+                              }
+                              j3valid[0] = true;
+                              if (j3array[1] > IKPI)
+                              {
+                                j3array[1] -= IK2PI;
+                              }
+                              else if (j3array[1] < -IKPI)
+                              {
+                                j3array[1] += IK2PI;
+                              }
+                              j3valid[1] = true;
+                              for (int ij3 = 0; ij3 < 2; ++ij3)
+                              {
+                                if (!j3valid[ij3])
+                                {
+                                  continue;
+                                }
+                                _ij3[0] = ij3;
+                                _ij3[1] = -1;
+                                for (int iij3 = ij3 + 1; iij3 < 2; ++iij3)
+                                {
+                                  if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                                      IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                                  {
+                                    j3valid[iij3] = false;
+                                    _ij3[1] = iij3;
+                                    break;
+                                  }
+                                }
+                                j3 = j3array[ij3];
+                                cj3 = cj3array[ij3];
+                                sj3 = sj3array[ij3];
+                                {
+                                  IkReal evalcond[1];
+                                  evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r02) * (IKsin(j3)))) +
+                                                 (((new_r12) * (IKcos(j3)))));
+                                  if (IKabs(evalcond[0]) > 0.000001)
+                                  {
+                                    continue;
+                                  }
+                                }
+
+                                {
+                                  IkReal j5array[1], cj5array[1], sj5array[1];
+                                  bool j5valid[1] = { false };
+                                  _nj5 = 1;
+                                  if (IKabs(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                      IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                             (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) <
+                                          IKFAST_ATAN2_MAGTHRESH &&
+                                      IKabs(IKsqr(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) +
+                                            IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) -
+                                            1) <= IKFAST_SINCOS_THRESH)
+                                    continue;
+                                  j5array[0] = IKatan2(((((new_r11) * (sj3))) + (((cj3) * (new_r01)))),
+                                                       ((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                        (((IkReal(-1.00000000000000)) * (new_r10) * (sj3)))));
+                                  sj5array[0] = IKsin(j5array[0]);
+                                  cj5array[0] = IKcos(j5array[0]);
+                                  if (j5array[0] > IKPI)
+                                  {
+                                    j5array[0] -= IK2PI;
+                                  }
+                                  else if (j5array[0] < -IKPI)
+                                  {
+                                    j5array[0] += IK2PI;
+                                  }
+                                  j5valid[0] = true;
+                                  for (int ij5 = 0; ij5 < 1; ++ij5)
+                                  {
+                                    if (!j5valid[ij5])
+                                    {
+                                      continue;
+                                    }
+                                    _ij5[0] = ij5;
+                                    _ij5[1] = -1;
+                                    for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                    {
+                                      if (j5valid[iij5] &&
+                                          IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                          IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                      {
+                                        j5valid[iij5] = false;
+                                        _ij5[1] = iij5;
+                                        break;
+                                      }
+                                    }
+                                    j5 = j5array[ij5];
+                                    cj5 = cj5array[ij5];
+                                    sj5 = sj5array[ij5];
+                                    {
+                                      IkReal evalcond[4];
+                                      IkReal x117 = IKcos(j5);
+                                      IkReal x118 = ((IkReal(1.00000000000000)) * (sj3));
+                                      IkReal x119 = ((IkReal(1.00000000000000)) * (IKsin(j5)));
+                                      evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r00) * (x118))) +
+                                                     (((IkReal(-1.00000000000000)) * (x119))) + (((cj3) * (new_r10))));
+                                      evalcond[1] = ((((IkReal(-1.00000000000000)) * (new_r01) * (x118))) +
+                                                     (((cj3) * (new_r11))) + (((IkReal(-1.00000000000000)) * (x117))));
+                                      evalcond[2] = ((((new_r11) * (sj3))) + (((IkReal(-1.00000000000000)) * (x119))) +
+                                                     (((cj3) * (new_r01))));
+                                      evalcond[3] = ((((new_r10) * (sj3))) + (x117) + (((cj3) * (new_r00))));
+                                      if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                          IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                      {
+                                        continue;
+                                      }
+                                    }
+
+                                    {
+                                      std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                      vinfos[0].jointtype = 1;
+                                      vinfos[0].foffset = j0;
+                                      vinfos[0].indices[0] = _ij0[0];
+                                      vinfos[0].indices[1] = _ij0[1];
+                                      vinfos[0].maxsolutions = _nj0;
+                                      vinfos[1].jointtype = 1;
+                                      vinfos[1].foffset = j1;
+                                      vinfos[1].indices[0] = _ij1[0];
+                                      vinfos[1].indices[1] = _ij1[1];
+                                      vinfos[1].maxsolutions = _nj1;
+                                      vinfos[2].jointtype = 1;
+                                      vinfos[2].foffset = j2;
+                                      vinfos[2].indices[0] = _ij2[0];
+                                      vinfos[2].indices[1] = _ij2[1];
+                                      vinfos[2].maxsolutions = _nj2;
+                                      vinfos[3].jointtype = 1;
+                                      vinfos[3].foffset = j3;
+                                      vinfos[3].indices[0] = _ij3[0];
+                                      vinfos[3].indices[1] = _ij3[1];
+                                      vinfos[3].maxsolutions = _nj3;
+                                      vinfos[4].jointtype = 1;
+                                      vinfos[4].foffset = j4;
+                                      vinfos[4].indices[0] = _ij4[0];
+                                      vinfos[4].indices[1] = _ij4[1];
+                                      vinfos[4].maxsolutions = _nj4;
+                                      vinfos[5].jointtype = 1;
+                                      vinfos[5].foffset = j5;
+                                      vinfos[5].indices[0] = _ij5[0];
+                                      vinfos[5].indices[1] = _ij5[1];
+                                      vinfos[5].maxsolutions = _nj5;
+                                      std::vector<int> vfree(0);
+                                      solutions.AddSolution(vinfos, vfree);
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                          else
+                          {
+                            if (1)
+                            {
+                              continue;
+                            }
+                            else
+                            {
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j3array[1], cj3array[1], sj3array[1];
+                        bool j3valid[1] = { false };
+                        _nj3 = 1;
+                        IkReal x120 = ((IkReal(-1.00000000000000)) * (cj4) * (gconst3) * (new_r20));
+                        if (IKabs(((new_r12) * (x120))) < IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((new_r02) * (x120))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j3array[0] = IKatan2(((new_r12) * (x120)), ((new_r02) * (x120)));
+                        sj3array[0] = IKsin(j3array[0]);
+                        cj3array[0] = IKcos(j3array[0]);
+                        if (j3array[0] > IKPI)
+                        {
+                          j3array[0] -= IK2PI;
+                        }
+                        else if (j3array[0] < -IKPI)
+                        {
+                          j3array[0] += IK2PI;
+                        }
+                        j3valid[0] = true;
+                        for (int ij3 = 0; ij3 < 1; ++ij3)
+                        {
+                          if (!j3valid[ij3])
+                          {
+                            continue;
+                          }
+                          _ij3[0] = ij3;
+                          _ij3[1] = -1;
+                          for (int iij3 = ij3 + 1; iij3 < 1; ++iij3)
+                          {
+                            if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j3valid[iij3] = false;
+                              _ij3[1] = iij3;
+                              break;
+                            }
+                          }
+                          j3 = j3array[ij3];
+                          cj3 = cj3array[ij3];
+                          sj3 = sj3array[ij3];
+                          {
+                            IkReal evalcond[6];
+                            IkReal x121 = IKsin(j3);
+                            IkReal x122 = IKcos(j3);
+                            IkReal x123 = ((IkReal(1.00000000000000)) * (sj4));
+                            IkReal x124 = ((sj4) * (x121));
+                            IkReal x125 = ((sj4) * (x122));
+                            IkReal x126 = ((new_r02) * (x122));
+                            IkReal x127 = ((new_r12) * (x121));
+                            evalcond[0] =
+                                ((((IkReal(-1.00000000000000)) * (new_r02) * (x121))) + (((new_r12) * (x122))));
+                            evalcond[1] = ((((IkReal(-1.00000000000000)) * (x123))) + (x126) + (x127));
+                            evalcond[2] = ((((new_r00) * (x125))) + (((cj4) * (new_r20))) + (((new_r10) * (x124))));
+                            evalcond[3] = ((((cj4) * (new_r21))) + (((new_r01) * (x125))) + (((new_r11) * (x124))));
+                            evalcond[4] = ((IkReal(-1.00000000000000)) + (((cj4) * (new_r22))) +
+                                           (((new_r02) * (x125))) + (((new_r12) * (x124))));
+                            evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r22) * (x123))) + (((cj4) * (x126))) +
+                                           (((cj4) * (x127))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          {
+                            IkReal dummyeval[1];
+                            IkReal gconst5;
+                            gconst5 = IKsign(sj4);
+                            dummyeval[0] = sj4;
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal dummyeval[1];
+                                dummyeval[0] = sj4;
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal dummyeval[1];
+                                    dummyeval[0] = sj4;
+                                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                    {
+                                      {
+                                        IkReal evalcond[11];
+                                        IkReal x128 = ((IkReal(-1.00000000000000)) + (new_r22));
+                                        IkReal x129 = ((((IkReal(-1.00000000000000)) * (new_r02) * (sj3))) +
+                                                       (((cj3) * (new_r12))));
+                                        IkReal x130 = ((((new_r12) * (sj3))) + (((cj3) * (new_r02))));
+                                        evalcond[0] =
+                                            ((IkReal(-3.14159265358979)) +
+                                             (IKfmod(((IkReal(3.14159265358979)) + (j4)), IkReal(6.28318530717959))));
+                                        evalcond[1] = x128;
+                                        evalcond[2] = new_r20;
+                                        evalcond[3] = new_r21;
+                                        evalcond[4] = x129;
+                                        evalcond[5] = x129;
+                                        evalcond[6] = x130;
+                                        evalcond[7] = new_r20;
+                                        evalcond[8] = new_r21;
+                                        evalcond[9] = x128;
+                                        evalcond[10] = x130;
+                                        if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[10]) < 0.0000010000000000)
+                                        {
+                                          {
+                                            IkReal j5array[1], cj5array[1], sj5array[1];
+                                            bool j5valid[1] = { false };
+                                            _nj5 = 1;
+                                            if (IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) <
+                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                IKabs(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) <
+                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                             (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) +
+                                                      IKsqr(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) - 1) <=
+                                                    IKFAST_SINCOS_THRESH)
+                                              continue;
+                                            j5array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                                  (((IkReal(-1.00000000000000)) * (new_r11) * (sj3)))),
+                                                                 ((((new_r10) * (sj3))) + (((cj3) * (new_r00)))));
+                                            sj5array[0] = IKsin(j5array[0]);
+                                            cj5array[0] = IKcos(j5array[0]);
+                                            if (j5array[0] > IKPI)
+                                            {
+                                              j5array[0] -= IK2PI;
+                                            }
+                                            else if (j5array[0] < -IKPI)
+                                            {
+                                              j5array[0] += IK2PI;
+                                            }
+                                            j5valid[0] = true;
+                                            for (int ij5 = 0; ij5 < 1; ++ij5)
+                                            {
+                                              if (!j5valid[ij5])
+                                              {
+                                                continue;
+                                              }
+                                              _ij5[0] = ij5;
+                                              _ij5[1] = -1;
+                                              for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                              {
+                                                if (j5valid[iij5] &&
+                                                    IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                                    IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                                {
+                                                  j5valid[iij5] = false;
+                                                  _ij5[1] = iij5;
+                                                  break;
+                                                }
+                                              }
+                                              j5 = j5array[ij5];
+                                              cj5 = cj5array[ij5];
+                                              sj5 = sj5array[ij5];
+                                              {
+                                                IkReal evalcond[4];
+                                                IkReal x131 = IKsin(j5);
+                                                IkReal x132 = ((IkReal(1.00000000000000)) * (sj3));
+                                                IkReal x133 = ((IkReal(1.00000000000000)) * (IKcos(j5)));
+                                                evalcond[0] =
+                                                    ((((IkReal(-1.00000000000000)) * (new_r00) * (x132))) +
+                                                     (((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (x131))));
+                                                evalcond[1] =
+                                                    ((((IkReal(-1.00000000000000)) * (new_r01) * (x132))) +
+                                                     (((IkReal(-1.00000000000000)) * (x133))) + (((cj3) * (new_r11))));
+                                                evalcond[2] = ((((new_r11) * (sj3))) + (x131) + (((cj3) * (new_r01))));
+                                                evalcond[3] =
+                                                    ((((new_r10) * (sj3))) + (((IkReal(-1.00000000000000)) * (x133))) +
+                                                     (((cj3) * (new_r00))));
+                                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                {
+                                                  continue;
+                                                }
+                                              }
+
+                                              {
+                                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                                vinfos[0].jointtype = 1;
+                                                vinfos[0].foffset = j0;
+                                                vinfos[0].indices[0] = _ij0[0];
+                                                vinfos[0].indices[1] = _ij0[1];
+                                                vinfos[0].maxsolutions = _nj0;
+                                                vinfos[1].jointtype = 1;
+                                                vinfos[1].foffset = j1;
+                                                vinfos[1].indices[0] = _ij1[0];
+                                                vinfos[1].indices[1] = _ij1[1];
+                                                vinfos[1].maxsolutions = _nj1;
+                                                vinfos[2].jointtype = 1;
+                                                vinfos[2].foffset = j2;
+                                                vinfos[2].indices[0] = _ij2[0];
+                                                vinfos[2].indices[1] = _ij2[1];
+                                                vinfos[2].maxsolutions = _nj2;
+                                                vinfos[3].jointtype = 1;
+                                                vinfos[3].foffset = j3;
+                                                vinfos[3].indices[0] = _ij3[0];
+                                                vinfos[3].indices[1] = _ij3[1];
+                                                vinfos[3].maxsolutions = _nj3;
+                                                vinfos[4].jointtype = 1;
+                                                vinfos[4].foffset = j4;
+                                                vinfos[4].indices[0] = _ij4[0];
+                                                vinfos[4].indices[1] = _ij4[1];
+                                                vinfos[4].maxsolutions = _nj4;
+                                                vinfos[5].jointtype = 1;
+                                                vinfos[5].foffset = j5;
+                                                vinfos[5].indices[0] = _ij5[0];
+                                                vinfos[5].indices[1] = _ij5[1];
+                                                vinfos[5].maxsolutions = _nj5;
+                                                std::vector<int> vfree(0);
+                                                solutions.AddSolution(vinfos, vfree);
+                                              }
+                                            }
+                                          }
+                                        }
+                                        else
+                                        {
+                                          IkReal x134 = ((new_r12) * (sj3));
+                                          IkReal x135 = ((IkReal(1.00000000000000)) * (new_r02));
+                                          IkReal x136 = ((((IkReal(-1.00000000000000)) * (sj3) * (x135))) +
+                                                         (((cj3) * (new_r12))));
+                                          evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                         (IKfmod(((IkReal(1.11022302462516e-16)) + (j4)),
+                                                                 IkReal(6.28318530717959))));
+                                          evalcond[1] = ((IkReal(1.00000000000000)) + (new_r22));
+                                          evalcond[2] = new_r20;
+                                          evalcond[3] = new_r21;
+                                          evalcond[4] = x136;
+                                          evalcond[5] = x136;
+                                          evalcond[6] = ((x134) + (((cj3) * (new_r02))));
+                                          evalcond[7] = ((IkReal(-1.00000000000000)) * (new_r20));
+                                          evalcond[8] = ((IkReal(-1.00000000000000)) * (new_r21));
+                                          evalcond[9] = ((IkReal(-1.00000000000000)) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r22))));
+                                          evalcond[10] = ((((IkReal(-1.00000000000000)) * (cj3) * (x135))) +
+                                                          (((IkReal(-1.00000000000000)) * (x134))));
+                                          if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[10]) < 0.0000010000000000)
+                                          {
+                                            {
+                                              IkReal j5array[1], cj5array[1], sj5array[1];
+                                              bool j5valid[1] = { false };
+                                              _nj5 = 1;
+                                              if (IKabs(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) <
+                                                      IKFAST_ATAN2_MAGTHRESH &&
+                                                  IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) <
+                                                      IKFAST_ATAN2_MAGTHRESH &&
+                                                  IKabs(IKsqr(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) +
+                                                        IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                               (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) -
+                                                        1) <= IKFAST_SINCOS_THRESH)
+                                                continue;
+                                              j5array[0] =
+                                                  IKatan2(((((new_r11) * (sj3))) + (((cj3) * (new_r01)))),
+                                                          ((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r10) * (sj3)))));
+                                              sj5array[0] = IKsin(j5array[0]);
+                                              cj5array[0] = IKcos(j5array[0]);
+                                              if (j5array[0] > IKPI)
+                                              {
+                                                j5array[0] -= IK2PI;
+                                              }
+                                              else if (j5array[0] < -IKPI)
+                                              {
+                                                j5array[0] += IK2PI;
+                                              }
+                                              j5valid[0] = true;
+                                              for (int ij5 = 0; ij5 < 1; ++ij5)
+                                              {
+                                                if (!j5valid[ij5])
+                                                {
+                                                  continue;
+                                                }
+                                                _ij5[0] = ij5;
+                                                _ij5[1] = -1;
+                                                for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                                {
+                                                  if (j5valid[iij5] &&
+                                                      IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                                      IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                                  {
+                                                    j5valid[iij5] = false;
+                                                    _ij5[1] = iij5;
+                                                    break;
+                                                  }
+                                                }
+                                                j5 = j5array[ij5];
+                                                cj5 = cj5array[ij5];
+                                                sj5 = sj5array[ij5];
+                                                {
+                                                  IkReal evalcond[4];
+                                                  IkReal x137 = IKcos(j5);
+                                                  IkReal x138 = ((IkReal(1.00000000000000)) * (sj3));
+                                                  IkReal x139 = ((IkReal(1.00000000000000)) * (IKsin(j5)));
+                                                  evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r00) * (x138))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x139))) +
+                                                                 (((cj3) * (new_r10))));
+                                                  evalcond[1] = ((((IkReal(-1.00000000000000)) * (new_r01) * (x138))) +
+                                                                 (((cj3) * (new_r11))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x137))));
+                                                  evalcond[2] = ((((new_r11) * (sj3))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x139))) +
+                                                                 (((cj3) * (new_r01))));
+                                                  evalcond[3] =
+                                                      ((((new_r10) * (sj3))) + (x137) + (((cj3) * (new_r00))));
+                                                  if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                      IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                  {
+                                                    continue;
+                                                  }
+                                                }
+
+                                                {
+                                                  std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                                  vinfos[0].jointtype = 1;
+                                                  vinfos[0].foffset = j0;
+                                                  vinfos[0].indices[0] = _ij0[0];
+                                                  vinfos[0].indices[1] = _ij0[1];
+                                                  vinfos[0].maxsolutions = _nj0;
+                                                  vinfos[1].jointtype = 1;
+                                                  vinfos[1].foffset = j1;
+                                                  vinfos[1].indices[0] = _ij1[0];
+                                                  vinfos[1].indices[1] = _ij1[1];
+                                                  vinfos[1].maxsolutions = _nj1;
+                                                  vinfos[2].jointtype = 1;
+                                                  vinfos[2].foffset = j2;
+                                                  vinfos[2].indices[0] = _ij2[0];
+                                                  vinfos[2].indices[1] = _ij2[1];
+                                                  vinfos[2].maxsolutions = _nj2;
+                                                  vinfos[3].jointtype = 1;
+                                                  vinfos[3].foffset = j3;
+                                                  vinfos[3].indices[0] = _ij3[0];
+                                                  vinfos[3].indices[1] = _ij3[1];
+                                                  vinfos[3].maxsolutions = _nj3;
+                                                  vinfos[4].jointtype = 1;
+                                                  vinfos[4].foffset = j4;
+                                                  vinfos[4].indices[0] = _ij4[0];
+                                                  vinfos[4].indices[1] = _ij4[1];
+                                                  vinfos[4].maxsolutions = _nj4;
+                                                  vinfos[5].jointtype = 1;
+                                                  vinfos[5].foffset = j5;
+                                                  vinfos[5].indices[0] = _ij5[0];
+                                                  vinfos[5].indices[1] = _ij5[1];
+                                                  vinfos[5].maxsolutions = _nj5;
+                                                  std::vector<int> vfree(0);
+                                                  solutions.AddSolution(vinfos, vfree);
+                                                }
+                                              }
+                                            }
+                                          }
+                                          else
+                                          {
+                                            if (1)
+                                            {
+                                              continue;
+                                            }
+                                            else
+                                            {
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                    else
+                                    {
+                                      {
+                                        IkReal j5array[1], cj5array[1], sj5array[1];
+                                        bool j5valid[1] = { false };
+                                        _nj5 = 1;
+                                        if (IKabs(((((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (new_r00) *
+                                                                             (sj3))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(((IkReal(-1.00000000000000)) * (new_r20) *
+                                                   (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(
+                                                IKsqr(((((cj3) * (new_r10))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r00) * (sj3))))) +
+                                                IKsqr(((IkReal(-1.00000000000000)) * (new_r20) *
+                                                       (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) -
+                                                1) <= IKFAST_SINCOS_THRESH)
+                                          continue;
+                                        j5array[0] =
+                                            IKatan2(((((cj3) * (new_r10))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r00) * (sj3)))),
+                                                    ((IkReal(-1.00000000000000)) * (new_r20) *
+                                                     (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30))));
+                                        sj5array[0] = IKsin(j5array[0]);
+                                        cj5array[0] = IKcos(j5array[0]);
+                                        if (j5array[0] > IKPI)
+                                        {
+                                          j5array[0] -= IK2PI;
+                                        }
+                                        else if (j5array[0] < -IKPI)
+                                        {
+                                          j5array[0] += IK2PI;
+                                        }
+                                        j5valid[0] = true;
+                                        for (int ij5 = 0; ij5 < 1; ++ij5)
+                                        {
+                                          if (!j5valid[ij5])
+                                          {
+                                            continue;
+                                          }
+                                          _ij5[0] = ij5;
+                                          _ij5[1] = -1;
+                                          for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                          {
+                                            if (j5valid[iij5] &&
+                                                IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                                IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                            {
+                                              j5valid[iij5] = false;
+                                              _ij5[1] = iij5;
+                                              break;
+                                            }
+                                          }
+                                          j5 = j5array[ij5];
+                                          cj5 = cj5array[ij5];
+                                          sj5 = sj5array[ij5];
+                                          {
+                                            IkReal evalcond[8];
+                                            IkReal x140 = IKsin(j5);
+                                            IkReal x141 = IKcos(j5);
+                                            IkReal x142 = ((IkReal(1.00000000000000)) * (sj3));
+                                            IkReal x143 = ((new_r11) * (sj3));
+                                            IkReal x144 = ((new_r10) * (sj3));
+                                            IkReal x145 = ((cj3) * (cj4));
+                                            IkReal x146 = ((IkReal(1.00000000000000)) * (sj4));
+                                            IkReal x147 = ((IkReal(1.00000000000000)) * (x141));
+                                            IkReal x148 = ((IkReal(1.00000000000000)) * (x140));
+                                            evalcond[0] = ((((sj4) * (x141))) + (new_r20));
+                                            evalcond[1] =
+                                                ((((IkReal(-1.00000000000000)) * (x140) * (x146))) + (new_r21));
+                                            evalcond[2] =
+                                                ((((IkReal(-1.00000000000000)) * (x148))) + (((cj3) * (new_r10))) +
+                                                 (((IkReal(-1.00000000000000)) * (new_r00) * (x142))));
+                                            evalcond[3] =
+                                                ((((IkReal(-1.00000000000000)) * (new_r01) * (x142))) +
+                                                 (((IkReal(-1.00000000000000)) * (x147))) + (((cj3) * (new_r11))));
+                                            evalcond[4] = ((x143) + (((cj3) * (new_r01))) + (((cj4) * (x140))));
+                                            evalcond[5] = ((x144) + (((cj3) * (new_r00))) +
+                                                           (((IkReal(-1.00000000000000)) * (cj4) * (x147))));
+                                            evalcond[6] = ((((new_r01) * (x145))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r21) * (x146))) +
+                                                           (x140) + (((cj4) * (x143))));
+                                            evalcond[7] = ((((IkReal(-1.00000000000000)) * (x147))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r20) * (x146))) +
+                                                           (((new_r00) * (x145))) + (((cj4) * (x144))));
+                                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                                IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                            {
+                                              continue;
+                                            }
+                                          }
+
+                                          {
+                                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                            vinfos[0].jointtype = 1;
+                                            vinfos[0].foffset = j0;
+                                            vinfos[0].indices[0] = _ij0[0];
+                                            vinfos[0].indices[1] = _ij0[1];
+                                            vinfos[0].maxsolutions = _nj0;
+                                            vinfos[1].jointtype = 1;
+                                            vinfos[1].foffset = j1;
+                                            vinfos[1].indices[0] = _ij1[0];
+                                            vinfos[1].indices[1] = _ij1[1];
+                                            vinfos[1].maxsolutions = _nj1;
+                                            vinfos[2].jointtype = 1;
+                                            vinfos[2].foffset = j2;
+                                            vinfos[2].indices[0] = _ij2[0];
+                                            vinfos[2].indices[1] = _ij2[1];
+                                            vinfos[2].maxsolutions = _nj2;
+                                            vinfos[3].jointtype = 1;
+                                            vinfos[3].foffset = j3;
+                                            vinfos[3].indices[0] = _ij3[0];
+                                            vinfos[3].indices[1] = _ij3[1];
+                                            vinfos[3].maxsolutions = _nj3;
+                                            vinfos[4].jointtype = 1;
+                                            vinfos[4].foffset = j4;
+                                            vinfos[4].indices[0] = _ij4[0];
+                                            vinfos[4].indices[1] = _ij4[1];
+                                            vinfos[4].maxsolutions = _nj4;
+                                            vinfos[5].jointtype = 1;
+                                            vinfos[5].foffset = j5;
+                                            vinfos[5].indices[0] = _ij5[0];
+                                            vinfos[5].indices[1] = _ij5[1];
+                                            vinfos[5].maxsolutions = _nj5;
+                                            std::vector<int> vfree(0);
+                                            solutions.AddSolution(vinfos, vfree);
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j5array[1], cj5array[1], sj5array[1];
+                                    bool j5valid[1] = { false };
+                                    _nj5 = 1;
+                                    if (IKabs(((new_r21) *
+                                               (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) +
+                                               (((cj3) * (new_r11))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(IKsqr(((new_r21) *
+                                                     (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) +
+                                              IKsqr(((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) +
+                                                     (((cj3) * (new_r11))))) -
+                                              1) <= IKFAST_SINCOS_THRESH)
+                                      continue;
+                                    j5array[0] = IKatan2(
+                                        ((new_r21) * (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30))),
+                                        ((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) + (((cj3) * (new_r11)))));
+                                    sj5array[0] = IKsin(j5array[0]);
+                                    cj5array[0] = IKcos(j5array[0]);
+                                    if (j5array[0] > IKPI)
+                                    {
+                                      j5array[0] -= IK2PI;
+                                    }
+                                    else if (j5array[0] < -IKPI)
+                                    {
+                                      j5array[0] += IK2PI;
+                                    }
+                                    j5valid[0] = true;
+                                    for (int ij5 = 0; ij5 < 1; ++ij5)
+                                    {
+                                      if (!j5valid[ij5])
+                                      {
+                                        continue;
+                                      }
+                                      _ij5[0] = ij5;
+                                      _ij5[1] = -1;
+                                      for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                      {
+                                        if (j5valid[iij5] &&
+                                            IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j5valid[iij5] = false;
+                                          _ij5[1] = iij5;
+                                          break;
+                                        }
+                                      }
+                                      j5 = j5array[ij5];
+                                      cj5 = cj5array[ij5];
+                                      sj5 = sj5array[ij5];
+                                      {
+                                        IkReal evalcond[8];
+                                        IkReal x149 = IKsin(j5);
+                                        IkReal x150 = IKcos(j5);
+                                        IkReal x151 = ((IkReal(1.00000000000000)) * (sj3));
+                                        IkReal x152 = ((new_r11) * (sj3));
+                                        IkReal x153 = ((new_r10) * (sj3));
+                                        IkReal x154 = ((cj3) * (cj4));
+                                        IkReal x155 = ((IkReal(1.00000000000000)) * (sj4));
+                                        IkReal x156 = ((IkReal(1.00000000000000)) * (x150));
+                                        IkReal x157 = ((IkReal(1.00000000000000)) * (x149));
+                                        evalcond[0] = ((((sj4) * (x150))) + (new_r20));
+                                        evalcond[1] = ((new_r21) + (((IkReal(-1.00000000000000)) * (x149) * (x155))));
+                                        evalcond[2] =
+                                            ((((IkReal(-1.00000000000000)) * (x157))) + (((cj3) * (new_r10))) +
+                                             (((IkReal(-1.00000000000000)) * (new_r00) * (x151))));
+                                        evalcond[3] =
+                                            ((((IkReal(-1.00000000000000)) * (x156))) + (((cj3) * (new_r11))) +
+                                             (((IkReal(-1.00000000000000)) * (new_r01) * (x151))));
+                                        evalcond[4] = ((x152) + (((cj3) * (new_r01))) + (((cj4) * (x149))));
+                                        evalcond[5] = ((x153) + (((cj3) * (new_r00))) +
+                                                       (((IkReal(-1.00000000000000)) * (cj4) * (x156))));
+                                        evalcond[6] = ((((cj4) * (x152))) + (((new_r01) * (x154))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r21) * (x155))) + (x149));
+                                        evalcond[7] =
+                                            ((((cj4) * (x153))) + (((IkReal(-1.00000000000000)) * (new_r20) * (x155))) +
+                                             (((IkReal(-1.00000000000000)) * (x156))) + (((new_r00) * (x154))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                            IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              {
+                                IkReal j5array[1], cj5array[1], sj5array[1];
+                                bool j5valid[1] = { false };
+                                _nj5 = 1;
+                                if (IKabs(((gconst5) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((IkReal(-1.00000000000000)) * (gconst5) * (new_r20))) <
+                                        IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                j5array[0] = IKatan2(((gconst5) * (new_r21)),
+                                                     ((IkReal(-1.00000000000000)) * (gconst5) * (new_r20)));
+                                sj5array[0] = IKsin(j5array[0]);
+                                cj5array[0] = IKcos(j5array[0]);
+                                if (j5array[0] > IKPI)
+                                {
+                                  j5array[0] -= IK2PI;
+                                }
+                                else if (j5array[0] < -IKPI)
+                                {
+                                  j5array[0] += IK2PI;
+                                }
+                                j5valid[0] = true;
+                                for (int ij5 = 0; ij5 < 1; ++ij5)
+                                {
+                                  if (!j5valid[ij5])
+                                  {
+                                    continue;
+                                  }
+                                  _ij5[0] = ij5;
+                                  _ij5[1] = -1;
+                                  for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                  {
+                                    if (j5valid[iij5] &&
+                                        IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j5valid[iij5] = false;
+                                      _ij5[1] = iij5;
+                                      break;
+                                    }
+                                  }
+                                  j5 = j5array[ij5];
+                                  cj5 = cj5array[ij5];
+                                  sj5 = sj5array[ij5];
+                                  {
+                                    IkReal evalcond[8];
+                                    IkReal x158 = IKsin(j5);
+                                    IkReal x159 = IKcos(j5);
+                                    IkReal x160 = ((IkReal(1.00000000000000)) * (sj3));
+                                    IkReal x161 = ((new_r11) * (sj3));
+                                    IkReal x162 = ((new_r10) * (sj3));
+                                    IkReal x163 = ((cj3) * (cj4));
+                                    IkReal x164 = ((IkReal(1.00000000000000)) * (sj4));
+                                    IkReal x165 = ((IkReal(1.00000000000000)) * (x159));
+                                    IkReal x166 = ((IkReal(1.00000000000000)) * (x158));
+                                    evalcond[0] = ((((sj4) * (x159))) + (new_r20));
+                                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (x158) * (x164))) + (new_r21));
+                                    evalcond[2] = ((((IkReal(-1.00000000000000)) * (new_r00) * (x160))) +
+                                                   (((IkReal(-1.00000000000000)) * (x166))) + (((cj3) * (new_r10))));
+                                    evalcond[3] = ((((IkReal(-1.00000000000000)) * (x165))) + (((cj3) * (new_r11))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r01) * (x160))));
+                                    evalcond[4] = ((((cj4) * (x158))) + (x161) + (((cj3) * (new_r01))));
+                                    evalcond[5] = ((((IkReal(-1.00000000000000)) * (cj4) * (x165))) + (x162) +
+                                                   (((cj3) * (new_r00))));
+                                    evalcond[6] = ((((new_r01) * (x163))) + (((cj4) * (x161))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r21) * (x164))) + (x158));
+                                    evalcond[7] = ((((new_r00) * (x163))) + (((cj4) * (x162))) +
+                                                   (((IkReal(-1.00000000000000)) * (x165))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r20) * (x164))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                        IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                    vinfos[0].jointtype = 1;
+                                    vinfos[0].foffset = j0;
+                                    vinfos[0].indices[0] = _ij0[0];
+                                    vinfos[0].indices[1] = _ij0[1];
+                                    vinfos[0].maxsolutions = _nj0;
+                                    vinfos[1].jointtype = 1;
+                                    vinfos[1].foffset = j1;
+                                    vinfos[1].indices[0] = _ij1[0];
+                                    vinfos[1].indices[1] = _ij1[1];
+                                    vinfos[1].maxsolutions = _nj1;
+                                    vinfos[2].jointtype = 1;
+                                    vinfos[2].foffset = j2;
+                                    vinfos[2].indices[0] = _ij2[0];
+                                    vinfos[2].indices[1] = _ij2[1];
+                                    vinfos[2].maxsolutions = _nj2;
+                                    vinfos[3].jointtype = 1;
+                                    vinfos[3].foffset = j3;
+                                    vinfos[3].indices[0] = _ij3[0];
+                                    vinfos[3].indices[1] = _ij3[1];
+                                    vinfos[3].maxsolutions = _nj3;
+                                    vinfos[4].jointtype = 1;
+                                    vinfos[4].foffset = j4;
+                                    vinfos[4].indices[0] = _ij4[0];
+                                    vinfos[4].indices[1] = _ij4[1];
+                                    vinfos[4].maxsolutions = _nj4;
+                                    vinfos[5].jointtype = 1;
+                                    vinfos[5].foffset = j5;
+                                    vinfos[5].indices[0] = _ij5[0];
+                                    vinfos[5].indices[1] = _ij5[1];
+                                    vinfos[5].maxsolutions = _nj5;
+                                    std::vector<int> vfree(0);
+                                    solutions.AddSolution(vinfos, vfree);
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                else
+                {
+                  {
+                    IkReal j3array[1], cj3array[1], sj3array[1];
+                    bool j3valid[1] = { false };
+                    _nj3 = 1;
+                    IkReal x167 = ((gconst2) * (sj4));
+                    if (IKabs(((new_r12) * (x167))) < IKFAST_ATAN2_MAGTHRESH &&
+                        IKabs(((new_r02) * (x167))) < IKFAST_ATAN2_MAGTHRESH)
+                      continue;
+                    j3array[0] = IKatan2(((new_r12) * (x167)), ((new_r02) * (x167)));
+                    sj3array[0] = IKsin(j3array[0]);
+                    cj3array[0] = IKcos(j3array[0]);
+                    if (j3array[0] > IKPI)
+                    {
+                      j3array[0] -= IK2PI;
+                    }
+                    else if (j3array[0] < -IKPI)
+                    {
+                      j3array[0] += IK2PI;
+                    }
+                    j3valid[0] = true;
+                    for (int ij3 = 0; ij3 < 1; ++ij3)
+                    {
+                      if (!j3valid[ij3])
+                      {
+                        continue;
+                      }
+                      _ij3[0] = ij3;
+                      _ij3[1] = -1;
+                      for (int iij3 = ij3 + 1; iij3 < 1; ++iij3)
+                      {
+                        if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                            IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                        {
+                          j3valid[iij3] = false;
+                          _ij3[1] = iij3;
+                          break;
+                        }
+                      }
+                      j3 = j3array[ij3];
+                      cj3 = cj3array[ij3];
+                      sj3 = sj3array[ij3];
+                      {
+                        IkReal evalcond[6];
+                        IkReal x168 = IKsin(j3);
+                        IkReal x169 = IKcos(j3);
+                        IkReal x170 = ((IkReal(1.00000000000000)) * (sj4));
+                        IkReal x171 = ((sj4) * (x168));
+                        IkReal x172 = ((sj4) * (x169));
+                        IkReal x173 = ((new_r02) * (x169));
+                        IkReal x174 = ((new_r12) * (x168));
+                        evalcond[0] = ((((new_r12) * (x169))) + (((IkReal(-1.00000000000000)) * (new_r02) * (x168))));
+                        evalcond[1] = ((((IkReal(-1.00000000000000)) * (x170))) + (x173) + (x174));
+                        evalcond[2] = ((((new_r00) * (x172))) + (((new_r10) * (x171))) + (((cj4) * (new_r20))));
+                        evalcond[3] = ((((new_r01) * (x172))) + (((new_r11) * (x171))) + (((cj4) * (new_r21))));
+                        evalcond[4] = ((IkReal(-1.00000000000000)) + (((new_r02) * (x172))) + (((cj4) * (new_r22))) +
+                                       (((new_r12) * (x171))));
+                        evalcond[5] = ((((cj4) * (x174))) + (((cj4) * (x173))) +
+                                       (((IkReal(-1.00000000000000)) * (new_r22) * (x170))));
+                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                        {
+                          continue;
+                        }
+                      }
+
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst5;
+                        gconst5 = IKsign(sj4);
+                        dummyeval[0] = sj4;
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal dummyeval[1];
+                            dummyeval[0] = sj4;
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal dummyeval[1];
+                                dummyeval[0] = sj4;
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal evalcond[11];
+                                    IkReal x175 = ((IkReal(-1.00000000000000)) + (new_r22));
+                                    IkReal x176 =
+                                        ((((IkReal(-1.00000000000000)) * (new_r02) * (sj3))) + (((cj3) * (new_r12))));
+                                    IkReal x177 = ((((new_r12) * (sj3))) + (((cj3) * (new_r02))));
+                                    evalcond[0] =
+                                        ((IkReal(-3.14159265358979)) +
+                                         (IKfmod(((IkReal(3.14159265358979)) + (j4)), IkReal(6.28318530717959))));
+                                    evalcond[1] = x175;
+                                    evalcond[2] = new_r20;
+                                    evalcond[3] = new_r21;
+                                    evalcond[4] = x176;
+                                    evalcond[5] = x176;
+                                    evalcond[6] = x177;
+                                    evalcond[7] = new_r20;
+                                    evalcond[8] = new_r21;
+                                    evalcond[9] = x175;
+                                    evalcond[10] = x177;
+                                    if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[10]) < 0.0000010000000000)
+                                    {
+                                      {
+                                        IkReal j5array[1], cj5array[1], sj5array[1];
+                                        bool j5valid[1] = { false };
+                                        _nj5 = 1;
+                                        if (IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r11) * (sj3))))) +
+                                                  IKsqr(((((new_r10) * (sj3))) + (((cj3) * (new_r00))))) - 1) <=
+                                                IKFAST_SINCOS_THRESH)
+                                          continue;
+                                        j5array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj3) * (new_r01))) +
+                                                              (((IkReal(-1.00000000000000)) * (new_r11) * (sj3)))),
+                                                             ((((new_r10) * (sj3))) + (((cj3) * (new_r00)))));
+                                        sj5array[0] = IKsin(j5array[0]);
+                                        cj5array[0] = IKcos(j5array[0]);
+                                        if (j5array[0] > IKPI)
+                                        {
+                                          j5array[0] -= IK2PI;
+                                        }
+                                        else if (j5array[0] < -IKPI)
+                                        {
+                                          j5array[0] += IK2PI;
+                                        }
+                                        j5valid[0] = true;
+                                        for (int ij5 = 0; ij5 < 1; ++ij5)
+                                        {
+                                          if (!j5valid[ij5])
+                                          {
+                                            continue;
+                                          }
+                                          _ij5[0] = ij5;
+                                          _ij5[1] = -1;
+                                          for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                          {
+                                            if (j5valid[iij5] &&
+                                                IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                                IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                            {
+                                              j5valid[iij5] = false;
+                                              _ij5[1] = iij5;
+                                              break;
+                                            }
+                                          }
+                                          j5 = j5array[ij5];
+                                          cj5 = cj5array[ij5];
+                                          sj5 = sj5array[ij5];
+                                          {
+                                            IkReal evalcond[4];
+                                            IkReal x178 = IKsin(j5);
+                                            IkReal x179 = ((IkReal(1.00000000000000)) * (sj3));
+                                            IkReal x180 = ((IkReal(1.00000000000000)) * (IKcos(j5)));
+                                            evalcond[0] =
+                                                ((((IkReal(-1.00000000000000)) * (x178))) + (((cj3) * (new_r10))) +
+                                                 (((IkReal(-1.00000000000000)) * (new_r00) * (x179))));
+                                            evalcond[1] =
+                                                ((((IkReal(-1.00000000000000)) * (x180))) + (((cj3) * (new_r11))) +
+                                                 (((IkReal(-1.00000000000000)) * (new_r01) * (x179))));
+                                            evalcond[2] = ((((new_r11) * (sj3))) + (x178) + (((cj3) * (new_r01))));
+                                            evalcond[3] =
+                                                ((((new_r10) * (sj3))) + (((IkReal(-1.00000000000000)) * (x180))) +
+                                                 (((cj3) * (new_r00))));
+                                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                            {
+                                              continue;
+                                            }
+                                          }
+
+                                          {
+                                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                            vinfos[0].jointtype = 1;
+                                            vinfos[0].foffset = j0;
+                                            vinfos[0].indices[0] = _ij0[0];
+                                            vinfos[0].indices[1] = _ij0[1];
+                                            vinfos[0].maxsolutions = _nj0;
+                                            vinfos[1].jointtype = 1;
+                                            vinfos[1].foffset = j1;
+                                            vinfos[1].indices[0] = _ij1[0];
+                                            vinfos[1].indices[1] = _ij1[1];
+                                            vinfos[1].maxsolutions = _nj1;
+                                            vinfos[2].jointtype = 1;
+                                            vinfos[2].foffset = j2;
+                                            vinfos[2].indices[0] = _ij2[0];
+                                            vinfos[2].indices[1] = _ij2[1];
+                                            vinfos[2].maxsolutions = _nj2;
+                                            vinfos[3].jointtype = 1;
+                                            vinfos[3].foffset = j3;
+                                            vinfos[3].indices[0] = _ij3[0];
+                                            vinfos[3].indices[1] = _ij3[1];
+                                            vinfos[3].maxsolutions = _nj3;
+                                            vinfos[4].jointtype = 1;
+                                            vinfos[4].foffset = j4;
+                                            vinfos[4].indices[0] = _ij4[0];
+                                            vinfos[4].indices[1] = _ij4[1];
+                                            vinfos[4].maxsolutions = _nj4;
+                                            vinfos[5].jointtype = 1;
+                                            vinfos[5].foffset = j5;
+                                            vinfos[5].indices[0] = _ij5[0];
+                                            vinfos[5].indices[1] = _ij5[1];
+                                            vinfos[5].maxsolutions = _nj5;
+                                            std::vector<int> vfree(0);
+                                            solutions.AddSolution(vinfos, vfree);
+                                          }
+                                        }
+                                      }
+                                    }
+                                    else
+                                    {
+                                      IkReal x181 = ((new_r12) * (sj3));
+                                      IkReal x182 = ((IkReal(1.00000000000000)) * (new_r02));
+                                      IkReal x183 =
+                                          ((((cj3) * (new_r12))) + (((IkReal(-1.00000000000000)) * (sj3) * (x182))));
+                                      evalcond[0] =
+                                          ((IkReal(-3.14159265358979)) +
+                                           (IKfmod(((IkReal(1.11022302462516e-16)) + (j4)), IkReal(6.28318530717959))));
+                                      evalcond[1] = ((IkReal(1.00000000000000)) + (new_r22));
+                                      evalcond[2] = new_r20;
+                                      evalcond[3] = new_r21;
+                                      evalcond[4] = x183;
+                                      evalcond[5] = x183;
+                                      evalcond[6] = ((x181) + (((cj3) * (new_r02))));
+                                      evalcond[7] = ((IkReal(-1.00000000000000)) * (new_r20));
+                                      evalcond[8] = ((IkReal(-1.00000000000000)) * (new_r21));
+                                      evalcond[9] =
+                                          ((IkReal(-1.00000000000000)) + (((IkReal(-1.00000000000000)) * (new_r22))));
+                                      evalcond[10] = ((((IkReal(-1.00000000000000)) * (x181))) +
+                                                      (((IkReal(-1.00000000000000)) * (cj3) * (x182))));
+                                      if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[10]) < 0.0000010000000000)
+                                      {
+                                        {
+                                          IkReal j5array[1], cj5array[1], sj5array[1];
+                                          bool j5valid[1] = { false };
+                                          _nj5 = 1;
+                                          if (IKabs(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) <
+                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                              IKabs(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) <
+                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                              IKabs(IKsqr(((((new_r11) * (sj3))) + (((cj3) * (new_r01))))) +
+                                                    IKsqr(((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r10) * (sj3))))) -
+                                                    1) <= IKFAST_SINCOS_THRESH)
+                                            continue;
+                                          j5array[0] = IKatan2(((((new_r11) * (sj3))) + (((cj3) * (new_r01)))),
+                                                               ((((IkReal(-1.00000000000000)) * (cj3) * (new_r00))) +
+                                                                (((IkReal(-1.00000000000000)) * (new_r10) * (sj3)))));
+                                          sj5array[0] = IKsin(j5array[0]);
+                                          cj5array[0] = IKcos(j5array[0]);
+                                          if (j5array[0] > IKPI)
+                                          {
+                                            j5array[0] -= IK2PI;
+                                          }
+                                          else if (j5array[0] < -IKPI)
+                                          {
+                                            j5array[0] += IK2PI;
+                                          }
+                                          j5valid[0] = true;
+                                          for (int ij5 = 0; ij5 < 1; ++ij5)
+                                          {
+                                            if (!j5valid[ij5])
+                                            {
+                                              continue;
+                                            }
+                                            _ij5[0] = ij5;
+                                            _ij5[1] = -1;
+                                            for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                            {
+                                              if (j5valid[iij5] &&
+                                                  IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                                  IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                              {
+                                                j5valid[iij5] = false;
+                                                _ij5[1] = iij5;
+                                                break;
+                                              }
+                                            }
+                                            j5 = j5array[ij5];
+                                            cj5 = cj5array[ij5];
+                                            sj5 = sj5array[ij5];
+                                            {
+                                              IkReal evalcond[4];
+                                              IkReal x184 = IKcos(j5);
+                                              IkReal x185 = ((IkReal(1.00000000000000)) * (sj3));
+                                              IkReal x186 = ((IkReal(1.00000000000000)) * (IKsin(j5)));
+                                              evalcond[0] =
+                                                  ((((IkReal(-1.00000000000000)) * (x186))) + (((cj3) * (new_r10))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r00) * (x185))));
+                                              evalcond[1] = ((((IkReal(-1.00000000000000)) * (x184))) +
+                                                             (((IkReal(-1.00000000000000)) * (new_r01) * (x185))) +
+                                                             (((cj3) * (new_r11))));
+                                              evalcond[2] =
+                                                  ((((new_r11) * (sj3))) + (((IkReal(-1.00000000000000)) * (x186))) +
+                                                   (((cj3) * (new_r01))));
+                                              evalcond[3] = ((((new_r10) * (sj3))) + (x184) + (((cj3) * (new_r00))));
+                                              if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                  IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                              {
+                                                continue;
+                                              }
+                                            }
+
+                                            {
+                                              std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                              vinfos[0].jointtype = 1;
+                                              vinfos[0].foffset = j0;
+                                              vinfos[0].indices[0] = _ij0[0];
+                                              vinfos[0].indices[1] = _ij0[1];
+                                              vinfos[0].maxsolutions = _nj0;
+                                              vinfos[1].jointtype = 1;
+                                              vinfos[1].foffset = j1;
+                                              vinfos[1].indices[0] = _ij1[0];
+                                              vinfos[1].indices[1] = _ij1[1];
+                                              vinfos[1].maxsolutions = _nj1;
+                                              vinfos[2].jointtype = 1;
+                                              vinfos[2].foffset = j2;
+                                              vinfos[2].indices[0] = _ij2[0];
+                                              vinfos[2].indices[1] = _ij2[1];
+                                              vinfos[2].maxsolutions = _nj2;
+                                              vinfos[3].jointtype = 1;
+                                              vinfos[3].foffset = j3;
+                                              vinfos[3].indices[0] = _ij3[0];
+                                              vinfos[3].indices[1] = _ij3[1];
+                                              vinfos[3].maxsolutions = _nj3;
+                                              vinfos[4].jointtype = 1;
+                                              vinfos[4].foffset = j4;
+                                              vinfos[4].indices[0] = _ij4[0];
+                                              vinfos[4].indices[1] = _ij4[1];
+                                              vinfos[4].maxsolutions = _nj4;
+                                              vinfos[5].jointtype = 1;
+                                              vinfos[5].foffset = j5;
+                                              vinfos[5].indices[0] = _ij5[0];
+                                              vinfos[5].indices[1] = _ij5[1];
+                                              vinfos[5].maxsolutions = _nj5;
+                                              std::vector<int> vfree(0);
+                                              solutions.AddSolution(vinfos, vfree);
+                                            }
+                                          }
+                                        }
+                                      }
+                                      else
+                                      {
+                                        if (1)
+                                        {
+                                          continue;
+                                        }
+                                        else
+                                        {
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j5array[1], cj5array[1], sj5array[1];
+                                    bool j5valid[1] = { false };
+                                    _nj5 = 1;
+                                    if (IKabs(((((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (new_r00) *
+                                                                         (sj3))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((IkReal(-1.00000000000000)) * (new_r20) *
+                                               (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(IKsqr(((((cj3) * (new_r10))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r00) * (sj3))))) +
+                                              IKsqr(((IkReal(-1.00000000000000)) * (new_r20) *
+                                                     (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) -
+                                              1) <= IKFAST_SINCOS_THRESH)
+                                      continue;
+                                    j5array[0] = IKatan2(
+                                        ((((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (new_r00) * (sj3)))),
+                                        ((IkReal(-1.00000000000000)) * (new_r20) *
+                                         (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30))));
+                                    sj5array[0] = IKsin(j5array[0]);
+                                    cj5array[0] = IKcos(j5array[0]);
+                                    if (j5array[0] > IKPI)
+                                    {
+                                      j5array[0] -= IK2PI;
+                                    }
+                                    else if (j5array[0] < -IKPI)
+                                    {
+                                      j5array[0] += IK2PI;
+                                    }
+                                    j5valid[0] = true;
+                                    for (int ij5 = 0; ij5 < 1; ++ij5)
+                                    {
+                                      if (!j5valid[ij5])
+                                      {
+                                        continue;
+                                      }
+                                      _ij5[0] = ij5;
+                                      _ij5[1] = -1;
+                                      for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                      {
+                                        if (j5valid[iij5] &&
+                                            IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j5valid[iij5] = false;
+                                          _ij5[1] = iij5;
+                                          break;
+                                        }
+                                      }
+                                      j5 = j5array[ij5];
+                                      cj5 = cj5array[ij5];
+                                      sj5 = sj5array[ij5];
+                                      {
+                                        IkReal evalcond[8];
+                                        IkReal x187 = IKsin(j5);
+                                        IkReal x188 = IKcos(j5);
+                                        IkReal x189 = ((IkReal(1.00000000000000)) * (sj3));
+                                        IkReal x190 = ((new_r11) * (sj3));
+                                        IkReal x191 = ((new_r10) * (sj3));
+                                        IkReal x192 = ((cj3) * (cj4));
+                                        IkReal x193 = ((IkReal(1.00000000000000)) * (sj4));
+                                        IkReal x194 = ((IkReal(1.00000000000000)) * (x188));
+                                        IkReal x195 = ((IkReal(1.00000000000000)) * (x187));
+                                        evalcond[0] = ((((sj4) * (x188))) + (new_r20));
+                                        evalcond[1] = ((((IkReal(-1.00000000000000)) * (x187) * (x193))) + (new_r21));
+                                        evalcond[2] =
+                                            ((((IkReal(-1.00000000000000)) * (x195))) + (((cj3) * (new_r10))) +
+                                             (((IkReal(-1.00000000000000)) * (new_r00) * (x189))));
+                                        evalcond[3] = ((((IkReal(-1.00000000000000)) * (x194))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r01) * (x189))) +
+                                                       (((cj3) * (new_r11))));
+                                        evalcond[4] = ((x190) + (((cj3) * (new_r01))) + (((cj4) * (x187))));
+                                        evalcond[5] = ((((IkReal(-1.00000000000000)) * (cj4) * (x194))) + (x191) +
+                                                       (((cj3) * (new_r00))));
+                                        evalcond[6] = ((((cj4) * (x190))) + (((new_r01) * (x192))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r21) * (x193))) + (x187));
+                                        evalcond[7] = ((((cj4) * (x191))) + (((new_r00) * (x192))) +
+                                                       (((IkReal(-1.00000000000000)) * (x194))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r20) * (x193))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                            IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              {
+                                IkReal j5array[1], cj5array[1], sj5array[1];
+                                bool j5valid[1] = { false };
+                                _nj5 = 1;
+                                if (IKabs(((new_r21) * (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) <
+                                        IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) +
+                                           (((cj3) * (new_r11))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(IKsqr(((new_r21) *
+                                                 (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30)))) +
+                                          IKsqr(((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) +
+                                                 (((cj3) * (new_r11))))) -
+                                          1) <= IKFAST_SINCOS_THRESH)
+                                  continue;
+                                j5array[0] = IKatan2(
+                                    ((new_r21) * (((IKabs(sj4) != 0) ? ((IkReal)1 / (sj4)) : (IkReal)1.0e30))),
+                                    ((((IkReal(-1.00000000000000)) * (new_r01) * (sj3))) + (((cj3) * (new_r11)))));
+                                sj5array[0] = IKsin(j5array[0]);
+                                cj5array[0] = IKcos(j5array[0]);
+                                if (j5array[0] > IKPI)
+                                {
+                                  j5array[0] -= IK2PI;
+                                }
+                                else if (j5array[0] < -IKPI)
+                                {
+                                  j5array[0] += IK2PI;
+                                }
+                                j5valid[0] = true;
+                                for (int ij5 = 0; ij5 < 1; ++ij5)
+                                {
+                                  if (!j5valid[ij5])
+                                  {
+                                    continue;
+                                  }
+                                  _ij5[0] = ij5;
+                                  _ij5[1] = -1;
+                                  for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                  {
+                                    if (j5valid[iij5] &&
+                                        IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j5valid[iij5] = false;
+                                      _ij5[1] = iij5;
+                                      break;
+                                    }
+                                  }
+                                  j5 = j5array[ij5];
+                                  cj5 = cj5array[ij5];
+                                  sj5 = sj5array[ij5];
+                                  {
+                                    IkReal evalcond[8];
+                                    IkReal x196 = IKsin(j5);
+                                    IkReal x197 = IKcos(j5);
+                                    IkReal x198 = ((IkReal(1.00000000000000)) * (sj3));
+                                    IkReal x199 = ((new_r11) * (sj3));
+                                    IkReal x200 = ((new_r10) * (sj3));
+                                    IkReal x201 = ((cj3) * (cj4));
+                                    IkReal x202 = ((IkReal(1.00000000000000)) * (sj4));
+                                    IkReal x203 = ((IkReal(1.00000000000000)) * (x197));
+                                    IkReal x204 = ((IkReal(1.00000000000000)) * (x196));
+                                    evalcond[0] = ((((sj4) * (x197))) + (new_r20));
+                                    evalcond[1] = ((new_r21) + (((IkReal(-1.00000000000000)) * (x196) * (x202))));
+                                    evalcond[2] = ((((IkReal(-1.00000000000000)) * (x204))) + (((cj3) * (new_r10))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r00) * (x198))));
+                                    evalcond[3] =
+                                        ((((IkReal(-1.00000000000000)) * (x203))) +
+                                         (((IkReal(-1.00000000000000)) * (new_r01) * (x198))) + (((cj3) * (new_r11))));
+                                    evalcond[4] = ((((cj4) * (x196))) + (x199) + (((cj3) * (new_r01))));
+                                    evalcond[5] = ((((IkReal(-1.00000000000000)) * (cj4) * (x203))) + (x200) +
+                                                   (((cj3) * (new_r00))));
+                                    evalcond[6] =
+                                        ((((cj4) * (x199))) + (((IkReal(-1.00000000000000)) * (new_r21) * (x202))) +
+                                         (((new_r01) * (x201))) + (x196));
+                                    evalcond[7] =
+                                        ((((new_r00) * (x201))) + (((IkReal(-1.00000000000000)) * (new_r20) * (x202))) +
+                                         (((IkReal(-1.00000000000000)) * (x203))) + (((cj4) * (x200))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                        IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                    vinfos[0].jointtype = 1;
+                                    vinfos[0].foffset = j0;
+                                    vinfos[0].indices[0] = _ij0[0];
+                                    vinfos[0].indices[1] = _ij0[1];
+                                    vinfos[0].maxsolutions = _nj0;
+                                    vinfos[1].jointtype = 1;
+                                    vinfos[1].foffset = j1;
+                                    vinfos[1].indices[0] = _ij1[0];
+                                    vinfos[1].indices[1] = _ij1[1];
+                                    vinfos[1].maxsolutions = _nj1;
+                                    vinfos[2].jointtype = 1;
+                                    vinfos[2].foffset = j2;
+                                    vinfos[2].indices[0] = _ij2[0];
+                                    vinfos[2].indices[1] = _ij2[1];
+                                    vinfos[2].maxsolutions = _nj2;
+                                    vinfos[3].jointtype = 1;
+                                    vinfos[3].foffset = j3;
+                                    vinfos[3].indices[0] = _ij3[0];
+                                    vinfos[3].indices[1] = _ij3[1];
+                                    vinfos[3].maxsolutions = _nj3;
+                                    vinfos[4].jointtype = 1;
+                                    vinfos[4].foffset = j4;
+                                    vinfos[4].indices[0] = _ij4[0];
+                                    vinfos[4].indices[1] = _ij4[1];
+                                    vinfos[4].maxsolutions = _nj4;
+                                    vinfos[5].jointtype = 1;
+                                    vinfos[5].foffset = j5;
+                                    vinfos[5].indices[0] = _ij5[0];
+                                    vinfos[5].indices[1] = _ij5[1];
+                                    vinfos[5].maxsolutions = _nj5;
+                                    std::vector<int> vfree(0);
+                                    solutions.AddSolution(vinfos, vfree);
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          {
+                            IkReal j5array[1], cj5array[1], sj5array[1];
+                            bool j5valid[1] = { false };
+                            _nj5 = 1;
+                            if (IKabs(((gconst5) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((IkReal(-1.00000000000000)) * (gconst5) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j5array[0] =
+                                IKatan2(((gconst5) * (new_r21)), ((IkReal(-1.00000000000000)) * (gconst5) * (new_r20)));
+                            sj5array[0] = IKsin(j5array[0]);
+                            cj5array[0] = IKcos(j5array[0]);
+                            if (j5array[0] > IKPI)
+                            {
+                              j5array[0] -= IK2PI;
+                            }
+                            else if (j5array[0] < -IKPI)
+                            {
+                              j5array[0] += IK2PI;
+                            }
+                            j5valid[0] = true;
+                            for (int ij5 = 0; ij5 < 1; ++ij5)
+                            {
+                              if (!j5valid[ij5])
+                              {
+                                continue;
+                              }
+                              _ij5[0] = ij5;
+                              _ij5[1] = -1;
+                              for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                              {
+                                if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j5valid[iij5] = false;
+                                  _ij5[1] = iij5;
+                                  break;
+                                }
+                              }
+                              j5 = j5array[ij5];
+                              cj5 = cj5array[ij5];
+                              sj5 = sj5array[ij5];
+                              {
+                                IkReal evalcond[8];
+                                IkReal x205 = IKsin(j5);
+                                IkReal x206 = IKcos(j5);
+                                IkReal x207 = ((IkReal(1.00000000000000)) * (sj3));
+                                IkReal x208 = ((new_r11) * (sj3));
+                                IkReal x209 = ((new_r10) * (sj3));
+                                IkReal x210 = ((cj3) * (cj4));
+                                IkReal x211 = ((IkReal(1.00000000000000)) * (sj4));
+                                IkReal x212 = ((IkReal(1.00000000000000)) * (x206));
+                                IkReal x213 = ((IkReal(1.00000000000000)) * (x205));
+                                evalcond[0] = ((((sj4) * (x206))) + (new_r20));
+                                evalcond[1] = ((((IkReal(-1.00000000000000)) * (x205) * (x211))) + (new_r21));
+                                evalcond[2] = ((((IkReal(-1.00000000000000)) * (new_r00) * (x207))) +
+                                               (((cj3) * (new_r10))) + (((IkReal(-1.00000000000000)) * (x213))));
+                                evalcond[3] = ((((cj3) * (new_r11))) + (((IkReal(-1.00000000000000)) * (x212))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r01) * (x207))));
+                                evalcond[4] = ((((cj4) * (x205))) + (x208) + (((cj3) * (new_r01))));
+                                evalcond[5] =
+                                    ((x209) + (((IkReal(-1.00000000000000)) * (cj4) * (x212))) + (((cj3) * (new_r00))));
+                                evalcond[6] =
+                                    ((((cj4) * (x208))) + (x205) +
+                                     (((IkReal(-1.00000000000000)) * (new_r21) * (x211))) + (((new_r01) * (x210))));
+                                evalcond[7] = ((((cj4) * (x209))) + (((new_r00) * (x210))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r20) * (x211))) +
+                                               (((IkReal(-1.00000000000000)) * (x212))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                    IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                vinfos[0].jointtype = 1;
+                                vinfos[0].foffset = j0;
+                                vinfos[0].indices[0] = _ij0[0];
+                                vinfos[0].indices[1] = _ij0[1];
+                                vinfos[0].maxsolutions = _nj0;
+                                vinfos[1].jointtype = 1;
+                                vinfos[1].foffset = j1;
+                                vinfos[1].indices[0] = _ij1[0];
+                                vinfos[1].indices[1] = _ij1[1];
+                                vinfos[1].maxsolutions = _nj1;
+                                vinfos[2].jointtype = 1;
+                                vinfos[2].foffset = j2;
+                                vinfos[2].indices[0] = _ij2[0];
+                                vinfos[2].indices[1] = _ij2[1];
+                                vinfos[2].maxsolutions = _nj2;
+                                vinfos[3].jointtype = 1;
+                                vinfos[3].foffset = j3;
+                                vinfos[3].indices[0] = _ij3[0];
+                                vinfos[3].indices[1] = _ij3[1];
+                                vinfos[3].maxsolutions = _nj3;
+                                vinfos[4].jointtype = 1;
+                                vinfos[4].foffset = j4;
+                                vinfos[4].indices[0] = _ij4[0];
+                                vinfos[4].indices[1] = _ij4[1];
+                                vinfos[4].maxsolutions = _nj4;
+                                vinfos[5].jointtype = 1;
+                                vinfos[5].foffset = j5;
+                                vinfos[5].indices[0] = _ij5[0];
+                                vinfos[5].indices[1] = _ij5[1];
+                                vinfos[5].maxsolutions = _nj5;
+                                std::vector<int> vfree(0);
+                                solutions.AddSolution(vinfos, vfree);
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            else
+            {
+              {
+                IkReal j5array[1], cj5array[1], sj5array[1];
+                bool j5valid[1] = { false };
+                _nj5 = 1;
+                if (IKabs(((gconst4) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                    IKabs(((IkReal(-1.00000000000000)) * (gconst4) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH)
+                  continue;
+                j5array[0] = IKatan2(((gconst4) * (new_r21)), ((IkReal(-1.00000000000000)) * (gconst4) * (new_r20)));
+                sj5array[0] = IKsin(j5array[0]);
+                cj5array[0] = IKcos(j5array[0]);
+                if (j5array[0] > IKPI)
+                {
+                  j5array[0] -= IK2PI;
+                }
+                else if (j5array[0] < -IKPI)
+                {
+                  j5array[0] += IK2PI;
+                }
+                j5valid[0] = true;
+                for (int ij5 = 0; ij5 < 1; ++ij5)
+                {
+                  if (!j5valid[ij5])
+                  {
+                    continue;
+                  }
+                  _ij5[0] = ij5;
+                  _ij5[1] = -1;
+                  for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                  {
+                    if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                        IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                    {
+                      j5valid[iij5] = false;
+                      _ij5[1] = iij5;
+                      break;
+                    }
+                  }
+                  j5 = j5array[ij5];
+                  cj5 = cj5array[ij5];
+                  sj5 = sj5array[ij5];
+                  {
+                    IkReal evalcond[2];
+                    evalcond[0] = ((((sj4) * (IKcos(j5)))) + (new_r20));
+                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (sj4) * (IKsin(j5)))) + (new_r21));
+                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001)
+                    {
+                      continue;
+                    }
+                  }
+
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst6;
+                    gconst6 = IKsign((((new_r12) * (new_r12)) + ((new_r02) * (new_r02))));
+                    dummyeval[0] = (((new_r12) * (new_r12)) + ((new_r02) * (new_r02)));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst7;
+                        gconst7 = IKsign(((((IkReal(-1.00000000000000)) * (new_r11) * (new_r12))) +
+                                          (((IkReal(-1.00000000000000)) * (new_r01) * (new_r02)))));
+                        dummyeval[0] = ((((IkReal(-1.00000000000000)) * (new_r11) * (new_r12))) +
+                                        (((IkReal(-1.00000000000000)) * (new_r01) * (new_r02))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          continue;
+                        }
+                        else
+                        {
+                          {
+                            IkReal j3array[1], cj3array[1], sj3array[1];
+                            bool j3valid[1] = { false };
+                            _nj3 = 1;
+                            IkReal x214 = ((cj4) * (gconst7) * (sj5));
+                            if (IKabs(((new_r12) * (x214))) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((new_r02) * (x214))) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j3array[0] = IKatan2(((new_r12) * (x214)), ((new_r02) * (x214)));
+                            sj3array[0] = IKsin(j3array[0]);
+                            cj3array[0] = IKcos(j3array[0]);
+                            if (j3array[0] > IKPI)
+                            {
+                              j3array[0] -= IK2PI;
+                            }
+                            else if (j3array[0] < -IKPI)
+                            {
+                              j3array[0] += IK2PI;
+                            }
+                            j3valid[0] = true;
+                            for (int ij3 = 0; ij3 < 1; ++ij3)
+                            {
+                              if (!j3valid[ij3])
+                              {
+                                continue;
+                              }
+                              _ij3[0] = ij3;
+                              _ij3[1] = -1;
+                              for (int iij3 = ij3 + 1; iij3 < 1; ++iij3)
+                              {
+                                if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j3valid[iij3] = false;
+                                  _ij3[1] = iij3;
+                                  break;
+                                }
+                              }
+                              j3 = j3array[ij3];
+                              cj3 = cj3array[ij3];
+                              sj3 = sj3array[ij3];
+                              {
+                                IkReal evalcond[12];
+                                IkReal x215 = IKsin(j3);
+                                IkReal x216 = IKcos(j3);
+                                IkReal x217 = ((IkReal(1.00000000000000)) * (cj5));
+                                IkReal x218 = ((IkReal(1.00000000000000)) * (sj4));
+                                IkReal x219 = ((cj4) * (x216));
+                                IkReal x220 = ((sj4) * (x216));
+                                IkReal x221 = ((cj4) * (x215));
+                                IkReal x222 = ((new_r11) * (x215));
+                                IkReal x223 = ((sj4) * (x215));
+                                IkReal x224 = ((IkReal(1.00000000000000)) * (x215));
+                                evalcond[0] =
+                                    ((((IkReal(-1.00000000000000)) * (new_r02) * (x224))) + (((new_r12) * (x216))));
+                                evalcond[1] = ((((new_r02) * (x216))) + (((IkReal(-1.00000000000000)) * (x218))) +
+                                               (((new_r12) * (x215))));
+                                evalcond[2] = ((((IkReal(-1.00000000000000)) * (sj5))) + (((new_r10) * (x216))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r00) * (x224))));
+                                evalcond[3] = ((((IkReal(-1.00000000000000)) * (new_r01) * (x224))) +
+                                               (((IkReal(-1.00000000000000)) * (x217))) + (((new_r11) * (x216))));
+                                evalcond[4] = ((((cj4) * (sj5))) + (x222) + (((new_r01) * (x216))));
+                                evalcond[5] = ((((IkReal(-1.00000000000000)) * (cj4) * (x217))) +
+                                               (((new_r00) * (x216))) + (((new_r10) * (x215))));
+                                evalcond[6] = ((((new_r00) * (x220))) + (((cj4) * (new_r20))) + (((new_r10) * (x223))));
+                                evalcond[7] = ((((sj4) * (x222))) + (((new_r01) * (x220))) + (((cj4) * (new_r21))));
+                                evalcond[8] = ((IkReal(-1.00000000000000)) + (((new_r02) * (x220))) +
+                                               (((cj4) * (new_r22))) + (((new_r12) * (x223))));
+                                evalcond[9] = ((((new_r12) * (x221))) + (((new_r02) * (x219))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r22) * (x218))));
+                                evalcond[10] = ((sj5) + (((IkReal(-1.00000000000000)) * (new_r21) * (x218))) +
+                                                (((new_r11) * (x221))) + (((new_r01) * (x219))));
+                                evalcond[11] =
+                                    ((((new_r00) * (x219))) + (((IkReal(-1.00000000000000)) * (new_r20) * (x218))) +
+                                     (((new_r10) * (x221))) + (((IkReal(-1.00000000000000)) * (x217))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                    IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001 ||
+                                    IKabs(evalcond[8]) > 0.000001 || IKabs(evalcond[9]) > 0.000001 ||
+                                    IKabs(evalcond[10]) > 0.000001 || IKabs(evalcond[11]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                                vinfos[0].jointtype = 1;
+                                vinfos[0].foffset = j0;
+                                vinfos[0].indices[0] = _ij0[0];
+                                vinfos[0].indices[1] = _ij0[1];
+                                vinfos[0].maxsolutions = _nj0;
+                                vinfos[1].jointtype = 1;
+                                vinfos[1].foffset = j1;
+                                vinfos[1].indices[0] = _ij1[0];
+                                vinfos[1].indices[1] = _ij1[1];
+                                vinfos[1].maxsolutions = _nj1;
+                                vinfos[2].jointtype = 1;
+                                vinfos[2].foffset = j2;
+                                vinfos[2].indices[0] = _ij2[0];
+                                vinfos[2].indices[1] = _ij2[1];
+                                vinfos[2].maxsolutions = _nj2;
+                                vinfos[3].jointtype = 1;
+                                vinfos[3].foffset = j3;
+                                vinfos[3].indices[0] = _ij3[0];
+                                vinfos[3].indices[1] = _ij3[1];
+                                vinfos[3].maxsolutions = _nj3;
+                                vinfos[4].jointtype = 1;
+                                vinfos[4].foffset = j4;
+                                vinfos[4].indices[0] = _ij4[0];
+                                vinfos[4].indices[1] = _ij4[1];
+                                vinfos[4].maxsolutions = _nj4;
+                                vinfos[5].jointtype = 1;
+                                vinfos[5].foffset = j5;
+                                vinfos[5].indices[0] = _ij5[0];
+                                vinfos[5].indices[1] = _ij5[1];
+                                vinfos[5].maxsolutions = _nj5;
+                                std::vector<int> vfree(0);
+                                solutions.AddSolution(vinfos, vfree);
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j3array[1], cj3array[1], sj3array[1];
+                        bool j3valid[1] = { false };
+                        _nj3 = 1;
+                        IkReal x225 = ((gconst6) * (sj4));
+                        if (IKabs(((new_r12) * (x225))) < IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((new_r02) * (x225))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j3array[0] = IKatan2(((new_r12) * (x225)), ((new_r02) * (x225)));
+                        sj3array[0] = IKsin(j3array[0]);
+                        cj3array[0] = IKcos(j3array[0]);
+                        if (j3array[0] > IKPI)
+                        {
+                          j3array[0] -= IK2PI;
+                        }
+                        else if (j3array[0] < -IKPI)
+                        {
+                          j3array[0] += IK2PI;
+                        }
+                        j3valid[0] = true;
+                        for (int ij3 = 0; ij3 < 1; ++ij3)
+                        {
+                          if (!j3valid[ij3])
+                          {
+                            continue;
+                          }
+                          _ij3[0] = ij3;
+                          _ij3[1] = -1;
+                          for (int iij3 = ij3 + 1; iij3 < 1; ++iij3)
+                          {
+                            if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j3valid[iij3] = false;
+                              _ij3[1] = iij3;
+                              break;
+                            }
+                          }
+                          j3 = j3array[ij3];
+                          cj3 = cj3array[ij3];
+                          sj3 = sj3array[ij3];
+                          {
+                            IkReal evalcond[12];
+                            IkReal x226 = IKsin(j3);
+                            IkReal x227 = IKcos(j3);
+                            IkReal x228 = ((IkReal(1.00000000000000)) * (cj5));
+                            IkReal x229 = ((IkReal(1.00000000000000)) * (sj4));
+                            IkReal x230 = ((cj4) * (x227));
+                            IkReal x231 = ((sj4) * (x227));
+                            IkReal x232 = ((cj4) * (x226));
+                            IkReal x233 = ((new_r11) * (x226));
+                            IkReal x234 = ((sj4) * (x226));
+                            IkReal x235 = ((IkReal(1.00000000000000)) * (x226));
+                            evalcond[0] =
+                                ((((IkReal(-1.00000000000000)) * (new_r02) * (x235))) + (((new_r12) * (x227))));
+                            evalcond[1] = ((((new_r02) * (x227))) + (((new_r12) * (x226))) +
+                                           (((IkReal(-1.00000000000000)) * (x229))));
+                            evalcond[2] = ((((IkReal(-1.00000000000000)) * (sj5))) + (((new_r10) * (x227))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r00) * (x235))));
+                            evalcond[3] =
+                                ((((new_r11) * (x227))) + (((IkReal(-1.00000000000000)) * (new_r01) * (x235))) +
+                                 (((IkReal(-1.00000000000000)) * (x228))));
+                            evalcond[4] = ((((new_r01) * (x227))) + (((cj4) * (sj5))) + (x233));
+                            evalcond[5] = ((((new_r00) * (x227))) + (((IkReal(-1.00000000000000)) * (cj4) * (x228))) +
+                                           (((new_r10) * (x226))));
+                            evalcond[6] = ((((new_r10) * (x234))) + (((cj4) * (new_r20))) + (((new_r00) * (x231))));
+                            evalcond[7] = ((((new_r01) * (x231))) + (((cj4) * (new_r21))) + (((sj4) * (x233))));
+                            evalcond[8] = ((IkReal(-1.00000000000000)) + (((new_r02) * (x231))) +
+                                           (((cj4) * (new_r22))) + (((new_r12) * (x234))));
+                            evalcond[9] = ((((new_r02) * (x230))) + (((new_r12) * (x232))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r22) * (x229))));
+                            evalcond[10] = ((sj5) + (((new_r11) * (x232))) + (((new_r01) * (x230))) +
+                                            (((IkReal(-1.00000000000000)) * (new_r21) * (x229))));
+                            evalcond[11] = ((((new_r10) * (x232))) + (((new_r00) * (x230))) +
+                                            (((IkReal(-1.00000000000000)) * (new_r20) * (x229))) +
+                                            (((IkReal(-1.00000000000000)) * (x228))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001 ||
+                                IKabs(evalcond[8]) > 0.000001 || IKabs(evalcond[9]) > 0.000001 ||
+                                IKabs(evalcond[10]) > 0.000001 || IKabs(evalcond[11]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          {
+                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(6);
+                            vinfos[0].jointtype = 1;
+                            vinfos[0].foffset = j0;
+                            vinfos[0].indices[0] = _ij0[0];
+                            vinfos[0].indices[1] = _ij0[1];
+                            vinfos[0].maxsolutions = _nj0;
+                            vinfos[1].jointtype = 1;
+                            vinfos[1].foffset = j1;
+                            vinfos[1].indices[0] = _ij1[0];
+                            vinfos[1].indices[1] = _ij1[1];
+                            vinfos[1].maxsolutions = _nj1;
+                            vinfos[2].jointtype = 1;
+                            vinfos[2].foffset = j2;
+                            vinfos[2].indices[0] = _ij2[0];
+                            vinfos[2].indices[1] = _ij2[1];
+                            vinfos[2].maxsolutions = _nj2;
+                            vinfos[3].jointtype = 1;
+                            vinfos[3].foffset = j3;
+                            vinfos[3].indices[0] = _ij3[0];
+                            vinfos[3].indices[1] = _ij3[1];
+                            vinfos[3].maxsolutions = _nj3;
+                            vinfos[4].jointtype = 1;
+                            vinfos[4].foffset = j4;
+                            vinfos[4].indices[0] = _ij4[0];
+                            vinfos[4].indices[1] = _ij4[1];
+                            vinfos[4].maxsolutions = _nj4;
+                            vinfos[5].jointtype = 1;
+                            vinfos[5].foffset = j5;
+                            vinfos[5].indices[0] = _ij5[0];
+                            vinfos[5].indices[1] = _ij5[1];
+                            vinfos[5].maxsolutions = _nj5;
+                            std::vector<int> vfree(0);
+                            solutions.AddSolution(vinfos, vfree);
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
 
 /// solves the inverse kinematics equations.
 /// \param pfree is an array specifying the free joints of the chain.
-IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions) {
-IKSolver solver;
-return solver.ComputeIk(eetrans,eerot,pfree,solutions);
+IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree,
+                          IkSolutionListBase<IkReal>& solutions)
+{
+  IKSolver solver;
+  return solver.ComputeIk(eetrans, eerot, pfree, solutions);
 }
 
-IKFAST_API const char* GetKinematicsHash() { return "<robot:genericrobot - kuka_kr210 (328f5fa894ca1be3105acbe6b4ce997b)>"; }
+IKFAST_API const char* GetKinematicsHash()
+{
+  return "<robot:genericrobot - kuka_kr210 (328f5fa894ca1be3105acbe6b4ce997b)>";
+}
 
-IKFAST_API const char* GetIkFastVersion() { return IKFAST_STRINGIZE(IKFAST_VERSION); }
+IKFAST_API const char* GetIkFastVersion()
+{
+  return IKFAST_STRINGIZE(IKFAST_VERSION);
+}
 
 #ifdef IKFAST_NAMESPACE
-} // end namespace
+}  // end namespace
 #endif
 
 #ifndef IKFAST_NO_MAIN
@@ -2821,41 +3813,54 @@ using namespace IKFAST_NAMESPACE;
 #endif
 int main(int argc, char** argv)
 {
-    if( argc != 12+GetNumFreeParameters()+1 ) {
-        printf("\nUsage: ./ik r00 r01 r02 t0 r10 r11 r12 t1 r20 r21 r22 t2 free0 ...\n\n"
-               "Returns the ik solutions given the transformation of the end effector specified by\n"
-               "a 3x3 rotation R (rXX), and a 3x1 translation (tX).\n"
-               "There are %d free parameters that have to be specified.\n\n",GetNumFreeParameters());
-        return 1;
-    }
+  if (argc != 12 + GetNumFreeParameters() + 1)
+  {
+    printf("\nUsage: ./ik r00 r01 r02 t0 r10 r11 r12 t1 r20 r21 r22 t2 free0 ...\n\n"
+           "Returns the ik solutions given the transformation of the end effector specified by\n"
+           "a 3x3 rotation R (rXX), and a 3x1 translation (tX).\n"
+           "There are %d free parameters that have to be specified.\n\n",
+           GetNumFreeParameters());
+    return 1;
+  }
 
-    IkSolutionList<IkReal> solutions;
-    std::vector<IkReal> vfree(GetNumFreeParameters());
-    IkReal eerot[9],eetrans[3];
-    eerot[0] = atof(argv[1]); eerot[1] = atof(argv[2]); eerot[2] = atof(argv[3]); eetrans[0] = atof(argv[4]);
-    eerot[3] = atof(argv[5]); eerot[4] = atof(argv[6]); eerot[5] = atof(argv[7]); eetrans[1] = atof(argv[8]);
-    eerot[6] = atof(argv[9]); eerot[7] = atof(argv[10]); eerot[8] = atof(argv[11]); eetrans[2] = atof(argv[12]);
-    for(std::size_t i = 0; i < vfree.size(); ++i)
-        vfree[i] = atof(argv[13+i]);
-    bool bSuccess = ComputeIk(eetrans, eerot, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
+  IkSolutionList<IkReal> solutions;
+  std::vector<IkReal> vfree(GetNumFreeParameters());
+  IkReal eerot[9], eetrans[3];
+  eerot[0] = atof(argv[1]);
+  eerot[1] = atof(argv[2]);
+  eerot[2] = atof(argv[3]);
+  eetrans[0] = atof(argv[4]);
+  eerot[3] = atof(argv[5]);
+  eerot[4] = atof(argv[6]);
+  eerot[5] = atof(argv[7]);
+  eetrans[1] = atof(argv[8]);
+  eerot[6] = atof(argv[9]);
+  eerot[7] = atof(argv[10]);
+  eerot[8] = atof(argv[11]);
+  eetrans[2] = atof(argv[12]);
+  for (std::size_t i = 0; i < vfree.size(); ++i)
+    vfree[i] = atof(argv[13 + i]);
+  bool bSuccess = ComputeIk(eetrans, eerot, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
 
-    if( !bSuccess ) {
-        fprintf(stderr,"Failed to get ik solution\n");
-        return -1;
-    }
+  if (!bSuccess)
+  {
+    fprintf(stderr, "Failed to get ik solution\n");
+    return -1;
+  }
 
-    printf("Found %d ik solutions:\n", (int)solutions.GetNumSolutions());
-    std::vector<IkReal> solvalues(GetNumJoints());
-    for(std::size_t i = 0; i < solutions.GetNumSolutions(); ++i) {
-        const IkSolutionBase<IkReal>& sol = solutions.GetSolution(i);
-        printf("sol%d (free=%d): ", (int)i, (int)sol.GetFree().size());
-        std::vector<IkReal> vsolfree(sol.GetFree().size());
-        sol.GetSolution(&solvalues[0],vsolfree.size()>0?&vsolfree[0]:NULL);
-        for( std::size_t j = 0; j < solvalues.size(); ++j)
-            printf("%.15f, ", solvalues[j]);
-        printf("\n");
-    }
-    return 0;
+  printf("Found %d ik solutions:\n", (int)solutions.GetNumSolutions());
+  std::vector<IkReal> solvalues(GetNumJoints());
+  for (std::size_t i = 0; i < solutions.GetNumSolutions(); ++i)
+  {
+    const IkSolutionBase<IkReal>& sol = solutions.GetSolution(i);
+    printf("sol%d (free=%d): ", (int)i, (int)sol.GetFree().size());
+    std::vector<IkReal> vsolfree(sol.GetFree().size());
+    sol.GetSolution(&solvalues[0], vsolfree.size() > 0 ? &vsolfree[0] : NULL);
+    for (std::size_t j = 0; j < solvalues.size(); ++j)
+      printf("%.15f, ", solvalues[j]);
+    printf("\n");
+  }
+  return 0;
 }
 
 #endif

--- a/motoman_sia20d_ikfast_manipulator_plugin/config/ikfast_sia20d_manipulator.cpp
+++ b/motoman_sia20d_ikfast_manipulator_plugin/config/ikfast_sia20d_manipulator.cpp
@@ -5,7 +5,7 @@
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///     http://www.apache.org/licenses/LICENSE-2.0
-/// 
+///
 /// Unless required by applicable law or agreed to in writing, software
 /// distributed under the License is distributed on an "AS IS" BASIS,
 /// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,26 +18,26 @@
 /// To compile without any main function as a shared object (might need -llapack):
 ///     gcc -fPIC -lstdc++ -DIKFAST_NO_MAIN -DIKFAST_CLIBRARY -shared -Wl,-soname,libik.so -o libik.so ik.cpp
 #define IKFAST_HAS_LIBRARY
-#include "ikfast.h" // found inside share/openrave-X.Y/python/ikfast.h
+#include "ikfast.h"  // found inside share/openrave-X.Y/python/ikfast.h
 using namespace ikfast;
 
 // check if the included ikfast version matches what this file was compiled with
 #define IKFAST_COMPILE_ASSERT(x) extern int __dummy[(int)x]
-IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
+IKFAST_COMPILE_ASSERT(IKFAST_VERSION == 61);
 
-#include <cmath>
-#include <vector>
-#include <limits>
 #include <algorithm>
+#include <cmath>
 #include <complex>
+#include <limits>
+#include <vector>
 
 #define IKFAST_STRINGIZE2(s) #s
 #define IKFAST_STRINGIZE(s) IKFAST_STRINGIZE2(s)
 
 #ifndef IKFAST_ASSERT
-#include <stdexcept>
-#include <sstream>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 
 #ifdef _MSC_VER
 #ifndef __PRETTY_FUNCTION__
@@ -49,7 +49,16 @@ IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
 #define __PRETTY_FUNCTION__ __func__
 #endif
 
-#define IKFAST_ASSERT(b) { if( !(b) ) { std::stringstream ss; ss << "ikfast exception: " << __FILE__ << ":" << __LINE__ << ": " <<__PRETTY_FUNCTION__ << ": Assertion '" << #b << "' failed"; throw std::runtime_error(ss.str()); } }
+#define IKFAST_ASSERT(b)                                                                                               \
+  {                                                                                                                    \
+    if (!(b))                                                                                                          \
+    {                                                                                                                  \
+      std::stringstream ss;                                                                                            \
+      ss << "ikfast exception: " << __FILE__ << ":" << __LINE__ << ": " << __PRETTY_FUNCTION__ << ": Assertion '"      \
+         << #b << "' failed";                                                                                          \
+      throw std::runtime_error(ss.str());                                                                              \
+    }                                                                                                                  \
+  }
 
 #endif
 
@@ -59,40 +68,61 @@ IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
 #define IKFAST_ALIGNED16(x) x __attribute((aligned(16)))
 #endif
 
-#define IK2PI  ((IkReal)6.28318530717959)
-#define IKPI  ((IkReal)3.14159265358979)
-#define IKPI_2  ((IkReal)1.57079632679490)
+#define IK2PI ((IkReal)6.28318530717959)
+#define IKPI ((IkReal)3.14159265358979)
+#define IKPI_2 ((IkReal)1.57079632679490)
 
 #ifdef _MSC_VER
 #ifndef isnan
 #define isnan _isnan
 #endif
-#endif // _MSC_VER
+#endif  // _MSC_VER
 
 // lapack routines
 extern "C" {
-  void dgetrf_ (const int* m, const int* n, double* a, const int* lda, int* ipiv, int* info);
-  void zgetrf_ (const int* m, const int* n, std::complex<double>* a, const int* lda, int* ipiv, int* info);
-  void dgetri_(const int* n, const double* a, const int* lda, int* ipiv, double* work, const int* lwork, int* info);
-  void dgesv_ (const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b, const int* ldb, int* info);
-  void dgetrs_(const char *trans, const int *n, const int *nrhs, double *a, const int *lda, int *ipiv, double *b, const int *ldb, int *info);
-  void dgeev_(const char *jobvl, const char *jobvr, const int *n, double *a, const int *lda, double *wr, double *wi,double *vl, const int *ldvl, double *vr, const int *ldvr, double *work, const int *lwork, int *info);
+void dgetrf_(const int* m, const int* n, double* a, const int* lda, int* ipiv, int* info);
+void zgetrf_(const int* m, const int* n, std::complex<double>* a, const int* lda, int* ipiv, int* info);
+void dgetri_(const int* n, const double* a, const int* lda, int* ipiv, double* work, const int* lwork, int* info);
+void dgesv_(const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b, const int* ldb, int* info);
+void dgetrs_(const char* trans, const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b,
+             const int* ldb, int* info);
+void dgeev_(const char* jobvl, const char* jobvr, const int* n, double* a, const int* lda, double* wr, double* wi,
+            double* vl, const int* ldvl, double* vr, const int* ldvr, double* work, const int* lwork, int* info);
 }
 
-using namespace std; // necessary to get std math routines
+using namespace std;  // necessary to get std math routines
 
 #ifdef IKFAST_NAMESPACE
-namespace IKFAST_NAMESPACE {
+namespace IKFAST_NAMESPACE
+{
 #endif
 
-inline float IKabs(float f) { return fabsf(f); }
-inline double IKabs(double f) { return fabs(f); }
+inline float IKabs(float f)
+{
+  return fabsf(f);
+}
+inline double IKabs(double f)
+{
+  return fabs(f);
+}
 
-inline float IKsqr(float f) { return f*f; }
-inline double IKsqr(double f) { return f*f; }
+inline float IKsqr(float f)
+{
+  return f * f;
+}
+inline double IKsqr(double f)
+{
+  return f * f;
+}
 
-inline float IKlog(float f) { return logf(f); }
-inline double IKlog(double f) { return log(f); }
+inline float IKlog(float f)
+{
+  return logf(f);
+}
+inline double IKlog(double f)
+{
+  return log(f);
+}
 
 // allows asin and acos to exceed 1
 #ifndef IKFAST_SINCOS_THRESH
@@ -111,4138 +141,5450 @@ inline double IKlog(double f) { return log(f); }
 
 inline float IKasin(float f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return float(-IKPI_2);
-else if( f >= 1 ) return float(IKPI_2);
-return asinf(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return float(-IKPI_2);
+  else if (f >= 1)
+    return float(IKPI_2);
+  return asinf(f);
 }
 inline double IKasin(double f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return -IKPI_2;
-else if( f >= 1 ) return IKPI_2;
-return asin(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return -IKPI_2;
+  else if (f >= 1)
+    return IKPI_2;
+  return asin(f);
 }
 
 // return positive value in [0,y)
 inline float IKfmod(float x, float y)
 {
-    while(x < 0) {
-        x += y;
-    }
-    return fmodf(x,y);
+  while (x < 0)
+  {
+    x += y;
+  }
+  return fmodf(x, y);
 }
 
 // return positive value in [0,y)
 inline double IKfmod(double x, double y)
 {
-    while(x < 0) {
-        x += y;
-    }
-    return fmod(x,y);
+  while (x < 0)
+  {
+    x += y;
+  }
+  return fmod(x, y);
 }
 
 inline float IKacos(float f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return float(IKPI);
-else if( f >= 1 ) return float(0);
-return acosf(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return float(IKPI);
+  else if (f >= 1)
+    return float(0);
+  return acosf(f);
 }
 inline double IKacos(double f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return IKPI;
-else if( f >= 1 ) return 0;
-return acos(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return IKPI;
+  else if (f >= 1)
+    return 0;
+  return acos(f);
 }
-inline float IKsin(float f) { return sinf(f); }
-inline double IKsin(double f) { return sin(f); }
-inline float IKcos(float f) { return cosf(f); }
-inline double IKcos(double f) { return cos(f); }
-inline float IKtan(float f) { return tanf(f); }
-inline double IKtan(double f) { return tan(f); }
-inline float IKsqrt(float f) { if( f <= 0.0f ) return 0.0f; return sqrtf(f); }
-inline double IKsqrt(double f) { if( f <= 0.0 ) return 0.0; return sqrt(f); }
-inline float IKatan2(float fy, float fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
-        return float(IKPI_2);
-    }
-    else if( isnan(fx) ) {
-        return 0;
-    }
-    return atan2f(fy,fx);
+inline float IKsin(float f)
+{
+  return sinf(f);
 }
-inline double IKatan2(double fy, double fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
-        return IKPI_2;
-    }
-    else if( isnan(fx) ) {
-        return 0;
-    }
-    return atan2(fy,fx);
+inline double IKsin(double f)
+{
+  return sin(f);
+}
+inline float IKcos(float f)
+{
+  return cosf(f);
+}
+inline double IKcos(double f)
+{
+  return cos(f);
+}
+inline float IKtan(float f)
+{
+  return tanf(f);
+}
+inline double IKtan(double f)
+{
+  return tan(f);
+}
+inline float IKsqrt(float f)
+{
+  if (f <= 0.0f)
+    return 0.0f;
+  return sqrtf(f);
+}
+inline double IKsqrt(double f)
+{
+  if (f <= 0.0)
+    return 0.0;
+  return sqrt(f);
+}
+inline float IKatan2(float fy, float fx)
+{
+  if (isnan(fy))
+  {
+    IKFAST_ASSERT(!isnan(fx));  // if both are nan, probably wrong value will be returned
+    return float(IKPI_2);
+  }
+  else if (isnan(fx))
+  {
+    return 0;
+  }
+  return atan2f(fy, fx);
+}
+inline double IKatan2(double fy, double fx)
+{
+  if (isnan(fy))
+  {
+    IKFAST_ASSERT(!isnan(fx));  // if both are nan, probably wrong value will be returned
+    return IKPI_2;
+  }
+  else if (isnan(fx))
+  {
+    return 0;
+  }
+  return atan2(fy, fx);
 }
 
-inline float IKsign(float f) {
-    if( f > 0 ) {
-        return float(1);
-    }
-    else if( f < 0 ) {
-        return float(-1);
-    }
-    return 0;
+inline float IKsign(float f)
+{
+  if (f > 0)
+  {
+    return float(1);
+  }
+  else if (f < 0)
+  {
+    return float(-1);
+  }
+  return 0;
 }
 
-inline double IKsign(double f) {
-    if( f > 0 ) {
-        return 1.0;
-    }
-    else if( f < 0 ) {
-        return -1.0;
-    }
-    return 0;
+inline double IKsign(double f)
+{
+  if (f > 0)
+  {
+    return 1.0;
+  }
+  else if (f < 0)
+  {
+    return -1.0;
+  }
+  return 0;
 }
 
 /// solves the forward kinematics equations.
 /// \param pfree is an array specifying the free joints of the chain.
-IKFAST_API void ComputeFk(const IkReal* j, IkReal* eetrans, IkReal* eerot) {
-IkReal x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63;
-x0=IKcos(j[0]);
-x1=IKcos(j[3]);
-x2=IKcos(j[1]);
-x3=IKcos(j[2]);
-x4=IKsin(j[1]);
-x5=IKsin(j[3]);
-x6=IKsin(j[0]);
-x7=IKsin(j[2]);
-x8=IKsin(j[4]);
-x9=IKcos(j[4]);
-x10=IKcos(j[6]);
-x11=IKsin(j[6]);
-x12=IKsin(j[5]);
-x13=IKcos(j[5]);
-x14=((IkReal(1.00000000000000))*(x7));
-x15=((IkReal(1.00000000000000))*(x1));
-x16=((IkReal(0.180000000000000))*(x9));
-x17=((IkReal(0.420000000000000))*(x2));
-x18=((IkReal(1.00000000000000))*(x9));
-x19=((IkReal(1.00000000000000))*(x2));
-x20=((IkReal(0.180000000000000))*(x1));
-x21=((IkReal(1.00000000000000))*(x13));
-x22=((IkReal(1.00000000000000))*(x8));
-x23=((IkReal(0.180000000000000))*(x5));
-x24=((IkReal(1.00000000000000))*(x5));
-x25=((IkReal(0.420000000000000))*(x1));
-x26=((IkReal(1.00000000000000))*(x12));
-x27=((x0)*(x7));
-x28=((IkReal(-1.00000000000000))*(x13));
-x29=((x3)*(x6));
-x30=((x0)*(x4));
-x31=((x4)*(x8));
-x32=((x4)*(x6));
-x33=((x6)*(x7));
-x34=((x0)*(x3));
-x35=((x3)*(x4));
-x36=((IkReal(-1.00000000000000))*(x12));
-x37=((x14)*(x6));
-x38=((x15)*(x35));
-x39=((x14)*(x4)*(x9));
-x40=((x14)*(x31));
-x41=((((IkReal(-1.00000000000000))*(x37)))+(((x2)*(x34))));
-x42=((((x2)*(x27)))+(x29));
-x43=((((x2)*(x29)))+(x27));
-x44=((((IkReal(-1.00000000000000))*(x34)))+(((x2)*(x33))));
-x45=((((IkReal(-1.00000000000000))*(x38)))+(((x2)*(x5))));
-x46=((((x1)*(x2)))+(((x35)*(x5))));
-x47=((((IkReal(-1.00000000000000))*(x19)*(x34)))+(x37));
-x48=((((IkReal(-1.00000000000000))*(x19)*(x5)))+(x38));
-x49=((((IkReal(-1.00000000000000))*(x0)*(x14)))+(((IkReal(-1.00000000000000))*(x19)*(x29))));
-x50=((x42)*(x8));
-x51=((x1)*(x41));
-x52=((x44)*(x8));
-x53=((x49)*(x5));
-x54=((((x30)*(x5)))+(x51));
-x55=((((x32)*(x5)))+(((x1)*(x43))));
-x56=((((x47)*(x5)))+(((x1)*(x30))));
-x57=((((IkReal(-1.00000000000000))*(x15)*(x43)))+(((IkReal(-1.00000000000000))*(x24)*(x32))));
-x58=((x53)+(((x1)*(x32))));
-x59=((x54)*(x9));
-x60=((x59)+(x50));
-x61=((x52)+(((x55)*(x9))));
-x62=((((x21)*(((((IkReal(-1.00000000000000))*(x45)*(x9)))+(x40)))))+(((IkReal(-1.00000000000000))*(x26)*(x46))));
-x63=((x13)*(x60));
-eerot[0]=((((x10)*(((((x36)*(x56)))+(((x28)*(x60)))))))+(((IkReal(-1.00000000000000))*(x11)*(((((x18)*(x42)))+(((x22)*(((((IkReal(-1.00000000000000))*(x15)*(x41)))+(((IkReal(-1.00000000000000))*(x24)*(x30))))))))))));
-eerot[1]=((((x10)*(((((x42)*(x9)))+(((x8)*(((((IkReal(-1.00000000000000))*(x51)))+(((IkReal(-1.00000000000000))*(x30)*(x5)))))))))))+(((x11)*(((((IkReal(-1.00000000000000))*(x26)*(x56)))+(((IkReal(-1.00000000000000))*(x21)*(x60))))))));
-eerot[2]=((((x12)*(((((IkReal(-1.00000000000000))*(x18)*(x54)))+(((IkReal(-1.00000000000000))*(x22)*(x42)))))))+(((x13)*(x56))));
-eetrans[0]=((((x12)*(((((IkReal(-0.180000000000000))*(x50)))+(((IkReal(-1.00000000000000))*(x16)*(x54)))))))+(((IkReal(0.490000000000000))*(x30)))+(((x25)*(x30)))+(((x5)*(((((IkReal(0.420000000000000))*(x33)))+(((IkReal(-1.00000000000000))*(x17)*(x34)))))))+(((x13)*(((((x20)*(x30)))+(((x23)*(x47))))))));
-eerot[3]=((((x11)*(((((IkReal(-1.00000000000000))*(x18)*(x44)))+(((IkReal(-1.00000000000000))*(x22)*(x57)))))))+(((x10)*(((((x36)*(x58)))+(((x28)*(x61))))))));
-eerot[4]=((((x10)*(((((x57)*(x8)))+(((x44)*(x9)))))))+(((x11)*(((((IkReal(-1.00000000000000))*(x26)*(x58)))+(((IkReal(-1.00000000000000))*(x21)*(x61))))))));
-eerot[5]=((((x13)*(x58)))+(((x12)*(((((IkReal(-1.00000000000000))*(x18)*(x55)))+(((IkReal(-1.00000000000000))*(x22)*(x44))))))));
-eetrans[1]=((((x5)*(((((IkReal(-1.00000000000000))*(x17)*(x29)))+(((IkReal(-0.420000000000000))*(x27)))))))+(((x12)*(((((IkReal(-0.180000000000000))*(x52)))+(((IkReal(-1.00000000000000))*(x16)*(x55)))))))+(((IkReal(0.490000000000000))*(x32)))+(((x25)*(x32)))+(((x13)*(((((x20)*(x32)))+(((x23)*(x49))))))));
-eerot[6]=((((x11)*(((((IkReal(-1.00000000000000))*(x22)*(x48)))+(x39)))))+(((x10)*(x62))));
-eerot[7]=((((x11)*(x62)))+(((x10)*(((((IkReal(-1.00000000000000))*(x39)))+(((x48)*(x8))))))));
-eerot[8]=((((x12)*(((((IkReal(-1.00000000000000))*(x18)*(x45)))+(x40)))))+(((x13)*(x46))));
-eetrans[2]=((IkReal(0.410000000000000))+(((x1)*(x17)))+(((x13)*(((((x23)*(x35)))+(((x2)*(x20)))))))+(((x12)*(((((IkReal(0.180000000000000))*(x31)*(x7)))+(((IkReal(-1.00000000000000))*(x16)*(x45)))))))+(((IkReal(0.420000000000000))*(x35)*(x5)))+(((IkReal(0.490000000000000))*(x2))));
+IKFAST_API void ComputeFk(const IkReal* j, IkReal* eetrans, IkReal* eerot)
+{
+  IkReal x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23,
+      x24, x25, x26, x27, x28, x29, x30, x31, x32, x33, x34, x35, x36, x37, x38, x39, x40, x41, x42, x43, x44, x45, x46,
+      x47, x48, x49, x50, x51, x52, x53, x54, x55, x56, x57, x58, x59, x60, x61, x62, x63;
+  x0 = IKcos(j[0]);
+  x1 = IKcos(j[3]);
+  x2 = IKcos(j[1]);
+  x3 = IKcos(j[2]);
+  x4 = IKsin(j[1]);
+  x5 = IKsin(j[3]);
+  x6 = IKsin(j[0]);
+  x7 = IKsin(j[2]);
+  x8 = IKsin(j[4]);
+  x9 = IKcos(j[4]);
+  x10 = IKcos(j[6]);
+  x11 = IKsin(j[6]);
+  x12 = IKsin(j[5]);
+  x13 = IKcos(j[5]);
+  x14 = ((IkReal(1.00000000000000)) * (x7));
+  x15 = ((IkReal(1.00000000000000)) * (x1));
+  x16 = ((IkReal(0.180000000000000)) * (x9));
+  x17 = ((IkReal(0.420000000000000)) * (x2));
+  x18 = ((IkReal(1.00000000000000)) * (x9));
+  x19 = ((IkReal(1.00000000000000)) * (x2));
+  x20 = ((IkReal(0.180000000000000)) * (x1));
+  x21 = ((IkReal(1.00000000000000)) * (x13));
+  x22 = ((IkReal(1.00000000000000)) * (x8));
+  x23 = ((IkReal(0.180000000000000)) * (x5));
+  x24 = ((IkReal(1.00000000000000)) * (x5));
+  x25 = ((IkReal(0.420000000000000)) * (x1));
+  x26 = ((IkReal(1.00000000000000)) * (x12));
+  x27 = ((x0) * (x7));
+  x28 = ((IkReal(-1.00000000000000)) * (x13));
+  x29 = ((x3) * (x6));
+  x30 = ((x0) * (x4));
+  x31 = ((x4) * (x8));
+  x32 = ((x4) * (x6));
+  x33 = ((x6) * (x7));
+  x34 = ((x0) * (x3));
+  x35 = ((x3) * (x4));
+  x36 = ((IkReal(-1.00000000000000)) * (x12));
+  x37 = ((x14) * (x6));
+  x38 = ((x15) * (x35));
+  x39 = ((x14) * (x4) * (x9));
+  x40 = ((x14) * (x31));
+  x41 = ((((IkReal(-1.00000000000000)) * (x37))) + (((x2) * (x34))));
+  x42 = ((((x2) * (x27))) + (x29));
+  x43 = ((((x2) * (x29))) + (x27));
+  x44 = ((((IkReal(-1.00000000000000)) * (x34))) + (((x2) * (x33))));
+  x45 = ((((IkReal(-1.00000000000000)) * (x38))) + (((x2) * (x5))));
+  x46 = ((((x1) * (x2))) + (((x35) * (x5))));
+  x47 = ((((IkReal(-1.00000000000000)) * (x19) * (x34))) + (x37));
+  x48 = ((((IkReal(-1.00000000000000)) * (x19) * (x5))) + (x38));
+  x49 = ((((IkReal(-1.00000000000000)) * (x0) * (x14))) + (((IkReal(-1.00000000000000)) * (x19) * (x29))));
+  x50 = ((x42) * (x8));
+  x51 = ((x1) * (x41));
+  x52 = ((x44) * (x8));
+  x53 = ((x49) * (x5));
+  x54 = ((((x30) * (x5))) + (x51));
+  x55 = ((((x32) * (x5))) + (((x1) * (x43))));
+  x56 = ((((x47) * (x5))) + (((x1) * (x30))));
+  x57 = ((((IkReal(-1.00000000000000)) * (x15) * (x43))) + (((IkReal(-1.00000000000000)) * (x24) * (x32))));
+  x58 = ((x53) + (((x1) * (x32))));
+  x59 = ((x54) * (x9));
+  x60 = ((x59) + (x50));
+  x61 = ((x52) + (((x55) * (x9))));
+  x62 = ((((x21) * (((((IkReal(-1.00000000000000)) * (x45) * (x9))) + (x40))))) +
+         (((IkReal(-1.00000000000000)) * (x26) * (x46))));
+  x63 = ((x13) * (x60));
+  eerot[0] = ((((x10) * (((((x36) * (x56))) + (((x28) * (x60))))))) +
+              (((IkReal(-1.00000000000000)) * (x11) *
+                (((((x18) * (x42))) + (((x22) * (((((IkReal(-1.00000000000000)) * (x15) * (x41))) +
+                                                  (((IkReal(-1.00000000000000)) * (x24) * (x30))))))))))));
+  eerot[1] =
+      ((((x10) * (((((x42) * (x9))) + (((x8) * (((((IkReal(-1.00000000000000)) * (x51))) +
+                                                 (((IkReal(-1.00000000000000)) * (x30) * (x5))))))))))) +
+       (((x11) *
+         (((((IkReal(-1.00000000000000)) * (x26) * (x56))) + (((IkReal(-1.00000000000000)) * (x21) * (x60))))))));
+  eerot[2] =
+      ((((x12) *
+         (((((IkReal(-1.00000000000000)) * (x18) * (x54))) + (((IkReal(-1.00000000000000)) * (x22) * (x42))))))) +
+       (((x13) * (x56))));
+  eetrans[0] =
+      ((((x12) * (((((IkReal(-0.180000000000000)) * (x50))) + (((IkReal(-1.00000000000000)) * (x16) * (x54))))))) +
+       (((IkReal(0.490000000000000)) * (x30))) + (((x25) * (x30))) +
+       (((x5) * (((((IkReal(0.420000000000000)) * (x33))) + (((IkReal(-1.00000000000000)) * (x17) * (x34))))))) +
+       (((x13) * (((((x20) * (x30))) + (((x23) * (x47))))))));
+  eerot[3] =
+      ((((x11) *
+         (((((IkReal(-1.00000000000000)) * (x18) * (x44))) + (((IkReal(-1.00000000000000)) * (x22) * (x57))))))) +
+       (((x10) * (((((x36) * (x58))) + (((x28) * (x61))))))));
+  eerot[4] =
+      ((((x10) * (((((x57) * (x8))) + (((x44) * (x9))))))) +
+       (((x11) *
+         (((((IkReal(-1.00000000000000)) * (x26) * (x58))) + (((IkReal(-1.00000000000000)) * (x21) * (x61))))))));
+  eerot[5] = ((((x13) * (x58))) + (((x12) * (((((IkReal(-1.00000000000000)) * (x18) * (x55))) +
+                                              (((IkReal(-1.00000000000000)) * (x22) * (x44))))))));
+  eetrans[1] =
+      ((((x5) * (((((IkReal(-1.00000000000000)) * (x17) * (x29))) + (((IkReal(-0.420000000000000)) * (x27))))))) +
+       (((x12) * (((((IkReal(-0.180000000000000)) * (x52))) + (((IkReal(-1.00000000000000)) * (x16) * (x55))))))) +
+       (((IkReal(0.490000000000000)) * (x32))) + (((x25) * (x32))) +
+       (((x13) * (((((x20) * (x32))) + (((x23) * (x49))))))));
+  eerot[6] = ((((x11) * (((((IkReal(-1.00000000000000)) * (x22) * (x48))) + (x39))))) + (((x10) * (x62))));
+  eerot[7] = ((((x11) * (x62))) + (((x10) * (((((IkReal(-1.00000000000000)) * (x39))) + (((x48) * (x8))))))));
+  eerot[8] = ((((x12) * (((((IkReal(-1.00000000000000)) * (x18) * (x45))) + (x40))))) + (((x13) * (x46))));
+  eetrans[2] =
+      ((IkReal(0.410000000000000)) + (((x1) * (x17))) + (((x13) * (((((x23) * (x35))) + (((x2) * (x20))))))) +
+       (((x12) *
+         (((((IkReal(0.180000000000000)) * (x31) * (x7))) + (((IkReal(-1.00000000000000)) * (x16) * (x45))))))) +
+       (((IkReal(0.420000000000000)) * (x35) * (x5))) + (((IkReal(0.490000000000000)) * (x2))));
 }
 
-IKFAST_API int GetNumFreeParameters() { return 1; }
-IKFAST_API int* GetFreeParameters() { static int freeparams[] = {4}; return freeparams; }
-IKFAST_API int GetNumJoints() { return 7; }
+IKFAST_API int GetNumFreeParameters()
+{
+  return 1;
+}
+IKFAST_API int* GetFreeParameters()
+{
+  static int freeparams[] = { 4 };
+  return freeparams;
+}
+IKFAST_API int GetNumJoints()
+{
+  return 7;
+}
 
-IKFAST_API int GetIkRealSize() { return sizeof(IkReal); }
+IKFAST_API int GetIkRealSize()
+{
+  return sizeof(IkReal);
+}
 
-IKFAST_API int GetIkType() { return 0x67000001; }
+IKFAST_API int GetIkType()
+{
+  return 0x67000001;
+}
 
-class IKSolver {
+class IKSolver
+{
 public:
-IkReal j0,cj0,sj0,htj0,j1,cj1,sj1,htj1,j2,cj2,sj2,htj2,j3,cj3,sj3,htj3,j5,cj5,sj5,htj5,j6,cj6,sj6,htj6,j4,cj4,sj4,htj4,new_r00,r00,rxp0_0,new_r01,r01,rxp0_1,new_r02,r02,rxp0_2,new_r10,r10,rxp1_0,new_r11,r11,rxp1_1,new_r12,r12,rxp1_2,new_r20,r20,rxp2_0,new_r21,r21,rxp2_1,new_r22,r22,rxp2_2,new_px,px,npx,new_py,py,npy,new_pz,pz,npz,pp;
-unsigned char _ij0[2], _nj0,_ij1[2], _nj1,_ij2[2], _nj2,_ij3[2], _nj3,_ij5[2], _nj5,_ij6[2], _nj6,_ij4[2], _nj4;
-
-bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions) {
-j0=numeric_limits<IkReal>::quiet_NaN(); _ij0[0] = -1; _ij0[1] = -1; _nj0 = -1; j1=numeric_limits<IkReal>::quiet_NaN(); _ij1[0] = -1; _ij1[1] = -1; _nj1 = -1; j2=numeric_limits<IkReal>::quiet_NaN(); _ij2[0] = -1; _ij2[1] = -1; _nj2 = -1; j3=numeric_limits<IkReal>::quiet_NaN(); _ij3[0] = -1; _ij3[1] = -1; _nj3 = -1; j5=numeric_limits<IkReal>::quiet_NaN(); _ij5[0] = -1; _ij5[1] = -1; _nj5 = -1; j6=numeric_limits<IkReal>::quiet_NaN(); _ij6[0] = -1; _ij6[1] = -1; _nj6 = -1;  _ij4[0] = -1; _ij4[1] = -1; _nj4 = 0; 
-for(int dummyiter = 0; dummyiter < 1; ++dummyiter) {
-    solutions.Clear();
-j4=pfree[0]; cj4=cos(pfree[0]); sj4=sin(pfree[0]);
-r00 = eerot[0*3+0];
-r01 = eerot[0*3+1];
-r02 = eerot[0*3+2];
-r10 = eerot[1*3+0];
-r11 = eerot[1*3+1];
-r12 = eerot[1*3+2];
-r20 = eerot[2*3+0];
-r21 = eerot[2*3+1];
-r22 = eerot[2*3+2];
-px = eetrans[0]; py = eetrans[1]; pz = eetrans[2];
-
-new_r00=((IkReal(-1.00000000000000))*(r00));
-new_r01=r01;
-new_r02=((IkReal(-1.00000000000000))*(r02));
-new_px=((((IkReal(-0.180000000000000))*(r02)))+(px));
-new_r10=((IkReal(-1.00000000000000))*(r10));
-new_r11=r11;
-new_r12=((IkReal(-1.00000000000000))*(r12));
-new_py=((((IkReal(-0.180000000000000))*(r12)))+(py));
-new_r20=((IkReal(-1.00000000000000))*(r20));
-new_r21=r21;
-new_r22=((IkReal(-1.00000000000000))*(r22));
-new_pz=((IkReal(-0.410000000000000))+(pz)+(((IkReal(-0.180000000000000))*(r22))));
-r00 = new_r00; r01 = new_r01; r02 = new_r02; r10 = new_r10; r11 = new_r11; r12 = new_r12; r20 = new_r20; r21 = new_r21; r22 = new_r22; px = new_px; py = new_py; pz = new_pz;
-pp=(((px)*(px))+((py)*(py))+((pz)*(pz)));
-npx=((((px)*(r00)))+(((py)*(r10)))+(((pz)*(r20))));
-npy=((((px)*(r01)))+(((py)*(r11)))+(((pz)*(r21))));
-npz=((((px)*(r02)))+(((py)*(r12)))+(((pz)*(r22))));
-rxp0_0=((((IkReal(-1.00000000000000))*(py)*(r20)))+(((pz)*(r10))));
-rxp0_1=((((px)*(r20)))+(((IkReal(-1.00000000000000))*(pz)*(r00))));
-rxp0_2=((((IkReal(-1.00000000000000))*(px)*(r10)))+(((py)*(r00))));
-rxp1_0=((((IkReal(-1.00000000000000))*(py)*(r21)))+(((pz)*(r11))));
-rxp1_1=((((px)*(r21)))+(((IkReal(-1.00000000000000))*(pz)*(r01))));
-rxp1_2=((((IkReal(-1.00000000000000))*(px)*(r11)))+(((py)*(r01))));
-rxp2_0=((((IkReal(-1.00000000000000))*(py)*(r22)))+(((pz)*(r12))));
-rxp2_1=((((px)*(r22)))+(((IkReal(-1.00000000000000))*(pz)*(r02))));
-rxp2_2=((((IkReal(-1.00000000000000))*(px)*(r12)))+(((py)*(r02))));
-{
-IkReal j3array[2], cj3array[2], sj3array[2];
-bool j3valid[2]={false};
-_nj3 = 2;
-cj3array[0]=((IkReal(-1.01190476190476))+(((IkReal(2.42954324586978))*(pp))));
-if( cj3array[0] >= -1-IKFAST_SINCOS_THRESH && cj3array[0] <= 1+IKFAST_SINCOS_THRESH )
-{
-    j3valid[0] = j3valid[1] = true;
-    j3array[0] = IKacos(cj3array[0]);
-    sj3array[0] = IKsin(j3array[0]);
-    cj3array[1] = cj3array[0];
-    j3array[1] = -j3array[0];
-    sj3array[1] = -sj3array[0];
-}
-else if( isnan(cj3array[0]) )
-{
-    // probably any value will work
-    j3valid[0] = true;
-    cj3array[0] = 1; sj3array[0] = 0; j3array[0] = 0;
-}
-for(int ij3 = 0; ij3 < 2; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 2; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-
-{
-IkReal dummyeval[1];
-dummyeval[0]=(((npx)*(npx))+((npy)*(npy)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=(((npx)*(npx))+((npy)*(npy)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=((IkReal(1.00000000000000))+(((IkReal(2.33333333333333))*(cj3)))+(((IkReal(1.36111111111111))*((cj4)*(cj4))*((sj3)*(sj3))))+(((IkReal(1.36111111111111))*((cj3)*(cj3)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j5array[2], cj5array[2], sj5array[2];
-bool j5valid[2]={false};
-_nj5 = 2;
-IkReal x64=((IkReal(-0.420000000000000))+(((IkReal(-0.490000000000000))*(cj3))));
-if( IKabs(x64) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(0.490000000000000))*(cj4)*(sj3))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x65=((IkReal(1.00000000000000))*(IKatan2(x64, ((IkReal(0.490000000000000))*(cj4)*(sj3)))));
-if( ((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3)))))) < (IkReal)-0.00001 )
-    continue;
-if( (((npz)*(((IKabs(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3)))))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3))))))))):(IkReal)1.0e30)))) < -1-IKFAST_SINCOS_THRESH || (((npz)*(((IKabs(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3)))))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3))))))))):(IkReal)1.0e30)))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x66=IKasin(((npz)*(((IKabs(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3)))))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3))))))))):(IkReal)1.0e30))));
-j5array[0]=((x66)+(((IkReal(-1.00000000000000))*(x65))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-j5array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x65)))+(((IkReal(-1.00000000000000))*(x66))));
-sj5array[1]=IKsin(j5array[1]);
-cj5array[1]=IKcos(j5array[1]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-if( j5array[1] > IKPI )
-{
-    j5array[1]-=IK2PI;
-}
-else if( j5array[1] < -IKPI )
-{    j5array[1]+=IK2PI;
-}
-j5valid[1] = true;
-for(int ij5 = 0; ij5 < 2; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 2; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-
-{
-IkReal dummyeval[1];
-IkReal gconst0;
-IkReal x67=((IkReal(100.000000000000))*(sj5));
-gconst0=IKsign(((((x67)*((npx)*(npx))))+(((x67)*((npy)*(npy))))));
-dummyeval[0]=((((sj5)*((npy)*(npy))))+(((sj5)*((npx)*(npx)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst1;
-IkReal x68=((IkReal(2100.00000000000))*(sj5));
-gconst1=IKsign(((((x68)*((npx)*(npx))))+(((x68)*((npy)*(npy))))));
-dummyeval[0]=((((sj5)*((npy)*(npy))))+(((sj5)*((npx)*(npx)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[5];
-IkReal x69=((IkReal(1.00000000000000))*(pp));
-IkReal x70=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(npz)))+(((IkReal(-0.490000000000000))*(cj3))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j5)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x69)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=x70;
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(-0.840000000000000))*(npz)))+(((IkReal(-1.00000000000000))*(x69))));
-evalcond[4]=x70;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst2;
-gconst2=IKsign(((((IkReal(-100.000000000000))*((npy)*(npy))))+(((IkReal(-100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*((npy)*(npy))))+(((IkReal(-1.00000000000000))*((npx)*(npx)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst3;
-IkReal x71=((IkReal(100.000000000000))*(sj4));
-gconst3=IKsign(((((IkReal(-1.00000000000000))*(x71)*((npx)*(npx))))+(((IkReal(-1.00000000000000))*(x71)*((npy)*(npy))))));
-IkReal x72=((IkReal(1.00000000000000))*(sj4));
-dummyeval[0]=((((IkReal(-1.00000000000000))*(x72)*((npx)*(npx))))+(((IkReal(-1.00000000000000))*(x72)*((npy)*(npy)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[5];
-IkReal x73=((IkReal(1.00000000000000))*(pp));
-IkReal x74=x70;
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x73)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=x74;
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(-1.00000000000000))*(x73)))+(((IkReal(-0.840000000000000))*(npz))));
-evalcond[4]=x74;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst4;
-gconst4=IKsign(((((IkReal(-100.000000000000))*((npy)*(npy))))+(((IkReal(-100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*((npy)*(npy))))+(((IkReal(-1.00000000000000))*((npx)*(npx)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x75=((gconst4)*(sj3));
-if( IKabs(((IkReal(49.0000000000000))*(npy)*(x75))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-49.0000000000000))*(npx)*(x75))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((IkReal(49.0000000000000))*(npy)*(x75)), ((IkReal(-49.0000000000000))*(npx)*(x75)));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[2];
-IkReal x76=IKcos(j6);
-IkReal x77=IKsin(j6);
-evalcond[0]=((((npx)*(x77)))+(((npy)*(x76))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(npy)*(x77)))+(((npx)*(x76)))+(((IkReal(-0.490000000000000))*(sj3))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-IkReal x234=((IkReal(1.00000000000000))*(pp));
-IkReal x235=x70;
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x234)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=x235;
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(-0.840000000000000))*(npz)))+(((IkReal(-1.00000000000000))*(x234))));
-evalcond[4]=x235;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst5;
-gconst5=IKsign(((((IkReal(100.000000000000))*((npy)*(npy))))+(((IkReal(100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=(((npx)*(npx))+((npy)*(npy)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x236=((gconst5)*(sj3));
-if( IKabs(((IkReal(49.0000000000000))*(npy)*(x236))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-49.0000000000000))*(npx)*(x236))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((IkReal(49.0000000000000))*(npy)*(x236)), ((IkReal(-49.0000000000000))*(npx)*(x236)));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[2];
-IkReal x237=IKcos(j6);
-IkReal x238=IKsin(j6);
-evalcond[0]=((((npx)*(x238)))+(((npy)*(x237))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(npy)*(x238)))+(((npx)*(x237)))+(((IkReal(0.490000000000000))*(sj3))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x239=(sj4)*(sj4);
-IkReal x240=((IkReal(49.0000000000000))*(sj3)*(x239));
-IkReal x241=((IkReal(49.0000000000000))*(cj4)*(sj3)*(sj4));
-if( IKabs(((gconst3)*(((((npy)*(x241)))+(((npx)*(x240))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst3)*(((((IkReal(-1.00000000000000))*(npx)*(x241)))+(((npy)*(x240))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst3)*(((((npy)*(x241)))+(((npx)*(x240)))))), ((gconst3)*(((((IkReal(-1.00000000000000))*(npx)*(x241)))+(((npy)*(x240)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[4];
-IkReal x242=IKcos(j6);
-IkReal x243=IKsin(j6);
-IkReal x244=((cj4)*(npy));
-IkReal x245=((IkReal(0.490000000000000))*(sj3));
-IkReal x246=((npy)*(sj4));
-IkReal x247=((IkReal(1.00000000000000))*(x243));
-IkReal x248=((npx)*(x243));
-IkReal x249=((npx)*(x242));
-evalcond[0]=((x248)+(((npy)*(x242)))+(((sj4)*(x245))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(npy)*(x247)))+(((IkReal(-1.00000000000000))*(cj4)*(x245)))+(x249));
-evalcond[2]=((((cj4)*(x248)))+(((x242)*(x244)))+(((sj4)*(x249)))+(((IkReal(-1.00000000000000))*(x246)*(x247))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(npx)*(sj4)*(x247)))+(((cj4)*(x249)))+(((IkReal(-1.00000000000000))*(x245)))+(((IkReal(-1.00000000000000))*(x244)*(x247)))+(((IkReal(-1.00000000000000))*(x242)*(x246))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x250=((IkReal(49.0000000000000))*(cj4)*(sj3));
-IkReal x251=((IkReal(49.0000000000000))*(sj3)*(sj4));
-if( IKabs(((gconst2)*(((((npy)*(x250)))+(((npx)*(x251))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst2)*(((((npy)*(x251)))+(((IkReal(-1.00000000000000))*(npx)*(x250))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst2)*(((((npy)*(x250)))+(((npx)*(x251)))))), ((gconst2)*(((((npy)*(x251)))+(((IkReal(-1.00000000000000))*(npx)*(x250)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[4];
-IkReal x252=IKcos(j6);
-IkReal x253=IKsin(j6);
-IkReal x254=((cj4)*(npy));
-IkReal x255=((IkReal(0.490000000000000))*(sj3));
-IkReal x256=((npy)*(sj4));
-IkReal x257=((IkReal(1.00000000000000))*(x253));
-IkReal x258=((npx)*(x253));
-IkReal x259=((npx)*(x252));
-evalcond[0]=((((sj4)*(x255)))+(((npy)*(x252)))+(x258));
-evalcond[1]=((((IkReal(-1.00000000000000))*(npy)*(x257)))+(((IkReal(-1.00000000000000))*(cj4)*(x255)))+(x259));
-evalcond[2]=((((sj4)*(x259)))+(((IkReal(-1.00000000000000))*(x256)*(x257)))+(((x252)*(x254)))+(((cj4)*(x258))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x252)*(x256)))+(((IkReal(-1.00000000000000))*(npx)*(sj4)*(x257)))+(((IkReal(-1.00000000000000))*(x254)*(x257)))+(((cj4)*(x259)))+(((IkReal(-1.00000000000000))*(x255))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-IkReal x260=((IkReal(1.00000000000000))*(pp));
-IkReal x261=((IkReal(0.490000000000000))*(cj3));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j5)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x260)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=((IkReal(0.420000000000000))+(((IkReal(-1.00000000000000))*(npz)))+(x261));
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(npz)))+(((IkReal(-1.00000000000000))*(x260))));
-evalcond[4]=((IkReal(-0.420000000000000))+(npz)+(((IkReal(-1.00000000000000))*(x261))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst6;
-gconst6=IKsign(((((IkReal(100.000000000000))*((npy)*(npy))))+(((IkReal(100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=(((npx)*(npx))+((npy)*(npy)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst7;
-IkReal x262=((IkReal(100.000000000000))*(sj4));
-gconst7=IKsign(((((x262)*((npy)*(npy))))+(((x262)*((npx)*(npx))))));
-dummyeval[0]=((((sj4)*((npx)*(npx))))+(((sj4)*((npy)*(npy)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[5];
-IkReal x263=((IkReal(1.00000000000000))*(pp));
-IkReal x264=((IkReal(0.490000000000000))*(cj3));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x263)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=((IkReal(0.420000000000000))+(((IkReal(-1.00000000000000))*(npz)))+(x264));
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(npz)))+(((IkReal(-1.00000000000000))*(x263))));
-evalcond[4]=((IkReal(-0.420000000000000))+(npz)+(((IkReal(-1.00000000000000))*(x264))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst8;
-gconst8=IKsign(((((IkReal(100.000000000000))*((npy)*(npy))))+(((IkReal(100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=(((npx)*(npx))+((npy)*(npy)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x265=((gconst8)*(sj3));
-if( IKabs(((IkReal(49.0000000000000))*(npy)*(x265))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-49.0000000000000))*(npx)*(x265))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((IkReal(49.0000000000000))*(npy)*(x265)), ((IkReal(-49.0000000000000))*(npx)*(x265)));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[2];
-IkReal x266=IKcos(j6);
-IkReal x267=IKsin(j6);
-evalcond[0]=((((npx)*(x267)))+(((npy)*(x266))));
-evalcond[1]=((((npx)*(x266)))+(((IkReal(-1.00000000000000))*(npy)*(x267)))+(((IkReal(0.490000000000000))*(sj3))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-IkReal x268=((IkReal(1.00000000000000))*(pp));
-IkReal x269=((IkReal(0.490000000000000))*(cj3));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x268)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=((IkReal(0.420000000000000))+(((IkReal(-1.00000000000000))*(npz)))+(x269));
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(npz)))+(((IkReal(-1.00000000000000))*(x268))));
-evalcond[4]=((IkReal(-0.420000000000000))+(npz)+(((IkReal(-1.00000000000000))*(x269))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst9;
-gconst9=IKsign(((((IkReal(-100.000000000000))*((npy)*(npy))))+(((IkReal(-100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*((npy)*(npy))))+(((IkReal(-1.00000000000000))*((npx)*(npx)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x270=((gconst9)*(sj3));
-if( IKabs(((IkReal(49.0000000000000))*(npy)*(x270))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-49.0000000000000))*(npx)*(x270))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((IkReal(49.0000000000000))*(npy)*(x270)), ((IkReal(-49.0000000000000))*(npx)*(x270)));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[2];
-IkReal x271=IKcos(j6);
-IkReal x272=IKsin(j6);
-evalcond[0]=((((npy)*(x271)))+(((npx)*(x272))));
-evalcond[1]=((((IkReal(-0.490000000000000))*(sj3)))+(((IkReal(-1.00000000000000))*(npy)*(x272)))+(((npx)*(x271))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x273=(sj4)*(sj4);
-IkReal x274=((cj4)*(sj4));
-IkReal x275=((IkReal(49.0000000000000))*(npx)*(sj3));
-IkReal x276=((IkReal(49.0000000000000))*(npy)*(sj3));
-if( IKabs(((gconst7)*(((((IkReal(-1.00000000000000))*(x273)*(x275)))+(((x274)*(x276))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst7)*(((((IkReal(-1.00000000000000))*(x273)*(x276)))+(((IkReal(-1.00000000000000))*(x274)*(x275))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst7)*(((((IkReal(-1.00000000000000))*(x273)*(x275)))+(((x274)*(x276)))))), ((gconst7)*(((((IkReal(-1.00000000000000))*(x273)*(x276)))+(((IkReal(-1.00000000000000))*(x274)*(x275)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[4];
-IkReal x277=IKcos(j6);
-IkReal x278=IKsin(j6);
-IkReal x279=((IkReal(1.00000000000000))*(sj4));
-IkReal x280=((IkReal(0.490000000000000))*(sj3));
-IkReal x281=((npy)*(x277));
-IkReal x282=((npx)*(x277));
-IkReal x283=((npx)*(x278));
-IkReal x284=((npy)*(x278));
-evalcond[0]=((x283)+(x281)+(((sj4)*(x280))));
-evalcond[1]=((x282)+(((IkReal(-1.00000000000000))*(x284)))+(((cj4)*(x280))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x279)*(x282)))+(((cj4)*(x283)))+(((cj4)*(x281)))+(((sj4)*(x284))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(cj4)*(x282)))+(((IkReal(-1.00000000000000))*(x280)))+(((IkReal(-1.00000000000000))*(x279)*(x281)))+(((IkReal(-1.00000000000000))*(x279)*(x283)))+(((cj4)*(x284))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x285=((IkReal(49.0000000000000))*(cj4)*(sj3));
-IkReal x286=((IkReal(49.0000000000000))*(sj3)*(sj4));
-if( IKabs(((gconst6)*(((((IkReal(-1.00000000000000))*(npx)*(x286)))+(((npy)*(x285))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst6)*(((((IkReal(-1.00000000000000))*(npy)*(x286)))+(((IkReal(-1.00000000000000))*(npx)*(x285))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst6)*(((((IkReal(-1.00000000000000))*(npx)*(x286)))+(((npy)*(x285)))))), ((gconst6)*(((((IkReal(-1.00000000000000))*(npy)*(x286)))+(((IkReal(-1.00000000000000))*(npx)*(x285)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[4];
-IkReal x287=IKcos(j6);
-IkReal x288=IKsin(j6);
-IkReal x289=((IkReal(1.00000000000000))*(sj4));
-IkReal x290=((IkReal(0.490000000000000))*(sj3));
-IkReal x291=((npy)*(x287));
-IkReal x292=((npx)*(x287));
-IkReal x293=((npx)*(x288));
-IkReal x294=((npy)*(x288));
-evalcond[0]=((((sj4)*(x290)))+(x291)+(x293));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x294)))+(((cj4)*(x290)))+(x292));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x289)*(x292)))+(((cj4)*(x291)))+(((cj4)*(x293)))+(((sj4)*(x294))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(cj4)*(x292)))+(((IkReal(-1.00000000000000))*(x289)*(x293)))+(((IkReal(-1.00000000000000))*(x289)*(x291)))+(((IkReal(-1.00000000000000))*(x290)))+(((cj4)*(x294))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x295=((IkReal(2500.00000000000))*(pp));
-IkReal x296=((IkReal(2100.00000000000))*(cj5)*(npz));
-IkReal x297=((IkReal(1029.00000000000))*(sj3)*(sj4)*(sj5));
-if( IKabs(((gconst1)*(((((IkReal(-1.00000000000000))*(npy)*(x295)))+(((IkReal(-1.00000000000000))*(npy)*(x296)))+(((IkReal(-1.00000000000000))*(npx)*(x297)))+(((IkReal(159.250000000000))*(npy))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst1)*(((((IkReal(-1.00000000000000))*(npy)*(x297)))+(((npx)*(x295)))+(((npx)*(x296)))+(((IkReal(-159.250000000000))*(npx))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst1)*(((((IkReal(-1.00000000000000))*(npy)*(x295)))+(((IkReal(-1.00000000000000))*(npy)*(x296)))+(((IkReal(-1.00000000000000))*(npx)*(x297)))+(((IkReal(159.250000000000))*(npy)))))), ((gconst1)*(((((IkReal(-1.00000000000000))*(npy)*(x297)))+(((npx)*(x295)))+(((npx)*(x296)))+(((IkReal(-159.250000000000))*(npx)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[6];
-IkReal x298=IKcos(j6);
-IkReal x299=IKsin(j6);
-IkReal x300=((IkReal(1.00000000000000))*(sj4));
-IkReal x301=((cj5)*(npz));
-IkReal x302=((cj4)*(cj5));
-IkReal x303=((IkReal(0.490000000000000))*(sj3));
-IkReal x304=((IkReal(0.490000000000000))*(cj3));
-IkReal x305=((IkReal(0.840000000000000))*(sj5));
-IkReal x306=((npz)*(sj5));
-IkReal x307=((npy)*(x298));
-IkReal x308=((npx)*(x298));
-IkReal x309=((npy)*(x299));
-IkReal x310=((npx)*(x299));
-evalcond[0]=((x307)+(x310)+(((sj4)*(x303))));
-evalcond[1]=((IkReal(0.0637000000000000))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-1.00000000000000))*(x305)*(x309)))+(((x305)*(x308)))+(((IkReal(-0.840000000000000))*(x301))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((sj5)*(x308)))+(((IkReal(-1.00000000000000))*(x301)))+(((IkReal(-1.00000000000000))*(sj5)*(x309)))+(((IkReal(-1.00000000000000))*(x304))));
-evalcond[3]=((((IkReal(-0.420000000000000))*(sj5)))+(((IkReal(-1.00000000000000))*(x302)*(x303)))+(((IkReal(-1.00000000000000))*(x309)))+(x308)+(((IkReal(-1.00000000000000))*(sj5)*(x304))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(cj5)*(x300)*(x309)))+(((cj5)*(sj4)*(x308)))+(((cj4)*(x310)))+(((sj4)*(x306)))+(((cj4)*(x307))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x302)*(x309)))+(((IkReal(-1.00000000000000))*(x300)*(x310)))+(((x302)*(x308)))+(((IkReal(-1.00000000000000))*(x300)*(x307)))+(((cj4)*(x306)))+(((IkReal(-1.00000000000000))*(x303))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x311=((IkReal(49.0000000000000))*(npx));
-IkReal x312=((IkReal(49.0000000000000))*(npy));
-IkReal x313=((sj3)*(sj4)*(sj5));
-IkReal x314=((IkReal(100.000000000000))*(cj5)*(npz));
-if( IKabs(((gconst0)*(((((IkReal(-1.00000000000000))*(npy)*(x314)))+(((IkReal(-1.00000000000000))*(x311)*(x313)))+(((IkReal(-1.00000000000000))*(cj3)*(x312)))+(((IkReal(-42.0000000000000))*(npy))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst0)*(((((IkReal(-1.00000000000000))*(x312)*(x313)))+(((npx)*(x314)))+(((cj3)*(x311)))+(((IkReal(42.0000000000000))*(npx))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst0)*(((((IkReal(-1.00000000000000))*(npy)*(x314)))+(((IkReal(-1.00000000000000))*(x311)*(x313)))+(((IkReal(-1.00000000000000))*(cj3)*(x312)))+(((IkReal(-42.0000000000000))*(npy)))))), ((gconst0)*(((((IkReal(-1.00000000000000))*(x312)*(x313)))+(((npx)*(x314)))+(((cj3)*(x311)))+(((IkReal(42.0000000000000))*(npx)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[6];
-IkReal x315=IKcos(j6);
-IkReal x316=IKsin(j6);
-IkReal x317=((IkReal(1.00000000000000))*(sj4));
-IkReal x318=((cj5)*(npz));
-IkReal x319=((cj4)*(cj5));
-IkReal x320=((IkReal(0.490000000000000))*(sj3));
-IkReal x321=((IkReal(0.490000000000000))*(cj3));
-IkReal x322=((IkReal(0.840000000000000))*(sj5));
-IkReal x323=((npz)*(sj5));
-IkReal x324=((npy)*(x315));
-IkReal x325=((npx)*(x315));
-IkReal x326=((npy)*(x316));
-IkReal x327=((npx)*(x316));
-evalcond[0]=((((sj4)*(x320)))+(x324)+(x327));
-evalcond[1]=((IkReal(0.0637000000000000))+(((x322)*(x325)))+(((IkReal(-0.840000000000000))*(x318)))+(((IkReal(-1.00000000000000))*(x322)*(x326)))+(((IkReal(-1.00000000000000))*(pp))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(x321)))+(((sj5)*(x325)))+(((IkReal(-1.00000000000000))*(sj5)*(x326)))+(((IkReal(-1.00000000000000))*(x318))));
-evalcond[3]=((((IkReal(-0.420000000000000))*(sj5)))+(((IkReal(-1.00000000000000))*(x326)))+(x325)+(((IkReal(-1.00000000000000))*(x319)*(x320)))+(((IkReal(-1.00000000000000))*(sj5)*(x321))));
-evalcond[4]=((((cj5)*(sj4)*(x325)))+(((sj4)*(x323)))+(((IkReal(-1.00000000000000))*(cj5)*(x317)*(x326)))+(((cj4)*(x324)))+(((cj4)*(x327))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x317)*(x327)))+(((IkReal(-1.00000000000000))*(x317)*(x324)))+(((IkReal(-1.00000000000000))*(x320)))+(((cj4)*(x323)))+(((IkReal(-1.00000000000000))*(x319)*(x326)))+(((x319)*(x325))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j6array[2], cj6array[2], sj6array[2];
-bool j6valid[2]={false};
-_nj6 = 2;
-if( IKabs(npy) < IKFAST_ATAN2_MAGTHRESH && IKabs(npx) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x328=((IkReal(1.00000000000000))*(IKatan2(npy, npx)));
-if( ((((npx)*(npx))+((npy)*(npy)))) < (IkReal)-0.00001 )
-    continue;
-if( (((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30)))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30)))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x329=IKasin(((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30))));
-j6array[0]=((((IkReal(-1.00000000000000))*(x328)))+(((IkReal(-1.00000000000000))*(x329))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-j6array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x328)))+(x329));
-sj6array[1]=IKsin(j6array[1]);
-cj6array[1]=IKcos(j6array[1]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-if( j6array[1] > IKPI )
-{
-    j6array[1]-=IK2PI;
-}
-else if( j6array[1] < -IKPI )
-{    j6array[1]+=IK2PI;
-}
-j6valid[1] = true;
-for(int ij6 = 0; ij6 < 2; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 2; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[2];
-IkReal x330=(npx)*(npx);
-IkReal x331=(cj4)*(cj4);
-IkReal x332=(sj4)*(sj4);
-IkReal x333=IKcos(j6);
-IkReal x334=(npy)*(npy);
-IkReal x335=IKsin(j6);
-IkReal x336=((npx)*(npy));
-IkReal x337=((IkReal(0.490000000000000))*(sj3)*(sj4));
-IkReal x338=((IkReal(1.00000000000000))*(x334));
-evalcond[0]=((((x333)*(((((x331)*(x336)))+(((x332)*(x336)))))))+(((x335)*(((((x330)*(x331)))+(((x330)*(x332)))))))+(((npx)*(x337))));
-evalcond[1]=((((x335)*(((((IkReal(-1.00000000000000))*(x332)*(x336)))+(((IkReal(-1.00000000000000))*(x331)*(x336)))))))+(((x333)*(((((IkReal(-1.00000000000000))*(x331)*(x338)))+(((IkReal(-1.00000000000000))*(x332)*(x338)))))))+(((IkReal(-1.00000000000000))*(npy)*(x337))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst10;
-IkReal x339=((cj6)*(npx));
-IkReal x340=((IkReal(49.0000000000000))*(cj3));
-IkReal x341=((npy)*(sj6));
-gconst10=IKsign(((((IkReal(-42.0000000000000))*(x339)))+(((IkReal(49.0000000000000))*(cj4)*(npz)*(sj3)))+(((x340)*(x341)))+(((IkReal(42.0000000000000))*(x341)))+(((IkReal(-1.00000000000000))*(x339)*(x340)))));
-IkReal x342=((npy)*(sj6));
-IkReal x343=((cj6)*(npx));
-IkReal x344=((IkReal(1.16666666666667))*(cj3));
-dummyeval[0]=((((IkReal(1.16666666666667))*(cj4)*(npz)*(sj3)))+(x342)+(((IkReal(-1.00000000000000))*(x343)*(x344)))+(((IkReal(-1.00000000000000))*(x343)))+(((x342)*(x344))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst11;
-IkReal x345=((npy)*(sj6));
-IkReal x346=((IkReal(1029.00000000000))*(cj3));
-IkReal x347=((cj6)*(npx));
-gconst11=IKsign(((((x345)*(x346)))+(((IkReal(1029.00000000000))*(cj4)*(npz)*(sj3)))+(((IkReal(-1.00000000000000))*(x346)*(x347)))+(((IkReal(-882.000000000000))*(x347)))+(((IkReal(882.000000000000))*(x345)))));
-IkReal x348=((npy)*(sj6));
-IkReal x349=((cj6)*(npx));
-IkReal x350=((IkReal(1.16666666666667))*(cj3));
-dummyeval[0]=((((IkReal(1.16666666666667))*(cj4)*(npz)*(sj3)))+(((IkReal(-1.00000000000000))*(x349)*(x350)))+(x348)+(((x348)*(x350)))+(((IkReal(-1.00000000000000))*(x349))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-IkReal x351=((cj4)*(sj3));
-IkReal x352=((IkReal(1225.00000000000))*(pp));
-IkReal x353=((IkReal(2100.00000000000))*(npz));
-if( IKabs(((gconst11)*(((IkReal(66.8850000000000))+(((IkReal(-1.00000000000000))*(cj3)*(x352)))+(((IkReal(-1050.00000000000))*(pp)))+(((IkReal(78.0325000000000))*(cj3)))+(((npz)*(x353))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst11)*(((((IkReal(78.0325000000000))*(x351)))+(((cj6)*(npx)*(x353)))+(((IkReal(-1.00000000000000))*(x351)*(x352)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x353))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst11)*(((IkReal(66.8850000000000))+(((IkReal(-1.00000000000000))*(cj3)*(x352)))+(((IkReal(-1050.00000000000))*(pp)))+(((IkReal(78.0325000000000))*(cj3)))+(((npz)*(x353)))))), ((gconst11)*(((((IkReal(78.0325000000000))*(x351)))+(((cj6)*(npx)*(x353)))+(((IkReal(-1.00000000000000))*(x351)*(x352)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x353)))))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[6];
-IkReal x354=IKcos(j5);
-IkReal x355=IKsin(j5);
-IkReal x356=((IkReal(1.00000000000000))*(npy));
-IkReal x357=((cj6)*(sj4));
-IkReal x358=((IkReal(0.490000000000000))*(sj3));
-IkReal x359=((sj4)*(sj6));
-IkReal x360=((IkReal(1.00000000000000))*(npz));
-IkReal x361=((cj6)*(npx));
-IkReal x362=((IkReal(0.490000000000000))*(cj3));
-IkReal x363=((npz)*(x355));
-IkReal x364=((cj4)*(x354));
-IkReal x365=((sj6)*(x355));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x354)*(x362)))+(((IkReal(-0.420000000000000))*(x354)))+(((IkReal(-1.00000000000000))*(x360)))+(((cj4)*(x355)*(x358))));
-evalcond[1]=((IkReal(0.0637000000000000))+(((IkReal(-0.840000000000000))*(npz)*(x354)))+(((IkReal(0.840000000000000))*(x355)*(x361)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-0.840000000000000))*(npy)*(x365))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(x354)*(x360)))+(((IkReal(-1.00000000000000))*(x362)))+(((x355)*(x361)))+(((IkReal(-1.00000000000000))*(x356)*(x365))));
-evalcond[3]=((((IkReal(-0.420000000000000))*(x355)))+(((IkReal(-1.00000000000000))*(x358)*(x364)))+(((IkReal(-1.00000000000000))*(x355)*(x362)))+(x361)+(((IkReal(-1.00000000000000))*(sj6)*(x356))));
-evalcond[4]=((((sj4)*(x363)))+(((npx)*(x354)*(x357)))+(((cj4)*(npx)*(sj6)))+(((cj4)*(cj6)*(npy)))+(((IkReal(-1.00000000000000))*(x354)*(x356)*(x359))));
-evalcond[5]=((((x361)*(x364)))+(((IkReal(-1.00000000000000))*(x358)))+(((IkReal(-1.00000000000000))*(x356)*(x357)))+(((cj4)*(x363)))+(((IkReal(-1.00000000000000))*(npx)*(x359)))+(((IkReal(-1.00000000000000))*(sj6)*(x356)*(x364))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-IkReal x366=((cj4)*(sj3));
-IkReal x367=((IkReal(100.000000000000))*(npz));
-if( IKabs(((gconst10)*(((IkReal(-17.6400000000000))+(((IkReal(-41.1600000000000))*(cj3)))+(((npz)*(x367)))+(((IkReal(-24.0100000000000))*((cj3)*(cj3)))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst10)*(((((IkReal(-20.5800000000000))*(x366)))+(((cj6)*(npx)*(x367)))+(((IkReal(-24.0100000000000))*(cj3)*(x366)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x367))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst10)*(((IkReal(-17.6400000000000))+(((IkReal(-41.1600000000000))*(cj3)))+(((npz)*(x367)))+(((IkReal(-24.0100000000000))*((cj3)*(cj3))))))), ((gconst10)*(((((IkReal(-20.5800000000000))*(x366)))+(((cj6)*(npx)*(x367)))+(((IkReal(-24.0100000000000))*(cj3)*(x366)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x367)))))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[6];
-IkReal x368=IKcos(j5);
-IkReal x369=IKsin(j5);
-IkReal x370=((IkReal(1.00000000000000))*(npy));
-IkReal x371=((cj6)*(sj4));
-IkReal x372=((IkReal(0.490000000000000))*(sj3));
-IkReal x373=((sj4)*(sj6));
-IkReal x374=((IkReal(1.00000000000000))*(npz));
-IkReal x375=((cj6)*(npx));
-IkReal x376=((IkReal(0.490000000000000))*(cj3));
-IkReal x377=((npz)*(x369));
-IkReal x378=((cj4)*(x368));
-IkReal x379=((sj6)*(x369));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x368)*(x376)))+(((cj4)*(x369)*(x372)))+(((IkReal(-1.00000000000000))*(x374)))+(((IkReal(-0.420000000000000))*(x368))));
-evalcond[1]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(x369)*(x375)))+(((IkReal(-0.840000000000000))*(npz)*(x368)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-0.840000000000000))*(npy)*(x379))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(x368)*(x374)))+(((IkReal(-1.00000000000000))*(x370)*(x379)))+(((x369)*(x375)))+(((IkReal(-1.00000000000000))*(x376))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x372)*(x378)))+(x375)+(((IkReal(-0.420000000000000))*(x369)))+(((IkReal(-1.00000000000000))*(sj6)*(x370)))+(((IkReal(-1.00000000000000))*(x369)*(x376))));
-evalcond[4]=((((sj4)*(x377)))+(((IkReal(-1.00000000000000))*(x368)*(x370)*(x373)))+(((cj4)*(npx)*(sj6)))+(((cj4)*(cj6)*(npy)))+(((npx)*(x368)*(x371))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(npx)*(x373)))+(((x375)*(x378)))+(((IkReal(-1.00000000000000))*(x370)*(x371)))+(((IkReal(-1.00000000000000))*(x372)))+(((cj4)*(x377)))+(((IkReal(-1.00000000000000))*(sj6)*(x370)*(x378))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j6array[2], cj6array[2], sj6array[2];
-bool j6valid[2]={false};
-_nj6 = 2;
-if( IKabs(npy) < IKFAST_ATAN2_MAGTHRESH && IKabs(npx) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x380=((IkReal(1.00000000000000))*(IKatan2(npy, npx)));
-if( ((((npx)*(npx))+((npy)*(npy)))) < (IkReal)-0.00001 )
-    continue;
-if( (((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30)))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30)))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x381=IKasin(((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30))));
-j6array[0]=((((IkReal(-1.00000000000000))*(x381)))+(((IkReal(-1.00000000000000))*(x380))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-j6array[1]=((IkReal(3.14159265358979))+(x381)+(((IkReal(-1.00000000000000))*(x380))));
-sj6array[1]=IKsin(j6array[1]);
-cj6array[1]=IKcos(j6array[1]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-if( j6array[1] > IKPI )
-{
-    j6array[1]-=IK2PI;
-}
-else if( j6array[1] < -IKPI )
-{    j6array[1]+=IK2PI;
-}
-j6valid[1] = true;
-for(int ij6 = 0; ij6 < 2; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 2; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-
-{
-IkReal dummyeval[1];
-IkReal gconst10;
-IkReal x382=((cj6)*(npx));
-IkReal x383=((IkReal(49.0000000000000))*(cj3));
-IkReal x384=((npy)*(sj6));
-gconst10=IKsign(((((IkReal(-42.0000000000000))*(x382)))+(((IkReal(42.0000000000000))*(x384)))+(((x383)*(x384)))+(((IkReal(49.0000000000000))*(cj4)*(npz)*(sj3)))+(((IkReal(-1.00000000000000))*(x382)*(x383)))));
-IkReal x385=((npy)*(sj6));
-IkReal x386=((cj6)*(npx));
-IkReal x387=((IkReal(1.16666666666667))*(cj3));
-dummyeval[0]=((((IkReal(1.16666666666667))*(cj4)*(npz)*(sj3)))+(x385)+(((IkReal(-1.00000000000000))*(x386)))+(((IkReal(-1.00000000000000))*(x386)*(x387)))+(((x385)*(x387))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst11;
-IkReal x388=((npy)*(sj6));
-IkReal x389=((IkReal(1029.00000000000))*(cj3));
-IkReal x390=((cj6)*(npx));
-gconst11=IKsign(((((IkReal(-1.00000000000000))*(x389)*(x390)))+(((IkReal(-882.000000000000))*(x390)))+(((x388)*(x389)))+(((IkReal(1029.00000000000))*(cj4)*(npz)*(sj3)))+(((IkReal(882.000000000000))*(x388)))));
-IkReal x391=((npy)*(sj6));
-IkReal x392=((cj6)*(npx));
-IkReal x393=((IkReal(1.16666666666667))*(cj3));
-dummyeval[0]=((((IkReal(1.16666666666667))*(cj4)*(npz)*(sj3)))+(((IkReal(-1.00000000000000))*(x392)))+(x391)+(((x391)*(x393)))+(((IkReal(-1.00000000000000))*(x392)*(x393))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-IkReal x394=((cj4)*(sj3));
-IkReal x395=((IkReal(1225.00000000000))*(pp));
-IkReal x396=((IkReal(2100.00000000000))*(npz));
-if( IKabs(((gconst11)*(((IkReal(66.8850000000000))+(((npz)*(x396)))+(((IkReal(-1050.00000000000))*(pp)))+(((IkReal(-1.00000000000000))*(cj3)*(x395)))+(((IkReal(78.0325000000000))*(cj3))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst11)*(((((cj6)*(npx)*(x396)))+(((IkReal(-1.00000000000000))*(x394)*(x395)))+(((IkReal(78.0325000000000))*(x394)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x396))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst11)*(((IkReal(66.8850000000000))+(((npz)*(x396)))+(((IkReal(-1050.00000000000))*(pp)))+(((IkReal(-1.00000000000000))*(cj3)*(x395)))+(((IkReal(78.0325000000000))*(cj3)))))), ((gconst11)*(((((cj6)*(npx)*(x396)))+(((IkReal(-1.00000000000000))*(x394)*(x395)))+(((IkReal(78.0325000000000))*(x394)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x396)))))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[6];
-IkReal x397=IKcos(j5);
-IkReal x398=IKsin(j5);
-IkReal x399=((IkReal(1.00000000000000))*(npy));
-IkReal x400=((cj6)*(sj4));
-IkReal x401=((IkReal(0.490000000000000))*(sj3));
-IkReal x402=((sj4)*(sj6));
-IkReal x403=((IkReal(1.00000000000000))*(npz));
-IkReal x404=((cj6)*(npx));
-IkReal x405=((IkReal(0.490000000000000))*(cj3));
-IkReal x406=((npz)*(x398));
-IkReal x407=((cj4)*(x397));
-IkReal x408=((sj6)*(x398));
-evalcond[0]=((((cj4)*(x398)*(x401)))+(((IkReal(-1.00000000000000))*(x397)*(x405)))+(((IkReal(-0.420000000000000))*(x397)))+(((IkReal(-1.00000000000000))*(x403))));
-evalcond[1]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(x398)*(x404)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-0.840000000000000))*(npy)*(x408)))+(((IkReal(-0.840000000000000))*(npz)*(x397))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(x399)*(x408)))+(((IkReal(-1.00000000000000))*(x397)*(x403)))+(((x398)*(x404)))+(((IkReal(-1.00000000000000))*(x405))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x401)*(x407)))+(((IkReal(-1.00000000000000))*(sj6)*(x399)))+(x404)+(((IkReal(-1.00000000000000))*(x398)*(x405)))+(((IkReal(-0.420000000000000))*(x398))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x397)*(x399)*(x402)))+(((npx)*(x397)*(x400)))+(((cj4)*(npx)*(sj6)))+(((cj4)*(cj6)*(npy)))+(((sj4)*(x406))));
-evalcond[5]=((((x404)*(x407)))+(((IkReal(-1.00000000000000))*(sj6)*(x399)*(x407)))+(((cj4)*(x406)))+(((IkReal(-1.00000000000000))*(x399)*(x400)))+(((IkReal(-1.00000000000000))*(npx)*(x402)))+(((IkReal(-1.00000000000000))*(x401))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-IkReal x409=((cj4)*(sj3));
-IkReal x410=((IkReal(100.000000000000))*(npz));
-if( IKabs(((gconst10)*(((IkReal(-17.6400000000000))+(((IkReal(-41.1600000000000))*(cj3)))+(((npz)*(x410)))+(((IkReal(-24.0100000000000))*((cj3)*(cj3)))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst10)*(((((IkReal(-1.00000000000000))*(npy)*(sj6)*(x410)))+(((cj6)*(npx)*(x410)))+(((IkReal(-24.0100000000000))*(cj3)*(x409)))+(((IkReal(-20.5800000000000))*(x409))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst10)*(((IkReal(-17.6400000000000))+(((IkReal(-41.1600000000000))*(cj3)))+(((npz)*(x410)))+(((IkReal(-24.0100000000000))*((cj3)*(cj3))))))), ((gconst10)*(((((IkReal(-1.00000000000000))*(npy)*(sj6)*(x410)))+(((cj6)*(npx)*(x410)))+(((IkReal(-24.0100000000000))*(cj3)*(x409)))+(((IkReal(-20.5800000000000))*(x409)))))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[6];
-IkReal x411=IKcos(j5);
-IkReal x412=IKsin(j5);
-IkReal x413=((IkReal(1.00000000000000))*(npy));
-IkReal x414=((cj6)*(sj4));
-IkReal x415=((IkReal(0.490000000000000))*(sj3));
-IkReal x416=((sj4)*(sj6));
-IkReal x417=((IkReal(1.00000000000000))*(npz));
-IkReal x418=((cj6)*(npx));
-IkReal x419=((IkReal(0.490000000000000))*(cj3));
-IkReal x420=((npz)*(x412));
-IkReal x421=((cj4)*(x411));
-IkReal x422=((sj6)*(x412));
-evalcond[0]=((((cj4)*(x412)*(x415)))+(((IkReal(-0.420000000000000))*(x411)))+(((IkReal(-1.00000000000000))*(x411)*(x419)))+(((IkReal(-1.00000000000000))*(x417))));
-evalcond[1]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(x412)*(x418)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-0.840000000000000))*(npy)*(x422)))+(((IkReal(-0.840000000000000))*(npz)*(x411))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(x411)*(x417)))+(((x412)*(x418)))+(((IkReal(-1.00000000000000))*(x413)*(x422)))+(((IkReal(-1.00000000000000))*(x419))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(sj6)*(x413)))+(((IkReal(-1.00000000000000))*(x412)*(x419)))+(((IkReal(-0.420000000000000))*(x412)))+(x418)+(((IkReal(-1.00000000000000))*(x415)*(x421))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x411)*(x413)*(x416)))+(((npx)*(x411)*(x414)))+(((sj4)*(x420)))+(((cj4)*(npx)*(sj6)))+(((cj4)*(cj6)*(npy))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(sj6)*(x413)*(x421)))+(((x418)*(x421)))+(((cj4)*(x420)))+(((IkReal(-1.00000000000000))*(x413)*(x414)))+(((IkReal(-1.00000000000000))*(npx)*(x416)))+(((IkReal(-1.00000000000000))*(x415))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-}
-}
-}
-return solutions.GetNumSolutions()>0;
-}
-inline void rotationfunction0(IkSolutionListBase<IkReal>& solutions) {
-for(int rotationiter = 0; rotationiter < 1; ++rotationiter) {
-IkReal x78=((cj6)*(sj4));
-IkReal x79=((IkReal(1.00000000000000))*(sj5));
-IkReal x80=((cj4)*(cj5));
-IkReal x81=((IkReal(1.00000000000000))*(sj3));
-IkReal x82=((cj3)*(sj5));
-IkReal x83=((IkReal(1.00000000000000))*(sj6));
-IkReal x84=((sj4)*(sj6));
-IkReal x85=((IkReal(1.00000000000000))*(cj3));
-IkReal x86=((IkReal(-1.00000000000000))*(cj3));
-IkReal x87=((((cj3)*(x80)))+(((IkReal(-1.00000000000000))*(sj3)*(x79))));
-IkReal x88=((((cj5)*(sj3)))+(((cj4)*(x82))));
-IkReal x89=((((cj5)*(x84)))+(((IkReal(-1.00000000000000))*(cj4)*(cj6))));
-IkReal x90=((x82)+(((sj3)*(x80))));
-IkReal x91=((((cj4)*(sj3)*(sj5)))+(((IkReal(-1.00000000000000))*(cj5)*(x85))));
-IkReal x92=((cj6)*(x87));
-IkReal x93=((((IkReal(-1.00000000000000))*(cj4)*(x83)))+(((IkReal(-1.00000000000000))*(cj5)*(x78))));
-IkReal x94=((((IkReal(-1.00000000000000))*(cj3)*(sj4)*(x83)))+(x92));
-IkReal x95=((((IkReal(-1.00000000000000))*(x81)*(x84)))+(((cj6)*(x90))));
-IkReal x96=((((IkReal(-1.00000000000000))*(x83)*(x90)))+(((IkReal(-1.00000000000000))*(x78)*(x81))));
-IkReal x97=((((x78)*(x86)))+(((IkReal(-1.00000000000000))*(sj6)*(x87))));
-new_r00=((((r00)*(((((x84)*(x86)))+(x92)))))+(((r01)*(((((IkReal(-1.00000000000000))*(x83)*(x87)))+(((IkReal(-1.00000000000000))*(x78)*(x85)))))))+(((r02)*(x88))));
-new_r01=((((r12)*(x88)))+(((r11)*(x97)))+(((r10)*(x94))));
-new_r02=((((r21)*(x97)))+(((r20)*(x94)))+(((r22)*(x88))));
-new_r10=((((r00)*(x93)))+(((r01)*(x89)))+(((IkReal(-1.00000000000000))*(r02)*(sj4)*(x79))));
-new_r11=((((r11)*(x89)))+(((r10)*(x93)))+(((IkReal(-1.00000000000000))*(r12)*(sj4)*(x79))));
-new_r12=((((r21)*(x89)))+(((IkReal(-1.00000000000000))*(r22)*(sj4)*(x79)))+(((r20)*(x93))));
-new_r20=((((r01)*(x96)))+(((r00)*(x95)))+(((r02)*(x91))));
-new_r21=((((r12)*(x91)))+(((r11)*(x96)))+(((r10)*(x95))));
-new_r22=((((r21)*(x96)))+(((r20)*(x95)))+(((r22)*(x91))));
-{
-IkReal j1array[2], cj1array[2], sj1array[2];
-bool j1valid[2]={false};
-_nj1 = 2;
-cj1array[0]=new_r22;
-if( cj1array[0] >= -1-IKFAST_SINCOS_THRESH && cj1array[0] <= 1+IKFAST_SINCOS_THRESH )
-{
-    j1valid[0] = j1valid[1] = true;
-    j1array[0] = IKacos(cj1array[0]);
-    sj1array[0] = IKsin(j1array[0]);
-    cj1array[1] = cj1array[0];
-    j1array[1] = -j1array[0];
-    sj1array[1] = -sj1array[0];
-}
-else if( isnan(cj1array[0]) )
-{
-    // probably any value will work
-    j1valid[0] = true;
-    cj1array[0] = 1; sj1array[0] = 0; j1array[0] = 0;
-}
-for(int ij1 = 0; ij1 < 2; ++ij1)
-{
-if( !j1valid[ij1] )
-{
-    continue;
-}
-_ij1[0] = ij1; _ij1[1] = -1;
-for(int iij1 = ij1+1; iij1 < 2; ++iij1)
-{
-if( j1valid[iij1] && IKabs(cj1array[ij1]-cj1array[iij1]) < IKFAST_SOLUTION_THRESH && IKabs(sj1array[ij1]-sj1array[iij1]) < IKFAST_SOLUTION_THRESH )
-{
-    j1valid[iij1]=false; _ij1[1] = iij1; break; 
-}
-}
-j1 = j1array[ij1]; cj1 = cj1array[ij1]; sj1 = sj1array[ij1];
-
-{
-IkReal dummyeval[1];
-IkReal gconst12;
-gconst12=IKsign(sj1);
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst13;
-gconst13=IKsign((((new_r12)*(new_r12))+((new_r02)*(new_r02))));
-dummyeval[0]=(((new_r12)*(new_r12))+((new_r02)*(new_r02)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst14;
-gconst14=IKsign(((((cj1)*((new_r12)*(new_r12))))+(((cj1)*((new_r02)*(new_r02))))));
-dummyeval[0]=((((cj1)*((new_r12)*(new_r12))))+(((cj1)*((new_r02)*(new_r02)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[7];
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.57079632679490))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=new_r22;
-evalcond[2]=new_r22;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(new_r21) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r20) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(new_r21)+IKsqr(new_r20)-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(new_r21, new_r20);
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[2];
-evalcond[0]=((((IkReal(-1.00000000000000))*(IKcos(j0))))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(IKsin(j0))))+(new_r21));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst21;
-gconst21=IKsign((((new_r12)*(new_r12))+((new_r02)*(new_r02))));
-dummyeval[0]=(((new_r12)*(new_r12))+((new_r02)*(new_r02)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst20;
-gconst20=IKsign(((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10)))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x98=((gconst20)*(sj0));
-if( IKabs(((new_r12)*(x98))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x98))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x98)), ((IkReal(-1.00000000000000))*(new_r02)*(x98)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x99=IKsin(j2);
-IkReal x100=IKcos(j2);
-IkReal x101=((IkReal(1.00000000000000))*(x99));
-evalcond[0]=((((new_r02)*(x99)))+(((new_r12)*(x100))));
-evalcond[1]=((((new_r10)*(x100)))+(sj0)+(((new_r00)*(x99))));
-evalcond[2]=((IkReal(1.00000000000000))+(((new_r02)*(x100)))+(((IkReal(-1.00000000000000))*(new_r12)*(x101))));
-evalcond[3]=((((new_r01)*(x99)))+(((IkReal(-1.00000000000000))*(cj0)))+(((new_r11)*(x100))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(new_r10)*(x101)))+(((new_r00)*(x100))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r11)*(x101)))+(((new_r01)*(x100))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-if( IKabs(((gconst21)*(new_r12))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(gconst21)*(new_r02))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((gconst21)*(new_r12)), ((IkReal(-1.00000000000000))*(gconst21)*(new_r02)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x102=IKsin(j2);
-IkReal x103=IKcos(j2);
-IkReal x104=((IkReal(1.00000000000000))*(x102));
-evalcond[0]=((((new_r02)*(x102)))+(((new_r12)*(x103))));
-evalcond[1]=((((new_r10)*(x103)))+(sj0)+(((new_r00)*(x102))));
-evalcond[2]=((IkReal(1.00000000000000))+(((new_r02)*(x103)))+(((IkReal(-1.00000000000000))*(new_r12)*(x104))));
-evalcond[3]=((((new_r01)*(x102)))+(((IkReal(-1.00000000000000))*(cj0)))+(((new_r11)*(x103))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(new_r10)*(x104)))+(((new_r00)*(x103))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r11)*(x104)))+(((new_r01)*(x103))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-} else
-{
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(4.71238898038469))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=new_r22;
-evalcond[2]=((IkReal(-1.00000000000000))*(new_r22));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((IkReal(-1.00000000000000))*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r20))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((IkReal(-1.00000000000000))*(new_r21)))+IKsqr(((IkReal(-1.00000000000000))*(new_r20)))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((IkReal(-1.00000000000000))*(new_r21)), ((IkReal(-1.00000000000000))*(new_r20)));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[2];
-evalcond[0]=((IKcos(j0))+(new_r20));
-evalcond[1]=((IKsin(j0))+(new_r21));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst24;
-gconst24=IKsign(((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10)))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst25;
-gconst25=IKsign(((((IkReal(-1.00000000000000))*((new_r02)*(new_r02))))+(((IkReal(-1.00000000000000))*((new_r12)*(new_r12))))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*((new_r02)*(new_r02))))+(((IkReal(-1.00000000000000))*((new_r12)*(new_r12)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-if( IKabs(((gconst25)*(new_r12))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(gconst25)*(new_r02))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((gconst25)*(new_r12)), ((IkReal(-1.00000000000000))*(gconst25)*(new_r02)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x105=IKsin(j2);
-IkReal x106=IKcos(j2);
-IkReal x107=((IkReal(1.00000000000000))*(x105));
-evalcond[0]=((((new_r02)*(x105)))+(((new_r12)*(x106))));
-evalcond[1]=((((new_r10)*(x106)))+(sj0)+(((new_r00)*(x105))));
-evalcond[2]=((IkReal(-1.00000000000000))+(((new_r02)*(x106)))+(((IkReal(-1.00000000000000))*(new_r12)*(x107))));
-evalcond[3]=((((new_r01)*(x105)))+(((IkReal(-1.00000000000000))*(cj0)))+(((new_r11)*(x106))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(new_r10)*(x107)))+(((new_r00)*(x106))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r11)*(x107)))+(((new_r01)*(x106))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x108=((gconst24)*(sj0));
-if( IKabs(((new_r12)*(x108))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x108))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x108)), ((IkReal(-1.00000000000000))*(new_r02)*(x108)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x109=IKsin(j2);
-IkReal x110=IKcos(j2);
-IkReal x111=((IkReal(1.00000000000000))*(x109));
-evalcond[0]=((((new_r02)*(x109)))+(((new_r12)*(x110))));
-evalcond[1]=((((new_r10)*(x110)))+(sj0)+(((new_r00)*(x109))));
-evalcond[2]=((IkReal(-1.00000000000000))+(((new_r02)*(x110)))+(((IkReal(-1.00000000000000))*(new_r12)*(x111))));
-evalcond[3]=((((new_r11)*(x110)))+(((new_r01)*(x109)))+(((IkReal(-1.00000000000000))*(cj0))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(new_r10)*(x111)))+(((new_r00)*(x110))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r11)*(x111)))+(((new_r01)*(x110))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-} else
-{
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(-1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[5]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[6]=((IkReal(1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  )
-{
-{
-IkReal j2array[2], cj2array[2], sj2array[2];
-bool j2valid[2]={false};
-_nj2 = 2;
-if( IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x112=IKatan2(new_r12, new_r02);
-j2array[0]=((IkReal(-1.00000000000000))*(x112));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-j2array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x112))));
-sj2array[1]=IKsin(j2array[1]);
-cj2array[1]=IKcos(j2array[1]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-if( j2array[1] > IKPI )
-{
-    j2array[1]-=IK2PI;
-}
-else if( j2array[1] < -IKPI )
-{    j2array[1]+=IK2PI;
-}
-j2valid[1] = true;
-for(int ij2 = 0; ij2 < 2; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 2; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[1];
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r12)*(IKsin(j2))))+(((new_r02)*(IKcos(j2)))));
-if( IKabs(evalcond[0]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x113=IKsin(j0);
-IkReal x114=((IkReal(1.00000000000000))*(sj2));
-IkReal x115=((IkReal(1.00000000000000))*(IKcos(j0)));
-evalcond[0]=((((new_r00)*(sj2)))+(x113)+(((cj2)*(new_r10))));
-evalcond[1]=((((new_r01)*(sj2)))+(((IkReal(-1.00000000000000))*(x115)))+(((cj2)*(new_r11))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r10)*(x114)))+(((IkReal(-1.00000000000000))*(x115)))+(((cj2)*(new_r00))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r11)*(x114)))+(((cj2)*(new_r01)))+(((IkReal(-1.00000000000000))*(x113))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-}
-}
-
-} else
-{
-IkReal x116=((IkReal(1.00000000000000))+(new_r22));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=x116;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=new_r20;
-evalcond[5]=new_r21;
-evalcond[6]=x116;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  )
-{
-{
-IkReal j2array[2], cj2array[2], sj2array[2];
-bool j2valid[2]={false};
-_nj2 = 2;
-if( IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x117=IKatan2(new_r12, new_r02);
-j2array[0]=((IkReal(-1.00000000000000))*(x117));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-j2array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x117))));
-sj2array[1]=IKsin(j2array[1]);
-cj2array[1]=IKcos(j2array[1]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-if( j2array[1] > IKPI )
-{
-    j2array[1]-=IK2PI;
-}
-else if( j2array[1] < -IKPI )
-{    j2array[1]+=IK2PI;
-}
-j2valid[1] = true;
-for(int ij2 = 0; ij2 < 2; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 2; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[1];
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r12)*(IKsin(j2))))+(((new_r02)*(IKcos(j2)))));
-if( IKabs(evalcond[0]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x118=IKcos(j0);
-IkReal x119=IKsin(j0);
-IkReal x120=((IkReal(1.00000000000000))*(sj2));
-evalcond[0]=((((new_r00)*(sj2)))+(x119)+(((cj2)*(new_r10))));
-evalcond[1]=((((new_r01)*(sj2)))+(((cj2)*(new_r11)))+(((IkReal(-1.00000000000000))*(x118))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r10)*(x120)))+(x118)+(((cj2)*(new_r00))));
-evalcond[3]=((x119)+(((cj2)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(x120))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x121=((gconst14)*(new_r22)*(sj1));
-if( IKabs(((new_r12)*(x121))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x121))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x121)), ((IkReal(-1.00000000000000))*(new_r02)*(x121)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x122=IKcos(j2);
-IkReal x123=IKsin(j2);
-IkReal x124=((IkReal(1.00000000000000))*(cj1));
-IkReal x125=((sj1)*(x122));
-IkReal x126=((new_r12)*(x123));
-IkReal x127=((new_r02)*(x122));
-IkReal x128=((IkReal(1.00000000000000))*(sj1)*(x123));
-evalcond[0]=((((new_r02)*(x123)))+(((new_r12)*(x122))));
-evalcond[1]=((sj1)+(x127)+(((IkReal(-1.00000000000000))*(x126))));
-evalcond[2]=((((cj1)*(x127)))+(((IkReal(-1.00000000000000))*(x124)*(x126)))+(((new_r22)*(sj1))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r10)*(x128)))+(((new_r00)*(x125)))+(((IkReal(-1.00000000000000))*(new_r20)*(x124))));
-evalcond[4]=((((new_r01)*(x125)))+(((IkReal(-1.00000000000000))*(new_r21)*(x124)))+(((IkReal(-1.00000000000000))*(new_r11)*(x128))));
-evalcond[5]=((IkReal(1.00000000000000))+(((IkReal(-1.00000000000000))*(sj1)*(x126)))+(((new_r02)*(x125)))+(((IkReal(-1.00000000000000))*(new_r22)*(x124))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst15;
-gconst15=IKsign(sj1);
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[11];
-IkReal x129=((((new_r02)*(sj2)))+(((cj2)*(new_r12))));
-IkReal x130=((((cj2)*(new_r02)))+(((IkReal(-1.00000000000000))*(new_r12)*(sj2))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(-1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x129;
-evalcond[5]=x129;
-evalcond[6]=x130;
-evalcond[7]=x130;
-evalcond[8]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[9]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[10]=((IkReal(1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x131=IKsin(j0);
-IkReal x132=((IkReal(1.00000000000000))*(sj2));
-IkReal x133=((IkReal(1.00000000000000))*(IKcos(j0)));
-evalcond[0]=((((new_r00)*(sj2)))+(x131)+(((cj2)*(new_r10))));
-evalcond[1]=((((new_r01)*(sj2)))+(((IkReal(-1.00000000000000))*(x133)))+(((cj2)*(new_r11))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r10)*(x132)))+(((IkReal(-1.00000000000000))*(x133)))+(((cj2)*(new_r00))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r11)*(x132)))+(((cj2)*(new_r01)))+(((IkReal(-1.00000000000000))*(x131))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-IkReal x134=((IkReal(1.00000000000000))+(new_r22));
-IkReal x135=((new_r12)*(sj2));
-IkReal x136=((cj2)*(new_r02));
-IkReal x137=((((new_r02)*(sj2)))+(((cj2)*(new_r12))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=x134;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x137;
-evalcond[5]=x137;
-evalcond[6]=((x136)+(((IkReal(-1.00000000000000))*(x135))));
-evalcond[7]=((x135)+(((IkReal(-1.00000000000000))*(x136))));
-evalcond[8]=new_r20;
-evalcond[9]=new_r21;
-evalcond[10]=x134;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x138=IKcos(j0);
-IkReal x139=IKsin(j0);
-IkReal x140=((IkReal(1.00000000000000))*(sj2));
-evalcond[0]=((((new_r00)*(sj2)))+(x139)+(((cj2)*(new_r10))));
-evalcond[1]=((((new_r01)*(sj2)))+(((cj2)*(new_r11)))+(((IkReal(-1.00000000000000))*(x138))));
-evalcond[2]=((x138)+(((IkReal(-1.00000000000000))*(new_r10)*(x140)))+(((cj2)*(new_r00))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r11)*(x140)))+(x139)+(((cj2)*(new_r01))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x141=IKsin(j0);
-IkReal x142=IKcos(j0);
-IkReal x143=((cj2)*(new_r01));
-IkReal x144=((IkReal(1.00000000000000))*(cj1));
-IkReal x145=((IkReal(1.00000000000000))*(sj1));
-IkReal x146=((new_r10)*(sj2));
-IkReal x147=((new_r11)*(sj2));
-IkReal x148=((cj2)*(new_r00));
-IkReal x149=((IkReal(1.00000000000000))*(x142));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x142)*(x145)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x141)*(x145)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x141)+(((cj2)*(new_r10))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x149)))+(((new_r01)*(sj2)))+(((cj2)*(new_r11))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x142)*(x144)))+(x148)+(((IkReal(-1.00000000000000))*(x146))));
-evalcond[5]=((x143)+(((IkReal(-1.00000000000000))*(x147)))+(((IkReal(-1.00000000000000))*(x141)*(x144))));
-evalcond[6]=((((IkReal(-1.00000000000000))*(x149)))+(((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(x144)*(x146)))+(((cj1)*(x148))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x144)*(x147)))+(((IkReal(-1.00000000000000))*(x141)))+(((new_r21)*(sj1)))+(((cj1)*(x143))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x150=IKsin(j0);
-IkReal x151=IKcos(j0);
-IkReal x152=((cj2)*(new_r01));
-IkReal x153=((IkReal(1.00000000000000))*(cj1));
-IkReal x154=((IkReal(1.00000000000000))*(sj1));
-IkReal x155=((new_r10)*(sj2));
-IkReal x156=((new_r11)*(sj2));
-IkReal x157=((cj2)*(new_r00));
-IkReal x158=((IkReal(1.00000000000000))*(x151));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x151)*(x154)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x150)*(x154)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x150)+(((cj2)*(new_r10))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x158)))+(((new_r01)*(sj2)))+(((cj2)*(new_r11))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x151)*(x153)))+(x157)+(((IkReal(-1.00000000000000))*(x155))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x150)*(x153)))+(x152)+(((IkReal(-1.00000000000000))*(x156))));
-evalcond[6]=((((IkReal(-1.00000000000000))*(x158)))+(((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(x153)*(x155)))+(((cj1)*(x157))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x153)*(x156)))+(((IkReal(-1.00000000000000))*(x150)))+(((new_r21)*(sj1)))+(((cj1)*(x152))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((gconst15)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst15)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j0array[0]=IKatan2(((gconst15)*(new_r21)), ((gconst15)*(new_r20)));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x159=IKsin(j0);
-IkReal x160=IKcos(j0);
-IkReal x161=((cj2)*(new_r01));
-IkReal x162=((IkReal(1.00000000000000))*(cj1));
-IkReal x163=((IkReal(1.00000000000000))*(sj1));
-IkReal x164=((new_r10)*(sj2));
-IkReal x165=((new_r11)*(sj2));
-IkReal x166=((cj2)*(new_r00));
-IkReal x167=((IkReal(1.00000000000000))*(x160));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x160)*(x163)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x159)*(x163)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x159)+(((cj2)*(new_r10))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x167)))+(((new_r01)*(sj2)))+(((cj2)*(new_r11))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x160)*(x162)))+(x166)+(((IkReal(-1.00000000000000))*(x164))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x159)*(x162)))+(x161)+(((IkReal(-1.00000000000000))*(x165))));
-evalcond[6]=((((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(x167)))+(((IkReal(-1.00000000000000))*(x162)*(x164)))+(((cj1)*(x166))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x162)*(x165)))+(((IkReal(-1.00000000000000))*(x159)))+(((cj1)*(x161)))+(((new_r21)*(sj1))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x168=((gconst13)*(sj1));
-if( IKabs(((new_r12)*(x168))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x168))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x168)), ((IkReal(-1.00000000000000))*(new_r02)*(x168)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x169=IKcos(j2);
-IkReal x170=IKsin(j2);
-IkReal x171=((IkReal(1.00000000000000))*(cj1));
-IkReal x172=((sj1)*(x169));
-IkReal x173=((new_r12)*(x170));
-IkReal x174=((new_r02)*(x169));
-IkReal x175=((IkReal(1.00000000000000))*(sj1)*(x170));
-evalcond[0]=((((new_r02)*(x170)))+(((new_r12)*(x169))));
-evalcond[1]=((sj1)+(((IkReal(-1.00000000000000))*(x173)))+(x174));
-evalcond[2]=((((new_r22)*(sj1)))+(((IkReal(-1.00000000000000))*(x171)*(x173)))+(((cj1)*(x174))));
-evalcond[3]=((((new_r00)*(x172)))+(((IkReal(-1.00000000000000))*(new_r20)*(x171)))+(((IkReal(-1.00000000000000))*(new_r10)*(x175))));
-evalcond[4]=((((new_r01)*(x172)))+(((IkReal(-1.00000000000000))*(new_r21)*(x171)))+(((IkReal(-1.00000000000000))*(new_r11)*(x175))));
-evalcond[5]=((IkReal(1.00000000000000))+(((new_r02)*(x172)))+(((IkReal(-1.00000000000000))*(sj1)*(x173)))+(((IkReal(-1.00000000000000))*(new_r22)*(x171))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst15;
-gconst15=IKsign(sj1);
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[11];
-IkReal x176=((((new_r02)*(sj2)))+(((cj2)*(new_r12))));
-IkReal x177=((((cj2)*(new_r02)))+(((IkReal(-1.00000000000000))*(new_r12)*(sj2))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(-1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x176;
-evalcond[5]=x176;
-evalcond[6]=x177;
-evalcond[7]=x177;
-evalcond[8]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[9]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[10]=((IkReal(1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x178=IKsin(j0);
-IkReal x179=((IkReal(1.00000000000000))*(sj2));
-IkReal x180=((IkReal(1.00000000000000))*(IKcos(j0)));
-evalcond[0]=((((new_r00)*(sj2)))+(x178)+(((cj2)*(new_r10))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x180)))+(((new_r01)*(sj2)))+(((cj2)*(new_r11))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r10)*(x179)))+(((IkReal(-1.00000000000000))*(x180)))+(((cj2)*(new_r00))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x178)))+(((IkReal(-1.00000000000000))*(new_r11)*(x179)))+(((cj2)*(new_r01))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-IkReal x181=((IkReal(1.00000000000000))+(new_r22));
-IkReal x182=((new_r12)*(sj2));
-IkReal x183=((cj2)*(new_r02));
-IkReal x184=((((new_r02)*(sj2)))+(((cj2)*(new_r12))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=x181;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x184;
-evalcond[5]=x184;
-evalcond[6]=((((IkReal(-1.00000000000000))*(x182)))+(x183));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x183)))+(x182));
-evalcond[8]=new_r20;
-evalcond[9]=new_r21;
-evalcond[10]=x181;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x185=IKcos(j0);
-IkReal x186=IKsin(j0);
-IkReal x187=((IkReal(1.00000000000000))*(sj2));
-evalcond[0]=((((new_r00)*(sj2)))+(x186)+(((cj2)*(new_r10))));
-evalcond[1]=((((new_r01)*(sj2)))+(((IkReal(-1.00000000000000))*(x185)))+(((cj2)*(new_r11))));
-evalcond[2]=((x185)+(((IkReal(-1.00000000000000))*(new_r10)*(x187)))+(((cj2)*(new_r00))));
-evalcond[3]=((x186)+(((IkReal(-1.00000000000000))*(new_r11)*(x187)))+(((cj2)*(new_r01))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x188=IKsin(j0);
-IkReal x189=IKcos(j0);
-IkReal x190=((cj2)*(new_r01));
-IkReal x191=((IkReal(1.00000000000000))*(cj1));
-IkReal x192=((IkReal(1.00000000000000))*(sj1));
-IkReal x193=((new_r10)*(sj2));
-IkReal x194=((new_r11)*(sj2));
-IkReal x195=((cj2)*(new_r00));
-IkReal x196=((IkReal(1.00000000000000))*(x189));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x189)*(x192)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x188)*(x192)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x188)+(((cj2)*(new_r10))));
-evalcond[3]=((((new_r01)*(sj2)))+(((IkReal(-1.00000000000000))*(x196)))+(((cj2)*(new_r11))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x189)*(x191)))+(((IkReal(-1.00000000000000))*(x193)))+(x195));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x188)*(x191)))+(((IkReal(-1.00000000000000))*(x194)))+(x190));
-evalcond[6]=((((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(x191)*(x193)))+(((IkReal(-1.00000000000000))*(x196)))+(((cj1)*(x195))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x191)*(x194)))+(((IkReal(-1.00000000000000))*(x188)))+(((cj1)*(x190)))+(((new_r21)*(sj1))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x197=IKsin(j0);
-IkReal x198=IKcos(j0);
-IkReal x199=((cj2)*(new_r01));
-IkReal x200=((IkReal(1.00000000000000))*(cj1));
-IkReal x201=((IkReal(1.00000000000000))*(sj1));
-IkReal x202=((new_r10)*(sj2));
-IkReal x203=((new_r11)*(sj2));
-IkReal x204=((cj2)*(new_r00));
-IkReal x205=((IkReal(1.00000000000000))*(x198));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x198)*(x201)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x197)*(x201)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x197)+(((cj2)*(new_r10))));
-evalcond[3]=((((new_r01)*(sj2)))+(((IkReal(-1.00000000000000))*(x205)))+(((cj2)*(new_r11))));
-evalcond[4]=((x204)+(((IkReal(-1.00000000000000))*(x198)*(x200)))+(((IkReal(-1.00000000000000))*(x202))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x197)*(x200)))+(x199)+(((IkReal(-1.00000000000000))*(x203))));
-evalcond[6]=((((IkReal(-1.00000000000000))*(x200)*(x202)))+(((cj1)*(x204)))+(((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(x205))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x200)*(x203)))+(((IkReal(-1.00000000000000))*(x197)))+(((cj1)*(x199)))+(((new_r21)*(sj1))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((gconst15)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst15)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j0array[0]=IKatan2(((gconst15)*(new_r21)), ((gconst15)*(new_r20)));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x206=IKsin(j0);
-IkReal x207=IKcos(j0);
-IkReal x208=((cj2)*(new_r01));
-IkReal x209=((IkReal(1.00000000000000))*(cj1));
-IkReal x210=((IkReal(1.00000000000000))*(sj1));
-IkReal x211=((new_r10)*(sj2));
-IkReal x212=((new_r11)*(sj2));
-IkReal x213=((cj2)*(new_r00));
-IkReal x214=((IkReal(1.00000000000000))*(x207));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x207)*(x210)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x206)*(x210)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x206)+(((cj2)*(new_r10))));
-evalcond[3]=((((new_r01)*(sj2)))+(((cj2)*(new_r11)))+(((IkReal(-1.00000000000000))*(x214))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x207)*(x209)))+(x213)+(((IkReal(-1.00000000000000))*(x211))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x206)*(x209)))+(x208)+(((IkReal(-1.00000000000000))*(x212))));
-evalcond[6]=((((new_r20)*(sj1)))+(((cj1)*(x213)))+(((IkReal(-1.00000000000000))*(x214)))+(((IkReal(-1.00000000000000))*(x209)*(x211))));
-evalcond[7]=((((cj1)*(x208)))+(((new_r21)*(sj1)))+(((IkReal(-1.00000000000000))*(x206)))+(((IkReal(-1.00000000000000))*(x209)*(x212))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((gconst12)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst12)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j0array[0]=IKatan2(((gconst12)*(new_r21)), ((gconst12)*(new_r20)));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[2];
-IkReal x215=((IkReal(1.00000000000000))*(sj1));
-evalcond[0]=((new_r20)+(((IkReal(-1.00000000000000))*(x215)*(IKcos(j0)))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x215)*(IKsin(j0))))+(new_r21));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst17;
-gconst17=IKsign((((new_r12)*(new_r12))+((new_r02)*(new_r02))));
-dummyeval[0]=(((new_r12)*(new_r12))+((new_r02)*(new_r02)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst16;
-gconst16=IKsign(((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10)))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x216=((gconst16)*(sj0));
-if( IKabs(((new_r12)*(x216))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x216))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x216)), ((IkReal(-1.00000000000000))*(new_r02)*(x216)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[12];
-IkReal x217=IKsin(j2);
-IkReal x218=IKcos(j2);
-IkReal x219=((IkReal(1.00000000000000))*(cj0));
-IkReal x220=((IkReal(1.00000000000000))*(cj1));
-IkReal x221=((IkReal(1.00000000000000))*(x217));
-IkReal x222=((new_r01)*(x218));
-IkReal x223=((new_r00)*(x218));
-IkReal x224=((new_r02)*(x218));
-evalcond[0]=((((new_r02)*(x217)))+(((new_r12)*(x218))));
-evalcond[1]=((sj0)+(((new_r00)*(x217)))+(((new_r10)*(x218))));
-evalcond[2]=((sj1)+(x224)+(((IkReal(-1.00000000000000))*(new_r12)*(x221))));
-evalcond[3]=((((new_r01)*(x217)))+(((IkReal(-1.00000000000000))*(x219)))+(((new_r11)*(x218))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(cj1)*(x219)))+(((IkReal(-1.00000000000000))*(new_r10)*(x221)))+(x223));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r11)*(x221)))+(((IkReal(-1.00000000000000))*(sj0)*(x220)))+(x222));
-evalcond[6]=((((IkReal(-1.00000000000000))*(new_r12)*(x217)*(x220)))+(((cj1)*(x224)))+(((new_r22)*(sj1))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(new_r10)*(sj1)*(x221)))+(((sj1)*(x223)))+(((IkReal(-1.00000000000000))*(new_r20)*(x220))));
-evalcond[8]=((((sj1)*(x222)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj1)*(x221)))+(((IkReal(-1.00000000000000))*(new_r21)*(x220))));
-evalcond[9]=((IkReal(1.00000000000000))+(((sj1)*(x224)))+(((IkReal(-1.00000000000000))*(new_r22)*(x220)))+(((IkReal(-1.00000000000000))*(new_r12)*(sj1)*(x221))));
-evalcond[10]=((((new_r20)*(sj1)))+(((cj1)*(x223)))+(((IkReal(-1.00000000000000))*(new_r10)*(x217)*(x220)))+(((IkReal(-1.00000000000000))*(x219))));
-evalcond[11]=((((IkReal(-1.00000000000000))*(sj0)))+(((cj1)*(x222)))+(((IkReal(-1.00000000000000))*(new_r11)*(x217)*(x220)))+(((new_r21)*(sj1))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  || IKabs(evalcond[8]) > 0.000001  || IKabs(evalcond[9]) > 0.000001  || IKabs(evalcond[10]) > 0.000001  || IKabs(evalcond[11]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x225=((gconst17)*(sj1));
-if( IKabs(((new_r12)*(x225))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x225))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x225)), ((IkReal(-1.00000000000000))*(new_r02)*(x225)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[12];
-IkReal x226=IKsin(j2);
-IkReal x227=IKcos(j2);
-IkReal x228=((IkReal(1.00000000000000))*(cj0));
-IkReal x229=((IkReal(1.00000000000000))*(cj1));
-IkReal x230=((IkReal(1.00000000000000))*(x226));
-IkReal x231=((new_r01)*(x227));
-IkReal x232=((new_r00)*(x227));
-IkReal x233=((new_r02)*(x227));
-evalcond[0]=((((new_r02)*(x226)))+(((new_r12)*(x227))));
-evalcond[1]=((((new_r00)*(x226)))+(sj0)+(((new_r10)*(x227))));
-evalcond[2]=((sj1)+(((IkReal(-1.00000000000000))*(new_r12)*(x230)))+(x233));
-evalcond[3]=((((new_r01)*(x226)))+(((new_r11)*(x227)))+(((IkReal(-1.00000000000000))*(x228))));
-evalcond[4]=((x232)+(((IkReal(-1.00000000000000))*(cj1)*(x228)))+(((IkReal(-1.00000000000000))*(new_r10)*(x230))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(sj0)*(x229)))+(x231)+(((IkReal(-1.00000000000000))*(new_r11)*(x230))));
-evalcond[6]=((((IkReal(-1.00000000000000))*(new_r12)*(x226)*(x229)))+(((cj1)*(x233)))+(((new_r22)*(sj1))));
-evalcond[7]=((((sj1)*(x232)))+(((IkReal(-1.00000000000000))*(new_r20)*(x229)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj1)*(x230))));
-evalcond[8]=((((sj1)*(x231)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj1)*(x230)))+(((IkReal(-1.00000000000000))*(new_r21)*(x229))));
-evalcond[9]=((IkReal(1.00000000000000))+(((sj1)*(x233)))+(((IkReal(-1.00000000000000))*(new_r22)*(x229)))+(((IkReal(-1.00000000000000))*(new_r12)*(sj1)*(x230))));
-evalcond[10]=((((cj1)*(x232)))+(((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(new_r10)*(x226)*(x229)))+(((IkReal(-1.00000000000000))*(x228))));
-evalcond[11]=((((cj1)*(x231)))+(((IkReal(-1.00000000000000))*(sj0)))+(((IkReal(-1.00000000000000))*(new_r11)*(x226)*(x229)))+(((new_r21)*(sj1))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  || IKabs(evalcond[8]) > 0.000001  || IKabs(evalcond[9]) > 0.000001  || IKabs(evalcond[10]) > 0.000001  || IKabs(evalcond[11]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-}
-}
-}
-}};
-
+  IkReal j0, cj0, sj0, htj0, j1, cj1, sj1, htj1, j2, cj2, sj2, htj2, j3, cj3, sj3, htj3, j5, cj5, sj5, htj5, j6, cj6,
+      sj6, htj6, j4, cj4, sj4, htj4, new_r00, r00, rxp0_0, new_r01, r01, rxp0_1, new_r02, r02, rxp0_2, new_r10, r10,
+      rxp1_0, new_r11, r11, rxp1_1, new_r12, r12, rxp1_2, new_r20, r20, rxp2_0, new_r21, r21, rxp2_1, new_r22, r22,
+      rxp2_2, new_px, px, npx, new_py, py, npy, new_pz, pz, npz, pp;
+  unsigned char _ij0[2], _nj0, _ij1[2], _nj1, _ij2[2], _nj2, _ij3[2], _nj3, _ij5[2], _nj5, _ij6[2], _nj6, _ij4[2], _nj4;
+
+  bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions)
+  {
+    j0 = numeric_limits<IkReal>::quiet_NaN();
+    _ij0[0] = -1;
+    _ij0[1] = -1;
+    _nj0 = -1;
+    j1 = numeric_limits<IkReal>::quiet_NaN();
+    _ij1[0] = -1;
+    _ij1[1] = -1;
+    _nj1 = -1;
+    j2 = numeric_limits<IkReal>::quiet_NaN();
+    _ij2[0] = -1;
+    _ij2[1] = -1;
+    _nj2 = -1;
+    j3 = numeric_limits<IkReal>::quiet_NaN();
+    _ij3[0] = -1;
+    _ij3[1] = -1;
+    _nj3 = -1;
+    j5 = numeric_limits<IkReal>::quiet_NaN();
+    _ij5[0] = -1;
+    _ij5[1] = -1;
+    _nj5 = -1;
+    j6 = numeric_limits<IkReal>::quiet_NaN();
+    _ij6[0] = -1;
+    _ij6[1] = -1;
+    _nj6 = -1;
+    _ij4[0] = -1;
+    _ij4[1] = -1;
+    _nj4 = 0;
+    for (int dummyiter = 0; dummyiter < 1; ++dummyiter)
+    {
+      solutions.Clear();
+      j4 = pfree[0];
+      cj4 = cos(pfree[0]);
+      sj4 = sin(pfree[0]);
+      r00 = eerot[0 * 3 + 0];
+      r01 = eerot[0 * 3 + 1];
+      r02 = eerot[0 * 3 + 2];
+      r10 = eerot[1 * 3 + 0];
+      r11 = eerot[1 * 3 + 1];
+      r12 = eerot[1 * 3 + 2];
+      r20 = eerot[2 * 3 + 0];
+      r21 = eerot[2 * 3 + 1];
+      r22 = eerot[2 * 3 + 2];
+      px = eetrans[0];
+      py = eetrans[1];
+      pz = eetrans[2];
+
+      new_r00 = ((IkReal(-1.00000000000000)) * (r00));
+      new_r01 = r01;
+      new_r02 = ((IkReal(-1.00000000000000)) * (r02));
+      new_px = ((((IkReal(-0.180000000000000)) * (r02))) + (px));
+      new_r10 = ((IkReal(-1.00000000000000)) * (r10));
+      new_r11 = r11;
+      new_r12 = ((IkReal(-1.00000000000000)) * (r12));
+      new_py = ((((IkReal(-0.180000000000000)) * (r12))) + (py));
+      new_r20 = ((IkReal(-1.00000000000000)) * (r20));
+      new_r21 = r21;
+      new_r22 = ((IkReal(-1.00000000000000)) * (r22));
+      new_pz = ((IkReal(-0.410000000000000)) + (pz) + (((IkReal(-0.180000000000000)) * (r22))));
+      r00 = new_r00;
+      r01 = new_r01;
+      r02 = new_r02;
+      r10 = new_r10;
+      r11 = new_r11;
+      r12 = new_r12;
+      r20 = new_r20;
+      r21 = new_r21;
+      r22 = new_r22;
+      px = new_px;
+      py = new_py;
+      pz = new_pz;
+      pp = (((px) * (px)) + ((py) * (py)) + ((pz) * (pz)));
+      npx = ((((px) * (r00))) + (((py) * (r10))) + (((pz) * (r20))));
+      npy = ((((px) * (r01))) + (((py) * (r11))) + (((pz) * (r21))));
+      npz = ((((px) * (r02))) + (((py) * (r12))) + (((pz) * (r22))));
+      rxp0_0 = ((((IkReal(-1.00000000000000)) * (py) * (r20))) + (((pz) * (r10))));
+      rxp0_1 = ((((px) * (r20))) + (((IkReal(-1.00000000000000)) * (pz) * (r00))));
+      rxp0_2 = ((((IkReal(-1.00000000000000)) * (px) * (r10))) + (((py) * (r00))));
+      rxp1_0 = ((((IkReal(-1.00000000000000)) * (py) * (r21))) + (((pz) * (r11))));
+      rxp1_1 = ((((px) * (r21))) + (((IkReal(-1.00000000000000)) * (pz) * (r01))));
+      rxp1_2 = ((((IkReal(-1.00000000000000)) * (px) * (r11))) + (((py) * (r01))));
+      rxp2_0 = ((((IkReal(-1.00000000000000)) * (py) * (r22))) + (((pz) * (r12))));
+      rxp2_1 = ((((px) * (r22))) + (((IkReal(-1.00000000000000)) * (pz) * (r02))));
+      rxp2_2 = ((((IkReal(-1.00000000000000)) * (px) * (r12))) + (((py) * (r02))));
+      {
+        IkReal j3array[2], cj3array[2], sj3array[2];
+        bool j3valid[2] = { false };
+        _nj3 = 2;
+        cj3array[0] = ((IkReal(-1.01190476190476)) + (((IkReal(2.42954324586978)) * (pp))));
+        if (cj3array[0] >= -1 - IKFAST_SINCOS_THRESH && cj3array[0] <= 1 + IKFAST_SINCOS_THRESH)
+        {
+          j3valid[0] = j3valid[1] = true;
+          j3array[0] = IKacos(cj3array[0]);
+          sj3array[0] = IKsin(j3array[0]);
+          cj3array[1] = cj3array[0];
+          j3array[1] = -j3array[0];
+          sj3array[1] = -sj3array[0];
+        }
+        else if (isnan(cj3array[0]))
+        {
+          // probably any value will work
+          j3valid[0] = true;
+          cj3array[0] = 1;
+          sj3array[0] = 0;
+          j3array[0] = 0;
+        }
+        for (int ij3 = 0; ij3 < 2; ++ij3)
+        {
+          if (!j3valid[ij3])
+          {
+            continue;
+          }
+          _ij3[0] = ij3;
+          _ij3[1] = -1;
+          for (int iij3 = ij3 + 1; iij3 < 2; ++iij3)
+          {
+            if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+            {
+              j3valid[iij3] = false;
+              _ij3[1] = iij3;
+              break;
+            }
+          }
+          j3 = j3array[ij3];
+          cj3 = cj3array[ij3];
+          sj3 = sj3array[ij3];
+
+          {
+            IkReal dummyeval[1];
+            dummyeval[0] = (((npx) * (npx)) + ((npy) * (npy)));
+            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+            {
+              {
+                IkReal dummyeval[1];
+                dummyeval[0] = (((npx) * (npx)) + ((npy) * (npy)));
+                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                {
+                  {
+                    IkReal dummyeval[1];
+                    dummyeval[0] = ((IkReal(1.00000000000000)) + (((IkReal(2.33333333333333)) * (cj3))) +
+                                    (((IkReal(1.36111111111111)) * ((cj4) * (cj4)) * ((sj3) * (sj3)))) +
+                                    (((IkReal(1.36111111111111)) * ((cj3) * (cj3)))));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      continue;
+                    }
+                    else
+                    {
+                      {
+                        IkReal j5array[2], cj5array[2], sj5array[2];
+                        bool j5valid[2] = { false };
+                        _nj5 = 2;
+                        IkReal x64 = ((IkReal(-0.420000000000000)) + (((IkReal(-0.490000000000000)) * (cj3))));
+                        if (IKabs(x64) < IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((IkReal(0.490000000000000)) * (cj4) * (sj3))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        IkReal x65 = ((IkReal(1.00000000000000)) *
+                                      (IKatan2(x64, ((IkReal(0.490000000000000)) * (cj4) * (sj3)))));
+                        if (((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) * ((sj3) * (sj3)))))) <
+                            (IkReal)-0.00001)
+                          continue;
+                        if ((((npz) *
+                              (((IKabs(IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                         ((sj3) * (sj3)))))))) != 0) ?
+                                    ((IkReal)1 /
+                                     (IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                        ((sj3) * (sj3))))))))) :
+                                    (IkReal)1.0e30)))) < -1 - IKFAST_SINCOS_THRESH ||
+                            (((npz) *
+                              (((IKabs(IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                         ((sj3) * (sj3)))))))) != 0) ?
+                                    ((IkReal)1 /
+                                     (IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                        ((sj3) * (sj3))))))))) :
+                                    (IkReal)1.0e30)))) > 1 + IKFAST_SINCOS_THRESH)
+                          continue;
+                        IkReal x66 = IKasin(
+                            ((npz) *
+                             (((IKabs(IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                        ((sj3) * (sj3)))))))) != 0) ?
+                                   ((IkReal)1 /
+                                    (IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                       ((sj3) * (sj3))))))))) :
+                                   (IkReal)1.0e30))));
+                        j5array[0] = ((x66) + (((IkReal(-1.00000000000000)) * (x65))));
+                        sj5array[0] = IKsin(j5array[0]);
+                        cj5array[0] = IKcos(j5array[0]);
+                        j5array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x65))) +
+                                      (((IkReal(-1.00000000000000)) * (x66))));
+                        sj5array[1] = IKsin(j5array[1]);
+                        cj5array[1] = IKcos(j5array[1]);
+                        if (j5array[0] > IKPI)
+                        {
+                          j5array[0] -= IK2PI;
+                        }
+                        else if (j5array[0] < -IKPI)
+                        {
+                          j5array[0] += IK2PI;
+                        }
+                        j5valid[0] = true;
+                        if (j5array[1] > IKPI)
+                        {
+                          j5array[1] -= IK2PI;
+                        }
+                        else if (j5array[1] < -IKPI)
+                        {
+                          j5array[1] += IK2PI;
+                        }
+                        j5valid[1] = true;
+                        for (int ij5 = 0; ij5 < 2; ++ij5)
+                        {
+                          if (!j5valid[ij5])
+                          {
+                            continue;
+                          }
+                          _ij5[0] = ij5;
+                          _ij5[1] = -1;
+                          for (int iij5 = ij5 + 1; iij5 < 2; ++iij5)
+                          {
+                            if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j5valid[iij5] = false;
+                              _ij5[1] = iij5;
+                              break;
+                            }
+                          }
+                          j5 = j5array[ij5];
+                          cj5 = cj5array[ij5];
+                          sj5 = sj5array[ij5];
+
+                          {
+                            IkReal dummyeval[1];
+                            IkReal gconst0;
+                            IkReal x67 = ((IkReal(100.000000000000)) * (sj5));
+                            gconst0 = IKsign(((((x67) * ((npx) * (npx)))) + (((x67) * ((npy) * (npy))))));
+                            dummyeval[0] = ((((sj5) * ((npy) * (npy)))) + (((sj5) * ((npx) * (npx)))));
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal dummyeval[1];
+                                IkReal gconst1;
+                                IkReal x68 = ((IkReal(2100.00000000000)) * (sj5));
+                                gconst1 = IKsign(((((x68) * ((npx) * (npx)))) + (((x68) * ((npy) * (npy))))));
+                                dummyeval[0] = ((((sj5) * ((npy) * (npy)))) + (((sj5) * ((npx) * (npx)))));
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal evalcond[5];
+                                    IkReal x69 = ((IkReal(1.00000000000000)) * (pp));
+                                    IkReal x70 =
+                                        ((IkReal(-0.420000000000000)) + (((IkReal(-1.00000000000000)) * (npz))) +
+                                         (((IkReal(-0.490000000000000)) * (cj3))));
+                                    evalcond[0] =
+                                        ((IkReal(-3.14159265358979)) +
+                                         (IKfmod(((IkReal(3.14159265358979)) + (j5)), IkReal(6.28318530717959))));
+                                    evalcond[1] =
+                                        ((IkReal(0.416500000000000)) + (((IkReal(-1.00000000000000)) * (x69))) +
+                                         (((IkReal(0.411600000000000)) * (cj3))));
+                                    evalcond[2] = x70;
+                                    evalcond[3] =
+                                        ((IkReal(0.0637000000000000)) + (((IkReal(-0.840000000000000)) * (npz))) +
+                                         (((IkReal(-1.00000000000000)) * (x69))));
+                                    evalcond[4] = x70;
+                                    if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[4]) < 0.0000010000000000)
+                                    {
+                                      {
+                                        IkReal dummyeval[1];
+                                        IkReal gconst2;
+                                        gconst2 = IKsign(((((IkReal(-100.000000000000)) * ((npy) * (npy)))) +
+                                                          (((IkReal(-100.000000000000)) * ((npx) * (npx))))));
+                                        dummyeval[0] = ((((IkReal(-1.00000000000000)) * ((npy) * (npy)))) +
+                                                        (((IkReal(-1.00000000000000)) * ((npx) * (npx)))));
+                                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                        {
+                                          {
+                                            IkReal dummyeval[1];
+                                            IkReal gconst3;
+                                            IkReal x71 = ((IkReal(100.000000000000)) * (sj4));
+                                            gconst3 =
+                                                IKsign(((((IkReal(-1.00000000000000)) * (x71) * ((npx) * (npx)))) +
+                                                        (((IkReal(-1.00000000000000)) * (x71) * ((npy) * (npy))))));
+                                            IkReal x72 = ((IkReal(1.00000000000000)) * (sj4));
+                                            dummyeval[0] = ((((IkReal(-1.00000000000000)) * (x72) * ((npx) * (npx)))) +
+                                                            (((IkReal(-1.00000000000000)) * (x72) * ((npy) * (npy)))));
+                                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                            {
+                                              {
+                                                IkReal evalcond[5];
+                                                IkReal x73 = ((IkReal(1.00000000000000)) * (pp));
+                                                IkReal x74 = x70;
+                                                evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                               (IKfmod(((IkReal(3.14159265358979)) + (j4)),
+                                                                       IkReal(6.28318530717959))));
+                                                evalcond[1] = ((IkReal(0.416500000000000)) +
+                                                               (((IkReal(-1.00000000000000)) * (x73))) +
+                                                               (((IkReal(0.411600000000000)) * (cj3))));
+                                                evalcond[2] = x74;
+                                                evalcond[3] = ((IkReal(0.0637000000000000)) +
+                                                               (((IkReal(-1.00000000000000)) * (x73))) +
+                                                               (((IkReal(-0.840000000000000)) * (npz))));
+                                                evalcond[4] = x74;
+                                                if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                                    IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                                    IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                                    IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                                    IKabs(evalcond[4]) < 0.0000010000000000)
+                                                {
+                                                  {
+                                                    IkReal dummyeval[1];
+                                                    IkReal gconst4;
+                                                    gconst4 =
+                                                        IKsign(((((IkReal(-100.000000000000)) * ((npy) * (npy)))) +
+                                                                (((IkReal(-100.000000000000)) * ((npx) * (npx))))));
+                                                    dummyeval[0] = ((((IkReal(-1.00000000000000)) * ((npy) * (npy)))) +
+                                                                    (((IkReal(-1.00000000000000)) * ((npx) * (npx)))));
+                                                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                                    {
+                                                      continue;
+                                                    }
+                                                    else
+                                                    {
+                                                      {
+                                                        IkReal j6array[1], cj6array[1], sj6array[1];
+                                                        bool j6valid[1] = { false };
+                                                        _nj6 = 1;
+                                                        IkReal x75 = ((gconst4) * (sj3));
+                                                        if (IKabs(((IkReal(49.0000000000000)) * (npy) * (x75))) <
+                                                                IKFAST_ATAN2_MAGTHRESH &&
+                                                            IKabs(((IkReal(-49.0000000000000)) * (npx) * (x75))) <
+                                                                IKFAST_ATAN2_MAGTHRESH)
+                                                          continue;
+                                                        j6array[0] =
+                                                            IKatan2(((IkReal(49.0000000000000)) * (npy) * (x75)),
+                                                                    ((IkReal(-49.0000000000000)) * (npx) * (x75)));
+                                                        sj6array[0] = IKsin(j6array[0]);
+                                                        cj6array[0] = IKcos(j6array[0]);
+                                                        if (j6array[0] > IKPI)
+                                                        {
+                                                          j6array[0] -= IK2PI;
+                                                        }
+                                                        else if (j6array[0] < -IKPI)
+                                                        {
+                                                          j6array[0] += IK2PI;
+                                                        }
+                                                        j6valid[0] = true;
+                                                        for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                        {
+                                                          if (!j6valid[ij6])
+                                                          {
+                                                            continue;
+                                                          }
+                                                          _ij6[0] = ij6;
+                                                          _ij6[1] = -1;
+                                                          for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                          {
+                                                            if (j6valid[iij6] &&
+                                                                IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                                    IKFAST_SOLUTION_THRESH &&
+                                                                IKabs(sj6array[ij6] - sj6array[iij6]) <
+                                                                    IKFAST_SOLUTION_THRESH)
+                                                            {
+                                                              j6valid[iij6] = false;
+                                                              _ij6[1] = iij6;
+                                                              break;
+                                                            }
+                                                          }
+                                                          j6 = j6array[ij6];
+                                                          cj6 = cj6array[ij6];
+                                                          sj6 = sj6array[ij6];
+                                                          {
+                                                            IkReal evalcond[2];
+                                                            IkReal x76 = IKcos(j6);
+                                                            IkReal x77 = IKsin(j6);
+                                                            evalcond[0] = ((((npx) * (x77))) + (((npy) * (x76))));
+                                                            evalcond[1] =
+                                                                ((((IkReal(-1.00000000000000)) * (npy) * (x77))) +
+                                                                 (((npx) * (x76))) +
+                                                                 (((IkReal(-0.490000000000000)) * (sj3))));
+                                                            if (IKabs(evalcond[0]) > 0.000001 ||
+                                                                IKabs(evalcond[1]) > 0.000001)
+                                                            {
+                                                              continue;
+                                                            }
+                                                          }
+
+                                                          rotationfunction0(solutions);
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                                else
+                                                {
+                                                  IkReal x234 = ((IkReal(1.00000000000000)) * (pp));
+                                                  IkReal x235 = x70;
+                                                  evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                                 (IKfmod(((IkReal(1.11022302462516e-16)) + (j4)),
+                                                                         IkReal(6.28318530717959))));
+                                                  evalcond[1] = ((IkReal(0.416500000000000)) +
+                                                                 (((IkReal(-1.00000000000000)) * (x234))) +
+                                                                 (((IkReal(0.411600000000000)) * (cj3))));
+                                                  evalcond[2] = x235;
+                                                  evalcond[3] = ((IkReal(0.0637000000000000)) +
+                                                                 (((IkReal(-0.840000000000000)) * (npz))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x234))));
+                                                  evalcond[4] = x235;
+                                                  if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[4]) < 0.0000010000000000)
+                                                  {
+                                                    {
+                                                      IkReal dummyeval[1];
+                                                      IkReal gconst5;
+                                                      gconst5 =
+                                                          IKsign(((((IkReal(100.000000000000)) * ((npy) * (npy)))) +
+                                                                  (((IkReal(100.000000000000)) * ((npx) * (npx))))));
+                                                      dummyeval[0] = (((npx) * (npx)) + ((npy) * (npy)));
+                                                      if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                                      {
+                                                        continue;
+                                                      }
+                                                      else
+                                                      {
+                                                        {
+                                                          IkReal j6array[1], cj6array[1], sj6array[1];
+                                                          bool j6valid[1] = { false };
+                                                          _nj6 = 1;
+                                                          IkReal x236 = ((gconst5) * (sj3));
+                                                          if (IKabs(((IkReal(49.0000000000000)) * (npy) * (x236))) <
+                                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                                              IKabs(((IkReal(-49.0000000000000)) * (npx) * (x236))) <
+                                                                  IKFAST_ATAN2_MAGTHRESH)
+                                                            continue;
+                                                          j6array[0] =
+                                                              IKatan2(((IkReal(49.0000000000000)) * (npy) * (x236)),
+                                                                      ((IkReal(-49.0000000000000)) * (npx) * (x236)));
+                                                          sj6array[0] = IKsin(j6array[0]);
+                                                          cj6array[0] = IKcos(j6array[0]);
+                                                          if (j6array[0] > IKPI)
+                                                          {
+                                                            j6array[0] -= IK2PI;
+                                                          }
+                                                          else if (j6array[0] < -IKPI)
+                                                          {
+                                                            j6array[0] += IK2PI;
+                                                          }
+                                                          j6valid[0] = true;
+                                                          for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                          {
+                                                            if (!j6valid[ij6])
+                                                            {
+                                                              continue;
+                                                            }
+                                                            _ij6[0] = ij6;
+                                                            _ij6[1] = -1;
+                                                            for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                            {
+                                                              if (j6valid[iij6] &&
+                                                                  IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                                      IKFAST_SOLUTION_THRESH &&
+                                                                  IKabs(sj6array[ij6] - sj6array[iij6]) <
+                                                                      IKFAST_SOLUTION_THRESH)
+                                                              {
+                                                                j6valid[iij6] = false;
+                                                                _ij6[1] = iij6;
+                                                                break;
+                                                              }
+                                                            }
+                                                            j6 = j6array[ij6];
+                                                            cj6 = cj6array[ij6];
+                                                            sj6 = sj6array[ij6];
+                                                            {
+                                                              IkReal evalcond[2];
+                                                              IkReal x237 = IKcos(j6);
+                                                              IkReal x238 = IKsin(j6);
+                                                              evalcond[0] = ((((npx) * (x238))) + (((npy) * (x237))));
+                                                              evalcond[1] =
+                                                                  ((((IkReal(-1.00000000000000)) * (npy) * (x238))) +
+                                                                   (((npx) * (x237))) +
+                                                                   (((IkReal(0.490000000000000)) * (sj3))));
+                                                              if (IKabs(evalcond[0]) > 0.000001 ||
+                                                                  IKabs(evalcond[1]) > 0.000001)
+                                                              {
+                                                                continue;
+                                                              }
+                                                            }
+
+                                                            rotationfunction0(solutions);
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                  else
+                                                  {
+                                                    if (1)
+                                                    {
+                                                      continue;
+                                                    }
+                                                    else
+                                                    {
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                            else
+                                            {
+                                              {
+                                                IkReal j6array[1], cj6array[1], sj6array[1];
+                                                bool j6valid[1] = { false };
+                                                _nj6 = 1;
+                                                IkReal x239 = (sj4) * (sj4);
+                                                IkReal x240 = ((IkReal(49.0000000000000)) * (sj3) * (x239));
+                                                IkReal x241 = ((IkReal(49.0000000000000)) * (cj4) * (sj3) * (sj4));
+                                                if (IKabs(((gconst3) * (((((npy) * (x241))) + (((npx) * (x240))))))) <
+                                                        IKFAST_ATAN2_MAGTHRESH &&
+                                                    IKabs(((gconst3) *
+                                                           (((((IkReal(-1.00000000000000)) * (npx) * (x241))) +
+                                                             (((npy) * (x240))))))) < IKFAST_ATAN2_MAGTHRESH)
+                                                  continue;
+                                                j6array[0] = IKatan2(
+                                                    ((gconst3) * (((((npy) * (x241))) + (((npx) * (x240)))))),
+                                                    ((gconst3) * (((((IkReal(-1.00000000000000)) * (npx) * (x241))) +
+                                                                   (((npy) * (x240)))))));
+                                                sj6array[0] = IKsin(j6array[0]);
+                                                cj6array[0] = IKcos(j6array[0]);
+                                                if (j6array[0] > IKPI)
+                                                {
+                                                  j6array[0] -= IK2PI;
+                                                }
+                                                else if (j6array[0] < -IKPI)
+                                                {
+                                                  j6array[0] += IK2PI;
+                                                }
+                                                j6valid[0] = true;
+                                                for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                {
+                                                  if (!j6valid[ij6])
+                                                  {
+                                                    continue;
+                                                  }
+                                                  _ij6[0] = ij6;
+                                                  _ij6[1] = -1;
+                                                  for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                  {
+                                                    if (j6valid[iij6] &&
+                                                        IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                            IKFAST_SOLUTION_THRESH &&
+                                                        IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                                                    {
+                                                      j6valid[iij6] = false;
+                                                      _ij6[1] = iij6;
+                                                      break;
+                                                    }
+                                                  }
+                                                  j6 = j6array[ij6];
+                                                  cj6 = cj6array[ij6];
+                                                  sj6 = sj6array[ij6];
+                                                  {
+                                                    IkReal evalcond[4];
+                                                    IkReal x242 = IKcos(j6);
+                                                    IkReal x243 = IKsin(j6);
+                                                    IkReal x244 = ((cj4) * (npy));
+                                                    IkReal x245 = ((IkReal(0.490000000000000)) * (sj3));
+                                                    IkReal x246 = ((npy) * (sj4));
+                                                    IkReal x247 = ((IkReal(1.00000000000000)) * (x243));
+                                                    IkReal x248 = ((npx) * (x243));
+                                                    IkReal x249 = ((npx) * (x242));
+                                                    evalcond[0] = ((x248) + (((npy) * (x242))) + (((sj4) * (x245))));
+                                                    evalcond[1] =
+                                                        ((((IkReal(-1.00000000000000)) * (npy) * (x247))) +
+                                                         (((IkReal(-1.00000000000000)) * (cj4) * (x245))) + (x249));
+                                                    evalcond[2] =
+                                                        ((((cj4) * (x248))) + (((x242) * (x244))) + (((sj4) * (x249))) +
+                                                         (((IkReal(-1.00000000000000)) * (x246) * (x247))));
+                                                    evalcond[3] =
+                                                        ((((IkReal(-1.00000000000000)) * (npx) * (sj4) * (x247))) +
+                                                         (((cj4) * (x249))) + (((IkReal(-1.00000000000000)) * (x245))) +
+                                                         (((IkReal(-1.00000000000000)) * (x244) * (x247))) +
+                                                         (((IkReal(-1.00000000000000)) * (x242) * (x246))));
+                                                    if (IKabs(evalcond[0]) > 0.000001 ||
+                                                        IKabs(evalcond[1]) > 0.000001 ||
+                                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                    {
+                                                      continue;
+                                                    }
+                                                  }
+
+                                                  rotationfunction0(solutions);
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                        else
+                                        {
+                                          {
+                                            IkReal j6array[1], cj6array[1], sj6array[1];
+                                            bool j6valid[1] = { false };
+                                            _nj6 = 1;
+                                            IkReal x250 = ((IkReal(49.0000000000000)) * (cj4) * (sj3));
+                                            IkReal x251 = ((IkReal(49.0000000000000)) * (sj3) * (sj4));
+                                            if (IKabs(((gconst2) * (((((npy) * (x250))) + (((npx) * (x251))))))) <
+                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                IKabs(((gconst2) *
+                                                       (((((npy) * (x251))) + (((IkReal(-1.00000000000000)) * (npx) *
+                                                                                (x250))))))) < IKFAST_ATAN2_MAGTHRESH)
+                                              continue;
+                                            j6array[0] = IKatan2(
+                                                ((gconst2) * (((((npy) * (x250))) + (((npx) * (x251)))))),
+                                                ((gconst2) * (((((npy) * (x251))) +
+                                                               (((IkReal(-1.00000000000000)) * (npx) * (x250)))))));
+                                            sj6array[0] = IKsin(j6array[0]);
+                                            cj6array[0] = IKcos(j6array[0]);
+                                            if (j6array[0] > IKPI)
+                                            {
+                                              j6array[0] -= IK2PI;
+                                            }
+                                            else if (j6array[0] < -IKPI)
+                                            {
+                                              j6array[0] += IK2PI;
+                                            }
+                                            j6valid[0] = true;
+                                            for (int ij6 = 0; ij6 < 1; ++ij6)
+                                            {
+                                              if (!j6valid[ij6])
+                                              {
+                                                continue;
+                                              }
+                                              _ij6[0] = ij6;
+                                              _ij6[1] = -1;
+                                              for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                              {
+                                                if (j6valid[iij6] &&
+                                                    IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                                                    IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                                                {
+                                                  j6valid[iij6] = false;
+                                                  _ij6[1] = iij6;
+                                                  break;
+                                                }
+                                              }
+                                              j6 = j6array[ij6];
+                                              cj6 = cj6array[ij6];
+                                              sj6 = sj6array[ij6];
+                                              {
+                                                IkReal evalcond[4];
+                                                IkReal x252 = IKcos(j6);
+                                                IkReal x253 = IKsin(j6);
+                                                IkReal x254 = ((cj4) * (npy));
+                                                IkReal x255 = ((IkReal(0.490000000000000)) * (sj3));
+                                                IkReal x256 = ((npy) * (sj4));
+                                                IkReal x257 = ((IkReal(1.00000000000000)) * (x253));
+                                                IkReal x258 = ((npx) * (x253));
+                                                IkReal x259 = ((npx) * (x252));
+                                                evalcond[0] = ((((sj4) * (x255))) + (((npy) * (x252))) + (x258));
+                                                evalcond[1] =
+                                                    ((((IkReal(-1.00000000000000)) * (npy) * (x257))) +
+                                                     (((IkReal(-1.00000000000000)) * (cj4) * (x255))) + (x259));
+                                                evalcond[2] = ((((sj4) * (x259))) +
+                                                               (((IkReal(-1.00000000000000)) * (x256) * (x257))) +
+                                                               (((x252) * (x254))) + (((cj4) * (x258))));
+                                                evalcond[3] =
+                                                    ((((IkReal(-1.00000000000000)) * (x252) * (x256))) +
+                                                     (((IkReal(-1.00000000000000)) * (npx) * (sj4) * (x257))) +
+                                                     (((IkReal(-1.00000000000000)) * (x254) * (x257))) +
+                                                     (((cj4) * (x259))) + (((IkReal(-1.00000000000000)) * (x255))));
+                                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                {
+                                                  continue;
+                                                }
+                                              }
+
+                                              rotationfunction0(solutions);
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                    else
+                                    {
+                                      IkReal x260 = ((IkReal(1.00000000000000)) * (pp));
+                                      IkReal x261 = ((IkReal(0.490000000000000)) * (cj3));
+                                      evalcond[0] =
+                                          ((IkReal(-3.14159265358979)) +
+                                           (IKfmod(((IkReal(1.11022302462516e-16)) + (j5)), IkReal(6.28318530717959))));
+                                      evalcond[1] =
+                                          ((IkReal(0.416500000000000)) + (((IkReal(-1.00000000000000)) * (x260))) +
+                                           (((IkReal(0.411600000000000)) * (cj3))));
+                                      evalcond[2] = ((IkReal(0.420000000000000)) +
+                                                     (((IkReal(-1.00000000000000)) * (npz))) + (x261));
+                                      evalcond[3] =
+                                          ((IkReal(0.0637000000000000)) + (((IkReal(0.840000000000000)) * (npz))) +
+                                           (((IkReal(-1.00000000000000)) * (x260))));
+                                      evalcond[4] = ((IkReal(-0.420000000000000)) + (npz) +
+                                                     (((IkReal(-1.00000000000000)) * (x261))));
+                                      if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[4]) < 0.0000010000000000)
+                                      {
+                                        {
+                                          IkReal dummyeval[1];
+                                          IkReal gconst6;
+                                          gconst6 = IKsign(((((IkReal(100.000000000000)) * ((npy) * (npy)))) +
+                                                            (((IkReal(100.000000000000)) * ((npx) * (npx))))));
+                                          dummyeval[0] = (((npx) * (npx)) + ((npy) * (npy)));
+                                          if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                          {
+                                            {
+                                              IkReal dummyeval[1];
+                                              IkReal gconst7;
+                                              IkReal x262 = ((IkReal(100.000000000000)) * (sj4));
+                                              gconst7 =
+                                                  IKsign(((((x262) * ((npy) * (npy)))) + (((x262) * ((npx) * (npx))))));
+                                              dummyeval[0] =
+                                                  ((((sj4) * ((npx) * (npx)))) + (((sj4) * ((npy) * (npy)))));
+                                              if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                              {
+                                                {
+                                                  IkReal evalcond[5];
+                                                  IkReal x263 = ((IkReal(1.00000000000000)) * (pp));
+                                                  IkReal x264 = ((IkReal(0.490000000000000)) * (cj3));
+                                                  evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                                 (IKfmod(((IkReal(3.14159265358979)) + (j4)),
+                                                                         IkReal(6.28318530717959))));
+                                                  evalcond[1] = ((IkReal(0.416500000000000)) +
+                                                                 (((IkReal(-1.00000000000000)) * (x263))) +
+                                                                 (((IkReal(0.411600000000000)) * (cj3))));
+                                                  evalcond[2] = ((IkReal(0.420000000000000)) +
+                                                                 (((IkReal(-1.00000000000000)) * (npz))) + (x264));
+                                                  evalcond[3] = ((IkReal(0.0637000000000000)) +
+                                                                 (((IkReal(0.840000000000000)) * (npz))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x263))));
+                                                  evalcond[4] = ((IkReal(-0.420000000000000)) + (npz) +
+                                                                 (((IkReal(-1.00000000000000)) * (x264))));
+                                                  if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[4]) < 0.0000010000000000)
+                                                  {
+                                                    {
+                                                      IkReal dummyeval[1];
+                                                      IkReal gconst8;
+                                                      gconst8 =
+                                                          IKsign(((((IkReal(100.000000000000)) * ((npy) * (npy)))) +
+                                                                  (((IkReal(100.000000000000)) * ((npx) * (npx))))));
+                                                      dummyeval[0] = (((npx) * (npx)) + ((npy) * (npy)));
+                                                      if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                                      {
+                                                        continue;
+                                                      }
+                                                      else
+                                                      {
+                                                        {
+                                                          IkReal j6array[1], cj6array[1], sj6array[1];
+                                                          bool j6valid[1] = { false };
+                                                          _nj6 = 1;
+                                                          IkReal x265 = ((gconst8) * (sj3));
+                                                          if (IKabs(((IkReal(49.0000000000000)) * (npy) * (x265))) <
+                                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                                              IKabs(((IkReal(-49.0000000000000)) * (npx) * (x265))) <
+                                                                  IKFAST_ATAN2_MAGTHRESH)
+                                                            continue;
+                                                          j6array[0] =
+                                                              IKatan2(((IkReal(49.0000000000000)) * (npy) * (x265)),
+                                                                      ((IkReal(-49.0000000000000)) * (npx) * (x265)));
+                                                          sj6array[0] = IKsin(j6array[0]);
+                                                          cj6array[0] = IKcos(j6array[0]);
+                                                          if (j6array[0] > IKPI)
+                                                          {
+                                                            j6array[0] -= IK2PI;
+                                                          }
+                                                          else if (j6array[0] < -IKPI)
+                                                          {
+                                                            j6array[0] += IK2PI;
+                                                          }
+                                                          j6valid[0] = true;
+                                                          for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                          {
+                                                            if (!j6valid[ij6])
+                                                            {
+                                                              continue;
+                                                            }
+                                                            _ij6[0] = ij6;
+                                                            _ij6[1] = -1;
+                                                            for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                            {
+                                                              if (j6valid[iij6] &&
+                                                                  IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                                      IKFAST_SOLUTION_THRESH &&
+                                                                  IKabs(sj6array[ij6] - sj6array[iij6]) <
+                                                                      IKFAST_SOLUTION_THRESH)
+                                                              {
+                                                                j6valid[iij6] = false;
+                                                                _ij6[1] = iij6;
+                                                                break;
+                                                              }
+                                                            }
+                                                            j6 = j6array[ij6];
+                                                            cj6 = cj6array[ij6];
+                                                            sj6 = sj6array[ij6];
+                                                            {
+                                                              IkReal evalcond[2];
+                                                              IkReal x266 = IKcos(j6);
+                                                              IkReal x267 = IKsin(j6);
+                                                              evalcond[0] = ((((npx) * (x267))) + (((npy) * (x266))));
+                                                              evalcond[1] =
+                                                                  ((((npx) * (x266))) +
+                                                                   (((IkReal(-1.00000000000000)) * (npy) * (x267))) +
+                                                                   (((IkReal(0.490000000000000)) * (sj3))));
+                                                              if (IKabs(evalcond[0]) > 0.000001 ||
+                                                                  IKabs(evalcond[1]) > 0.000001)
+                                                              {
+                                                                continue;
+                                                              }
+                                                            }
+
+                                                            rotationfunction0(solutions);
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                  else
+                                                  {
+                                                    IkReal x268 = ((IkReal(1.00000000000000)) * (pp));
+                                                    IkReal x269 = ((IkReal(0.490000000000000)) * (cj3));
+                                                    evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                                   (IKfmod(((IkReal(1.11022302462516e-16)) + (j4)),
+                                                                           IkReal(6.28318530717959))));
+                                                    evalcond[1] = ((IkReal(0.416500000000000)) +
+                                                                   (((IkReal(-1.00000000000000)) * (x268))) +
+                                                                   (((IkReal(0.411600000000000)) * (cj3))));
+                                                    evalcond[2] = ((IkReal(0.420000000000000)) +
+                                                                   (((IkReal(-1.00000000000000)) * (npz))) + (x269));
+                                                    evalcond[3] = ((IkReal(0.0637000000000000)) +
+                                                                   (((IkReal(0.840000000000000)) * (npz))) +
+                                                                   (((IkReal(-1.00000000000000)) * (x268))));
+                                                    evalcond[4] = ((IkReal(-0.420000000000000)) + (npz) +
+                                                                   (((IkReal(-1.00000000000000)) * (x269))));
+                                                    if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                                        IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                                        IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                                        IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                                        IKabs(evalcond[4]) < 0.0000010000000000)
+                                                    {
+                                                      {
+                                                        IkReal dummyeval[1];
+                                                        IkReal gconst9;
+                                                        gconst9 =
+                                                            IKsign(((((IkReal(-100.000000000000)) * ((npy) * (npy)))) +
+                                                                    (((IkReal(-100.000000000000)) * ((npx) * (npx))))));
+                                                        dummyeval[0] =
+                                                            ((((IkReal(-1.00000000000000)) * ((npy) * (npy)))) +
+                                                             (((IkReal(-1.00000000000000)) * ((npx) * (npx)))));
+                                                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                                        {
+                                                          continue;
+                                                        }
+                                                        else
+                                                        {
+                                                          {
+                                                            IkReal j6array[1], cj6array[1], sj6array[1];
+                                                            bool j6valid[1] = { false };
+                                                            _nj6 = 1;
+                                                            IkReal x270 = ((gconst9) * (sj3));
+                                                            if (IKabs(((IkReal(49.0000000000000)) * (npy) * (x270))) <
+                                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                                IKabs(((IkReal(-49.0000000000000)) * (npx) * (x270))) <
+                                                                    IKFAST_ATAN2_MAGTHRESH)
+                                                              continue;
+                                                            j6array[0] =
+                                                                IKatan2(((IkReal(49.0000000000000)) * (npy) * (x270)),
+                                                                        ((IkReal(-49.0000000000000)) * (npx) * (x270)));
+                                                            sj6array[0] = IKsin(j6array[0]);
+                                                            cj6array[0] = IKcos(j6array[0]);
+                                                            if (j6array[0] > IKPI)
+                                                            {
+                                                              j6array[0] -= IK2PI;
+                                                            }
+                                                            else if (j6array[0] < -IKPI)
+                                                            {
+                                                              j6array[0] += IK2PI;
+                                                            }
+                                                            j6valid[0] = true;
+                                                            for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                            {
+                                                              if (!j6valid[ij6])
+                                                              {
+                                                                continue;
+                                                              }
+                                                              _ij6[0] = ij6;
+                                                              _ij6[1] = -1;
+                                                              for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                              {
+                                                                if (j6valid[iij6] &&
+                                                                    IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                                        IKFAST_SOLUTION_THRESH &&
+                                                                    IKabs(sj6array[ij6] - sj6array[iij6]) <
+                                                                        IKFAST_SOLUTION_THRESH)
+                                                                {
+                                                                  j6valid[iij6] = false;
+                                                                  _ij6[1] = iij6;
+                                                                  break;
+                                                                }
+                                                              }
+                                                              j6 = j6array[ij6];
+                                                              cj6 = cj6array[ij6];
+                                                              sj6 = sj6array[ij6];
+                                                              {
+                                                                IkReal evalcond[2];
+                                                                IkReal x271 = IKcos(j6);
+                                                                IkReal x272 = IKsin(j6);
+                                                                evalcond[0] = ((((npy) * (x271))) + (((npx) * (x272))));
+                                                                evalcond[1] =
+                                                                    ((((IkReal(-0.490000000000000)) * (sj3))) +
+                                                                     (((IkReal(-1.00000000000000)) * (npy) * (x272))) +
+                                                                     (((npx) * (x271))));
+                                                                if (IKabs(evalcond[0]) > 0.000001 ||
+                                                                    IKabs(evalcond[1]) > 0.000001)
+                                                                {
+                                                                  continue;
+                                                                }
+                                                              }
+
+                                                              rotationfunction0(solutions);
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                    else
+                                                    {
+                                                      if (1)
+                                                      {
+                                                        continue;
+                                                      }
+                                                      else
+                                                      {
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                              else
+                                              {
+                                                {
+                                                  IkReal j6array[1], cj6array[1], sj6array[1];
+                                                  bool j6valid[1] = { false };
+                                                  _nj6 = 1;
+                                                  IkReal x273 = (sj4) * (sj4);
+                                                  IkReal x274 = ((cj4) * (sj4));
+                                                  IkReal x275 = ((IkReal(49.0000000000000)) * (npx) * (sj3));
+                                                  IkReal x276 = ((IkReal(49.0000000000000)) * (npy) * (sj3));
+                                                  if (IKabs(((gconst7) *
+                                                             (((((IkReal(-1.00000000000000)) * (x273) * (x275))) +
+                                                               (((x274) * (x276))))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                                      IKabs(((gconst7) *
+                                                             (((((IkReal(-1.00000000000000)) * (x273) * (x276))) +
+                                                               (((IkReal(-1.00000000000000)) * (x274) * (x275))))))) <
+                                                          IKFAST_ATAN2_MAGTHRESH)
+                                                    continue;
+                                                  j6array[0] = IKatan2(
+                                                      ((gconst7) * (((((IkReal(-1.00000000000000)) * (x273) * (x275))) +
+                                                                     (((x274) * (x276)))))),
+                                                      ((gconst7) *
+                                                       (((((IkReal(-1.00000000000000)) * (x273) * (x276))) +
+                                                         (((IkReal(-1.00000000000000)) * (x274) * (x275)))))));
+                                                  sj6array[0] = IKsin(j6array[0]);
+                                                  cj6array[0] = IKcos(j6array[0]);
+                                                  if (j6array[0] > IKPI)
+                                                  {
+                                                    j6array[0] -= IK2PI;
+                                                  }
+                                                  else if (j6array[0] < -IKPI)
+                                                  {
+                                                    j6array[0] += IK2PI;
+                                                  }
+                                                  j6valid[0] = true;
+                                                  for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                  {
+                                                    if (!j6valid[ij6])
+                                                    {
+                                                      continue;
+                                                    }
+                                                    _ij6[0] = ij6;
+                                                    _ij6[1] = -1;
+                                                    for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                    {
+                                                      if (j6valid[iij6] &&
+                                                          IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                              IKFAST_SOLUTION_THRESH &&
+                                                          IKabs(sj6array[ij6] - sj6array[iij6]) <
+                                                              IKFAST_SOLUTION_THRESH)
+                                                      {
+                                                        j6valid[iij6] = false;
+                                                        _ij6[1] = iij6;
+                                                        break;
+                                                      }
+                                                    }
+                                                    j6 = j6array[ij6];
+                                                    cj6 = cj6array[ij6];
+                                                    sj6 = sj6array[ij6];
+                                                    {
+                                                      IkReal evalcond[4];
+                                                      IkReal x277 = IKcos(j6);
+                                                      IkReal x278 = IKsin(j6);
+                                                      IkReal x279 = ((IkReal(1.00000000000000)) * (sj4));
+                                                      IkReal x280 = ((IkReal(0.490000000000000)) * (sj3));
+                                                      IkReal x281 = ((npy) * (x277));
+                                                      IkReal x282 = ((npx) * (x277));
+                                                      IkReal x283 = ((npx) * (x278));
+                                                      IkReal x284 = ((npy) * (x278));
+                                                      evalcond[0] = ((x283) + (x281) + (((sj4) * (x280))));
+                                                      evalcond[1] = ((x282) + (((IkReal(-1.00000000000000)) * (x284))) +
+                                                                     (((cj4) * (x280))));
+                                                      evalcond[2] = ((((IkReal(-1.00000000000000)) * (x279) * (x282))) +
+                                                                     (((cj4) * (x283))) + (((cj4) * (x281))) +
+                                                                     (((sj4) * (x284))));
+                                                      evalcond[3] = ((((IkReal(-1.00000000000000)) * (cj4) * (x282))) +
+                                                                     (((IkReal(-1.00000000000000)) * (x280))) +
+                                                                     (((IkReal(-1.00000000000000)) * (x279) * (x281))) +
+                                                                     (((IkReal(-1.00000000000000)) * (x279) * (x283))) +
+                                                                     (((cj4) * (x284))));
+                                                      if (IKabs(evalcond[0]) > 0.000001 ||
+                                                          IKabs(evalcond[1]) > 0.000001 ||
+                                                          IKabs(evalcond[2]) > 0.000001 ||
+                                                          IKabs(evalcond[3]) > 0.000001)
+                                                      {
+                                                        continue;
+                                                      }
+                                                    }
+
+                                                    rotationfunction0(solutions);
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                          else
+                                          {
+                                            {
+                                              IkReal j6array[1], cj6array[1], sj6array[1];
+                                              bool j6valid[1] = { false };
+                                              _nj6 = 1;
+                                              IkReal x285 = ((IkReal(49.0000000000000)) * (cj4) * (sj3));
+                                              IkReal x286 = ((IkReal(49.0000000000000)) * (sj3) * (sj4));
+                                              if (IKabs(
+                                                      ((gconst6) * (((((IkReal(-1.00000000000000)) * (npx) * (x286))) +
+                                                                     (((npy) * (x285))))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                                  IKabs(((gconst6) *
+                                                         (((((IkReal(-1.00000000000000)) * (npy) * (x286))) +
+                                                           (((IkReal(-1.00000000000000)) * (npx) * (x285))))))) <
+                                                      IKFAST_ATAN2_MAGTHRESH)
+                                                continue;
+                                              j6array[0] = IKatan2(
+                                                  ((gconst6) * (((((IkReal(-1.00000000000000)) * (npx) * (x286))) +
+                                                                 (((npy) * (x285)))))),
+                                                  ((gconst6) * (((((IkReal(-1.00000000000000)) * (npy) * (x286))) +
+                                                                 (((IkReal(-1.00000000000000)) * (npx) * (x285)))))));
+                                              sj6array[0] = IKsin(j6array[0]);
+                                              cj6array[0] = IKcos(j6array[0]);
+                                              if (j6array[0] > IKPI)
+                                              {
+                                                j6array[0] -= IK2PI;
+                                              }
+                                              else if (j6array[0] < -IKPI)
+                                              {
+                                                j6array[0] += IK2PI;
+                                              }
+                                              j6valid[0] = true;
+                                              for (int ij6 = 0; ij6 < 1; ++ij6)
+                                              {
+                                                if (!j6valid[ij6])
+                                                {
+                                                  continue;
+                                                }
+                                                _ij6[0] = ij6;
+                                                _ij6[1] = -1;
+                                                for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                {
+                                                  if (j6valid[iij6] &&
+                                                      IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                                                      IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                                                  {
+                                                    j6valid[iij6] = false;
+                                                    _ij6[1] = iij6;
+                                                    break;
+                                                  }
+                                                }
+                                                j6 = j6array[ij6];
+                                                cj6 = cj6array[ij6];
+                                                sj6 = sj6array[ij6];
+                                                {
+                                                  IkReal evalcond[4];
+                                                  IkReal x287 = IKcos(j6);
+                                                  IkReal x288 = IKsin(j6);
+                                                  IkReal x289 = ((IkReal(1.00000000000000)) * (sj4));
+                                                  IkReal x290 = ((IkReal(0.490000000000000)) * (sj3));
+                                                  IkReal x291 = ((npy) * (x287));
+                                                  IkReal x292 = ((npx) * (x287));
+                                                  IkReal x293 = ((npx) * (x288));
+                                                  IkReal x294 = ((npy) * (x288));
+                                                  evalcond[0] = ((((sj4) * (x290))) + (x291) + (x293));
+                                                  evalcond[1] = ((((IkReal(-1.00000000000000)) * (x294))) +
+                                                                 (((cj4) * (x290))) + (x292));
+                                                  evalcond[2] =
+                                                      ((((IkReal(-1.00000000000000)) * (x289) * (x292))) +
+                                                       (((cj4) * (x291))) + (((cj4) * (x293))) + (((sj4) * (x294))));
+                                                  evalcond[3] =
+                                                      ((((IkReal(-1.00000000000000)) * (cj4) * (x292))) +
+                                                       (((IkReal(-1.00000000000000)) * (x289) * (x293))) +
+                                                       (((IkReal(-1.00000000000000)) * (x289) * (x291))) +
+                                                       (((IkReal(-1.00000000000000)) * (x290))) + (((cj4) * (x294))));
+                                                  if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                      IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                  {
+                                                    continue;
+                                                  }
+                                                }
+
+                                                rotationfunction0(solutions);
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                      else
+                                      {
+                                        if (1)
+                                        {
+                                          continue;
+                                        }
+                                        else
+                                        {
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j6array[1], cj6array[1], sj6array[1];
+                                    bool j6valid[1] = { false };
+                                    _nj6 = 1;
+                                    IkReal x295 = ((IkReal(2500.00000000000)) * (pp));
+                                    IkReal x296 = ((IkReal(2100.00000000000)) * (cj5) * (npz));
+                                    IkReal x297 = ((IkReal(1029.00000000000)) * (sj3) * (sj4) * (sj5));
+                                    if (IKabs(((gconst1) * (((((IkReal(-1.00000000000000)) * (npy) * (x295))) +
+                                                             (((IkReal(-1.00000000000000)) * (npy) * (x296))) +
+                                                             (((IkReal(-1.00000000000000)) * (npx) * (x297))) +
+                                                             (((IkReal(159.250000000000)) * (npy))))))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((gconst1) *
+                                               (((((IkReal(-1.00000000000000)) * (npy) * (x297))) + (((npx) * (x295))) +
+                                                 (((npx) * (x296))) + (((IkReal(-159.250000000000)) * (npx))))))) <
+                                            IKFAST_ATAN2_MAGTHRESH)
+                                      continue;
+                                    j6array[0] =
+                                        IKatan2(((gconst1) * (((((IkReal(-1.00000000000000)) * (npy) * (x295))) +
+                                                               (((IkReal(-1.00000000000000)) * (npy) * (x296))) +
+                                                               (((IkReal(-1.00000000000000)) * (npx) * (x297))) +
+                                                               (((IkReal(159.250000000000)) * (npy)))))),
+                                                ((gconst1) * (((((IkReal(-1.00000000000000)) * (npy) * (x297))) +
+                                                               (((npx) * (x295))) + (((npx) * (x296))) +
+                                                               (((IkReal(-159.250000000000)) * (npx)))))));
+                                    sj6array[0] = IKsin(j6array[0]);
+                                    cj6array[0] = IKcos(j6array[0]);
+                                    if (j6array[0] > IKPI)
+                                    {
+                                      j6array[0] -= IK2PI;
+                                    }
+                                    else if (j6array[0] < -IKPI)
+                                    {
+                                      j6array[0] += IK2PI;
+                                    }
+                                    j6valid[0] = true;
+                                    for (int ij6 = 0; ij6 < 1; ++ij6)
+                                    {
+                                      if (!j6valid[ij6])
+                                      {
+                                        continue;
+                                      }
+                                      _ij6[0] = ij6;
+                                      _ij6[1] = -1;
+                                      for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                      {
+                                        if (j6valid[iij6] &&
+                                            IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j6valid[iij6] = false;
+                                          _ij6[1] = iij6;
+                                          break;
+                                        }
+                                      }
+                                      j6 = j6array[ij6];
+                                      cj6 = cj6array[ij6];
+                                      sj6 = sj6array[ij6];
+                                      {
+                                        IkReal evalcond[6];
+                                        IkReal x298 = IKcos(j6);
+                                        IkReal x299 = IKsin(j6);
+                                        IkReal x300 = ((IkReal(1.00000000000000)) * (sj4));
+                                        IkReal x301 = ((cj5) * (npz));
+                                        IkReal x302 = ((cj4) * (cj5));
+                                        IkReal x303 = ((IkReal(0.490000000000000)) * (sj3));
+                                        IkReal x304 = ((IkReal(0.490000000000000)) * (cj3));
+                                        IkReal x305 = ((IkReal(0.840000000000000)) * (sj5));
+                                        IkReal x306 = ((npz) * (sj5));
+                                        IkReal x307 = ((npy) * (x298));
+                                        IkReal x308 = ((npx) * (x298));
+                                        IkReal x309 = ((npy) * (x299));
+                                        IkReal x310 = ((npx) * (x299));
+                                        evalcond[0] = ((x307) + (x310) + (((sj4) * (x303))));
+                                        evalcond[1] =
+                                            ((IkReal(0.0637000000000000)) + (((IkReal(-1.00000000000000)) * (pp))) +
+                                             (((IkReal(-1.00000000000000)) * (x305) * (x309))) + (((x305) * (x308))) +
+                                             (((IkReal(-0.840000000000000)) * (x301))));
+                                        evalcond[2] = ((IkReal(-0.420000000000000)) + (((sj5) * (x308))) +
+                                                       (((IkReal(-1.00000000000000)) * (x301))) +
+                                                       (((IkReal(-1.00000000000000)) * (sj5) * (x309))) +
+                                                       (((IkReal(-1.00000000000000)) * (x304))));
+                                        evalcond[3] = ((((IkReal(-0.420000000000000)) * (sj5))) +
+                                                       (((IkReal(-1.00000000000000)) * (x302) * (x303))) +
+                                                       (((IkReal(-1.00000000000000)) * (x309))) + (x308) +
+                                                       (((IkReal(-1.00000000000000)) * (sj5) * (x304))));
+                                        evalcond[4] = ((((IkReal(-1.00000000000000)) * (cj5) * (x300) * (x309))) +
+                                                       (((cj5) * (sj4) * (x308))) + (((cj4) * (x310))) +
+                                                       (((sj4) * (x306))) + (((cj4) * (x307))));
+                                        evalcond[5] =
+                                            ((((IkReal(-1.00000000000000)) * (x302) * (x309))) +
+                                             (((IkReal(-1.00000000000000)) * (x300) * (x310))) + (((x302) * (x308))) +
+                                             (((IkReal(-1.00000000000000)) * (x300) * (x307))) + (((cj4) * (x306))) +
+                                             (((IkReal(-1.00000000000000)) * (x303))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      rotationfunction0(solutions);
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              {
+                                IkReal j6array[1], cj6array[1], sj6array[1];
+                                bool j6valid[1] = { false };
+                                _nj6 = 1;
+                                IkReal x311 = ((IkReal(49.0000000000000)) * (npx));
+                                IkReal x312 = ((IkReal(49.0000000000000)) * (npy));
+                                IkReal x313 = ((sj3) * (sj4) * (sj5));
+                                IkReal x314 = ((IkReal(100.000000000000)) * (cj5) * (npz));
+                                if (IKabs(((gconst0) * (((((IkReal(-1.00000000000000)) * (npy) * (x314))) +
+                                                         (((IkReal(-1.00000000000000)) * (x311) * (x313))) +
+                                                         (((IkReal(-1.00000000000000)) * (cj3) * (x312))) +
+                                                         (((IkReal(-42.0000000000000)) * (npy))))))) <
+                                        IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((gconst0) *
+                                           (((((IkReal(-1.00000000000000)) * (x312) * (x313))) + (((npx) * (x314))) +
+                                             (((cj3) * (x311))) + (((IkReal(42.0000000000000)) * (npx))))))) <
+                                        IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                j6array[0] = IKatan2(((gconst0) * (((((IkReal(-1.00000000000000)) * (npy) * (x314))) +
+                                                                    (((IkReal(-1.00000000000000)) * (x311) * (x313))) +
+                                                                    (((IkReal(-1.00000000000000)) * (cj3) * (x312))) +
+                                                                    (((IkReal(-42.0000000000000)) * (npy)))))),
+                                                     ((gconst0) * (((((IkReal(-1.00000000000000)) * (x312) * (x313))) +
+                                                                    (((npx) * (x314))) + (((cj3) * (x311))) +
+                                                                    (((IkReal(42.0000000000000)) * (npx)))))));
+                                sj6array[0] = IKsin(j6array[0]);
+                                cj6array[0] = IKcos(j6array[0]);
+                                if (j6array[0] > IKPI)
+                                {
+                                  j6array[0] -= IK2PI;
+                                }
+                                else if (j6array[0] < -IKPI)
+                                {
+                                  j6array[0] += IK2PI;
+                                }
+                                j6valid[0] = true;
+                                for (int ij6 = 0; ij6 < 1; ++ij6)
+                                {
+                                  if (!j6valid[ij6])
+                                  {
+                                    continue;
+                                  }
+                                  _ij6[0] = ij6;
+                                  _ij6[1] = -1;
+                                  for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                  {
+                                    if (j6valid[iij6] &&
+                                        IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j6valid[iij6] = false;
+                                      _ij6[1] = iij6;
+                                      break;
+                                    }
+                                  }
+                                  j6 = j6array[ij6];
+                                  cj6 = cj6array[ij6];
+                                  sj6 = sj6array[ij6];
+                                  {
+                                    IkReal evalcond[6];
+                                    IkReal x315 = IKcos(j6);
+                                    IkReal x316 = IKsin(j6);
+                                    IkReal x317 = ((IkReal(1.00000000000000)) * (sj4));
+                                    IkReal x318 = ((cj5) * (npz));
+                                    IkReal x319 = ((cj4) * (cj5));
+                                    IkReal x320 = ((IkReal(0.490000000000000)) * (sj3));
+                                    IkReal x321 = ((IkReal(0.490000000000000)) * (cj3));
+                                    IkReal x322 = ((IkReal(0.840000000000000)) * (sj5));
+                                    IkReal x323 = ((npz) * (sj5));
+                                    IkReal x324 = ((npy) * (x315));
+                                    IkReal x325 = ((npx) * (x315));
+                                    IkReal x326 = ((npy) * (x316));
+                                    IkReal x327 = ((npx) * (x316));
+                                    evalcond[0] = ((((sj4) * (x320))) + (x324) + (x327));
+                                    evalcond[1] = ((IkReal(0.0637000000000000)) + (((x322) * (x325))) +
+                                                   (((IkReal(-0.840000000000000)) * (x318))) +
+                                                   (((IkReal(-1.00000000000000)) * (x322) * (x326))) +
+                                                   (((IkReal(-1.00000000000000)) * (pp))));
+                                    evalcond[2] =
+                                        ((IkReal(-0.420000000000000)) + (((IkReal(-1.00000000000000)) * (x321))) +
+                                         (((sj5) * (x325))) + (((IkReal(-1.00000000000000)) * (sj5) * (x326))) +
+                                         (((IkReal(-1.00000000000000)) * (x318))));
+                                    evalcond[3] = ((((IkReal(-0.420000000000000)) * (sj5))) +
+                                                   (((IkReal(-1.00000000000000)) * (x326))) + (x325) +
+                                                   (((IkReal(-1.00000000000000)) * (x319) * (x320))) +
+                                                   (((IkReal(-1.00000000000000)) * (sj5) * (x321))));
+                                    evalcond[4] = ((((cj5) * (sj4) * (x325))) + (((sj4) * (x323))) +
+                                                   (((IkReal(-1.00000000000000)) * (cj5) * (x317) * (x326))) +
+                                                   (((cj4) * (x324))) + (((cj4) * (x327))));
+                                    evalcond[5] =
+                                        ((((IkReal(-1.00000000000000)) * (x317) * (x327))) +
+                                         (((IkReal(-1.00000000000000)) * (x317) * (x324))) +
+                                         (((IkReal(-1.00000000000000)) * (x320))) + (((cj4) * (x323))) +
+                                         (((IkReal(-1.00000000000000)) * (x319) * (x326))) + (((x319) * (x325))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  rotationfunction0(solutions);
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                else
+                {
+                  {
+                    IkReal j6array[2], cj6array[2], sj6array[2];
+                    bool j6valid[2] = { false };
+                    _nj6 = 2;
+                    if (IKabs(npy) < IKFAST_ATAN2_MAGTHRESH && IKabs(npx) < IKFAST_ATAN2_MAGTHRESH)
+                      continue;
+                    IkReal x328 = ((IkReal(1.00000000000000)) * (IKatan2(npy, npx)));
+                    if (((((npx) * (npx)) + ((npy) * (npy)))) < (IkReal)-0.00001)
+                      continue;
+                    if ((((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                          (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                                ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                                (IkReal)1.0e30)))) < -1 - IKFAST_SINCOS_THRESH ||
+                        (((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                          (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                                ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                                (IkReal)1.0e30)))) > 1 + IKFAST_SINCOS_THRESH)
+                      continue;
+                    IkReal x329 = IKasin(((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                                          (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                                                ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                                                (IkReal)1.0e30))));
+                    j6array[0] = ((((IkReal(-1.00000000000000)) * (x328))) + (((IkReal(-1.00000000000000)) * (x329))));
+                    sj6array[0] = IKsin(j6array[0]);
+                    cj6array[0] = IKcos(j6array[0]);
+                    j6array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x328))) + (x329));
+                    sj6array[1] = IKsin(j6array[1]);
+                    cj6array[1] = IKcos(j6array[1]);
+                    if (j6array[0] > IKPI)
+                    {
+                      j6array[0] -= IK2PI;
+                    }
+                    else if (j6array[0] < -IKPI)
+                    {
+                      j6array[0] += IK2PI;
+                    }
+                    j6valid[0] = true;
+                    if (j6array[1] > IKPI)
+                    {
+                      j6array[1] -= IK2PI;
+                    }
+                    else if (j6array[1] < -IKPI)
+                    {
+                      j6array[1] += IK2PI;
+                    }
+                    j6valid[1] = true;
+                    for (int ij6 = 0; ij6 < 2; ++ij6)
+                    {
+                      if (!j6valid[ij6])
+                      {
+                        continue;
+                      }
+                      _ij6[0] = ij6;
+                      _ij6[1] = -1;
+                      for (int iij6 = ij6 + 1; iij6 < 2; ++iij6)
+                      {
+                        if (j6valid[iij6] && IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                            IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                        {
+                          j6valid[iij6] = false;
+                          _ij6[1] = iij6;
+                          break;
+                        }
+                      }
+                      j6 = j6array[ij6];
+                      cj6 = cj6array[ij6];
+                      sj6 = sj6array[ij6];
+                      {
+                        IkReal evalcond[2];
+                        IkReal x330 = (npx) * (npx);
+                        IkReal x331 = (cj4) * (cj4);
+                        IkReal x332 = (sj4) * (sj4);
+                        IkReal x333 = IKcos(j6);
+                        IkReal x334 = (npy) * (npy);
+                        IkReal x335 = IKsin(j6);
+                        IkReal x336 = ((npx) * (npy));
+                        IkReal x337 = ((IkReal(0.490000000000000)) * (sj3) * (sj4));
+                        IkReal x338 = ((IkReal(1.00000000000000)) * (x334));
+                        evalcond[0] = ((((x333) * (((((x331) * (x336))) + (((x332) * (x336))))))) +
+                                       (((x335) * (((((x330) * (x331))) + (((x330) * (x332))))))) + (((npx) * (x337))));
+                        evalcond[1] = ((((x335) * (((((IkReal(-1.00000000000000)) * (x332) * (x336))) +
+                                                    (((IkReal(-1.00000000000000)) * (x331) * (x336))))))) +
+                                       (((x333) * (((((IkReal(-1.00000000000000)) * (x331) * (x338))) +
+                                                    (((IkReal(-1.00000000000000)) * (x332) * (x338))))))) +
+                                       (((IkReal(-1.00000000000000)) * (npy) * (x337))));
+                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001)
+                        {
+                          continue;
+                        }
+                      }
+
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst10;
+                        IkReal x339 = ((cj6) * (npx));
+                        IkReal x340 = ((IkReal(49.0000000000000)) * (cj3));
+                        IkReal x341 = ((npy) * (sj6));
+                        gconst10 = IKsign(((((IkReal(-42.0000000000000)) * (x339))) +
+                                           (((IkReal(49.0000000000000)) * (cj4) * (npz) * (sj3))) +
+                                           (((x340) * (x341))) + (((IkReal(42.0000000000000)) * (x341))) +
+                                           (((IkReal(-1.00000000000000)) * (x339) * (x340)))));
+                        IkReal x342 = ((npy) * (sj6));
+                        IkReal x343 = ((cj6) * (npx));
+                        IkReal x344 = ((IkReal(1.16666666666667)) * (cj3));
+                        dummyeval[0] = ((((IkReal(1.16666666666667)) * (cj4) * (npz) * (sj3))) + (x342) +
+                                        (((IkReal(-1.00000000000000)) * (x343) * (x344))) +
+                                        (((IkReal(-1.00000000000000)) * (x343))) + (((x342) * (x344))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal dummyeval[1];
+                            IkReal gconst11;
+                            IkReal x345 = ((npy) * (sj6));
+                            IkReal x346 = ((IkReal(1029.00000000000)) * (cj3));
+                            IkReal x347 = ((cj6) * (npx));
+                            gconst11 = IKsign(
+                                ((((x345) * (x346))) + (((IkReal(1029.00000000000)) * (cj4) * (npz) * (sj3))) +
+                                 (((IkReal(-1.00000000000000)) * (x346) * (x347))) +
+                                 (((IkReal(-882.000000000000)) * (x347))) + (((IkReal(882.000000000000)) * (x345)))));
+                            IkReal x348 = ((npy) * (sj6));
+                            IkReal x349 = ((cj6) * (npx));
+                            IkReal x350 = ((IkReal(1.16666666666667)) * (cj3));
+                            dummyeval[0] = ((((IkReal(1.16666666666667)) * (cj4) * (npz) * (sj3))) +
+                                            (((IkReal(-1.00000000000000)) * (x349) * (x350))) + (x348) +
+                                            (((x348) * (x350))) + (((IkReal(-1.00000000000000)) * (x349))));
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              continue;
+                            }
+                            else
+                            {
+                              {
+                                IkReal j5array[1], cj5array[1], sj5array[1];
+                                bool j5valid[1] = { false };
+                                _nj5 = 1;
+                                IkReal x351 = ((cj4) * (sj3));
+                                IkReal x352 = ((IkReal(1225.00000000000)) * (pp));
+                                IkReal x353 = ((IkReal(2100.00000000000)) * (npz));
+                                if (IKabs(((gconst11) * (((IkReal(66.8850000000000)) +
+                                                          (((IkReal(-1.00000000000000)) * (cj3) * (x352))) +
+                                                          (((IkReal(-1050.00000000000)) * (pp))) +
+                                                          (((IkReal(78.0325000000000)) * (cj3))) +
+                                                          (((npz) * (x353))))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((gconst11) *
+                                           (((((IkReal(78.0325000000000)) * (x351))) + (((cj6) * (npx) * (x353))) +
+                                             (((IkReal(-1.00000000000000)) * (x351) * (x352))) +
+                                             (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x353))))))) <
+                                        IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                j5array[0] = IKatan2(
+                                    ((gconst11) *
+                                     (((IkReal(66.8850000000000)) + (((IkReal(-1.00000000000000)) * (cj3) * (x352))) +
+                                       (((IkReal(-1050.00000000000)) * (pp))) + (((IkReal(78.0325000000000)) * (cj3))) +
+                                       (((npz) * (x353)))))),
+                                    ((gconst11) *
+                                     (((((IkReal(78.0325000000000)) * (x351))) + (((cj6) * (npx) * (x353))) +
+                                       (((IkReal(-1.00000000000000)) * (x351) * (x352))) +
+                                       (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x353)))))));
+                                sj5array[0] = IKsin(j5array[0]);
+                                cj5array[0] = IKcos(j5array[0]);
+                                if (j5array[0] > IKPI)
+                                {
+                                  j5array[0] -= IK2PI;
+                                }
+                                else if (j5array[0] < -IKPI)
+                                {
+                                  j5array[0] += IK2PI;
+                                }
+                                j5valid[0] = true;
+                                for (int ij5 = 0; ij5 < 1; ++ij5)
+                                {
+                                  if (!j5valid[ij5])
+                                  {
+                                    continue;
+                                  }
+                                  _ij5[0] = ij5;
+                                  _ij5[1] = -1;
+                                  for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                  {
+                                    if (j5valid[iij5] &&
+                                        IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j5valid[iij5] = false;
+                                      _ij5[1] = iij5;
+                                      break;
+                                    }
+                                  }
+                                  j5 = j5array[ij5];
+                                  cj5 = cj5array[ij5];
+                                  sj5 = sj5array[ij5];
+                                  {
+                                    IkReal evalcond[6];
+                                    IkReal x354 = IKcos(j5);
+                                    IkReal x355 = IKsin(j5);
+                                    IkReal x356 = ((IkReal(1.00000000000000)) * (npy));
+                                    IkReal x357 = ((cj6) * (sj4));
+                                    IkReal x358 = ((IkReal(0.490000000000000)) * (sj3));
+                                    IkReal x359 = ((sj4) * (sj6));
+                                    IkReal x360 = ((IkReal(1.00000000000000)) * (npz));
+                                    IkReal x361 = ((cj6) * (npx));
+                                    IkReal x362 = ((IkReal(0.490000000000000)) * (cj3));
+                                    IkReal x363 = ((npz) * (x355));
+                                    IkReal x364 = ((cj4) * (x354));
+                                    IkReal x365 = ((sj6) * (x355));
+                                    evalcond[0] =
+                                        ((((IkReal(-1.00000000000000)) * (x354) * (x362))) +
+                                         (((IkReal(-0.420000000000000)) * (x354))) +
+                                         (((IkReal(-1.00000000000000)) * (x360))) + (((cj4) * (x355) * (x358))));
+                                    evalcond[1] = ((IkReal(0.0637000000000000)) +
+                                                   (((IkReal(-0.840000000000000)) * (npz) * (x354))) +
+                                                   (((IkReal(0.840000000000000)) * (x355) * (x361))) +
+                                                   (((IkReal(-1.00000000000000)) * (pp))) +
+                                                   (((IkReal(-0.840000000000000)) * (npy) * (x365))));
+                                    evalcond[2] = ((IkReal(-0.420000000000000)) +
+                                                   (((IkReal(-1.00000000000000)) * (x354) * (x360))) +
+                                                   (((IkReal(-1.00000000000000)) * (x362))) + (((x355) * (x361))) +
+                                                   (((IkReal(-1.00000000000000)) * (x356) * (x365))));
+                                    evalcond[3] = ((((IkReal(-0.420000000000000)) * (x355))) +
+                                                   (((IkReal(-1.00000000000000)) * (x358) * (x364))) +
+                                                   (((IkReal(-1.00000000000000)) * (x355) * (x362))) + (x361) +
+                                                   (((IkReal(-1.00000000000000)) * (sj6) * (x356))));
+                                    evalcond[4] = ((((sj4) * (x363))) + (((npx) * (x354) * (x357))) +
+                                                   (((cj4) * (npx) * (sj6))) + (((cj4) * (cj6) * (npy))) +
+                                                   (((IkReal(-1.00000000000000)) * (x354) * (x356) * (x359))));
+                                    evalcond[5] =
+                                        ((((x361) * (x364))) + (((IkReal(-1.00000000000000)) * (x358))) +
+                                         (((IkReal(-1.00000000000000)) * (x356) * (x357))) + (((cj4) * (x363))) +
+                                         (((IkReal(-1.00000000000000)) * (npx) * (x359))) +
+                                         (((IkReal(-1.00000000000000)) * (sj6) * (x356) * (x364))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  rotationfunction0(solutions);
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          {
+                            IkReal j5array[1], cj5array[1], sj5array[1];
+                            bool j5valid[1] = { false };
+                            _nj5 = 1;
+                            IkReal x366 = ((cj4) * (sj3));
+                            IkReal x367 = ((IkReal(100.000000000000)) * (npz));
+                            if (IKabs(((gconst10) *
+                                       (((IkReal(-17.6400000000000)) + (((IkReal(-41.1600000000000)) * (cj3))) +
+                                         (((npz) * (x367))) + (((IkReal(-24.0100000000000)) * ((cj3) * (cj3)))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((gconst10) *
+                                       (((((IkReal(-20.5800000000000)) * (x366))) + (((cj6) * (npx) * (x367))) +
+                                         (((IkReal(-24.0100000000000)) * (cj3) * (x366))) +
+                                         (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x367))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j5array[0] = IKatan2(
+                                ((gconst10) *
+                                 (((IkReal(-17.6400000000000)) + (((IkReal(-41.1600000000000)) * (cj3))) +
+                                   (((npz) * (x367))) + (((IkReal(-24.0100000000000)) * ((cj3) * (cj3))))))),
+                                ((gconst10) * (((((IkReal(-20.5800000000000)) * (x366))) + (((cj6) * (npx) * (x367))) +
+                                                (((IkReal(-24.0100000000000)) * (cj3) * (x366))) +
+                                                (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x367)))))));
+                            sj5array[0] = IKsin(j5array[0]);
+                            cj5array[0] = IKcos(j5array[0]);
+                            if (j5array[0] > IKPI)
+                            {
+                              j5array[0] -= IK2PI;
+                            }
+                            else if (j5array[0] < -IKPI)
+                            {
+                              j5array[0] += IK2PI;
+                            }
+                            j5valid[0] = true;
+                            for (int ij5 = 0; ij5 < 1; ++ij5)
+                            {
+                              if (!j5valid[ij5])
+                              {
+                                continue;
+                              }
+                              _ij5[0] = ij5;
+                              _ij5[1] = -1;
+                              for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                              {
+                                if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j5valid[iij5] = false;
+                                  _ij5[1] = iij5;
+                                  break;
+                                }
+                              }
+                              j5 = j5array[ij5];
+                              cj5 = cj5array[ij5];
+                              sj5 = sj5array[ij5];
+                              {
+                                IkReal evalcond[6];
+                                IkReal x368 = IKcos(j5);
+                                IkReal x369 = IKsin(j5);
+                                IkReal x370 = ((IkReal(1.00000000000000)) * (npy));
+                                IkReal x371 = ((cj6) * (sj4));
+                                IkReal x372 = ((IkReal(0.490000000000000)) * (sj3));
+                                IkReal x373 = ((sj4) * (sj6));
+                                IkReal x374 = ((IkReal(1.00000000000000)) * (npz));
+                                IkReal x375 = ((cj6) * (npx));
+                                IkReal x376 = ((IkReal(0.490000000000000)) * (cj3));
+                                IkReal x377 = ((npz) * (x369));
+                                IkReal x378 = ((cj4) * (x368));
+                                IkReal x379 = ((sj6) * (x369));
+                                evalcond[0] = ((((IkReal(-1.00000000000000)) * (x368) * (x376))) +
+                                               (((cj4) * (x369) * (x372))) + (((IkReal(-1.00000000000000)) * (x374))) +
+                                               (((IkReal(-0.420000000000000)) * (x368))));
+                                evalcond[1] =
+                                    ((IkReal(0.0637000000000000)) + (((IkReal(0.840000000000000)) * (x369) * (x375))) +
+                                     (((IkReal(-0.840000000000000)) * (npz) * (x368))) +
+                                     (((IkReal(-1.00000000000000)) * (pp))) +
+                                     (((IkReal(-0.840000000000000)) * (npy) * (x379))));
+                                evalcond[2] =
+                                    ((IkReal(-0.420000000000000)) + (((IkReal(-1.00000000000000)) * (x368) * (x374))) +
+                                     (((IkReal(-1.00000000000000)) * (x370) * (x379))) + (((x369) * (x375))) +
+                                     (((IkReal(-1.00000000000000)) * (x376))));
+                                evalcond[3] = ((((IkReal(-1.00000000000000)) * (x372) * (x378))) + (x375) +
+                                               (((IkReal(-0.420000000000000)) * (x369))) +
+                                               (((IkReal(-1.00000000000000)) * (sj6) * (x370))) +
+                                               (((IkReal(-1.00000000000000)) * (x369) * (x376))));
+                                evalcond[4] =
+                                    ((((sj4) * (x377))) + (((IkReal(-1.00000000000000)) * (x368) * (x370) * (x373))) +
+                                     (((cj4) * (npx) * (sj6))) + (((cj4) * (cj6) * (npy))) +
+                                     (((npx) * (x368) * (x371))));
+                                evalcond[5] = ((((IkReal(-1.00000000000000)) * (npx) * (x373))) + (((x375) * (x378))) +
+                                               (((IkReal(-1.00000000000000)) * (x370) * (x371))) +
+                                               (((IkReal(-1.00000000000000)) * (x372))) + (((cj4) * (x377))) +
+                                               (((IkReal(-1.00000000000000)) * (sj6) * (x370) * (x378))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              rotationfunction0(solutions);
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            else
+            {
+              {
+                IkReal j6array[2], cj6array[2], sj6array[2];
+                bool j6valid[2] = { false };
+                _nj6 = 2;
+                if (IKabs(npy) < IKFAST_ATAN2_MAGTHRESH && IKabs(npx) < IKFAST_ATAN2_MAGTHRESH)
+                  continue;
+                IkReal x380 = ((IkReal(1.00000000000000)) * (IKatan2(npy, npx)));
+                if (((((npx) * (npx)) + ((npy) * (npy)))) < (IkReal)-0.00001)
+                  continue;
+                if ((((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                      (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                            ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                            (IkReal)1.0e30)))) < -1 - IKFAST_SINCOS_THRESH ||
+                    (((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                      (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                            ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                            (IkReal)1.0e30)))) > 1 + IKFAST_SINCOS_THRESH)
+                  continue;
+                IkReal x381 = IKasin(((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                                      (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                                            ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                                            (IkReal)1.0e30))));
+                j6array[0] = ((((IkReal(-1.00000000000000)) * (x381))) + (((IkReal(-1.00000000000000)) * (x380))));
+                sj6array[0] = IKsin(j6array[0]);
+                cj6array[0] = IKcos(j6array[0]);
+                j6array[1] = ((IkReal(3.14159265358979)) + (x381) + (((IkReal(-1.00000000000000)) * (x380))));
+                sj6array[1] = IKsin(j6array[1]);
+                cj6array[1] = IKcos(j6array[1]);
+                if (j6array[0] > IKPI)
+                {
+                  j6array[0] -= IK2PI;
+                }
+                else if (j6array[0] < -IKPI)
+                {
+                  j6array[0] += IK2PI;
+                }
+                j6valid[0] = true;
+                if (j6array[1] > IKPI)
+                {
+                  j6array[1] -= IK2PI;
+                }
+                else if (j6array[1] < -IKPI)
+                {
+                  j6array[1] += IK2PI;
+                }
+                j6valid[1] = true;
+                for (int ij6 = 0; ij6 < 2; ++ij6)
+                {
+                  if (!j6valid[ij6])
+                  {
+                    continue;
+                  }
+                  _ij6[0] = ij6;
+                  _ij6[1] = -1;
+                  for (int iij6 = ij6 + 1; iij6 < 2; ++iij6)
+                  {
+                    if (j6valid[iij6] && IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                        IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                    {
+                      j6valid[iij6] = false;
+                      _ij6[1] = iij6;
+                      break;
+                    }
+                  }
+                  j6 = j6array[ij6];
+                  cj6 = cj6array[ij6];
+                  sj6 = sj6array[ij6];
+
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst10;
+                    IkReal x382 = ((cj6) * (npx));
+                    IkReal x383 = ((IkReal(49.0000000000000)) * (cj3));
+                    IkReal x384 = ((npy) * (sj6));
+                    gconst10 =
+                        IKsign(((((IkReal(-42.0000000000000)) * (x382))) + (((IkReal(42.0000000000000)) * (x384))) +
+                                (((x383) * (x384))) + (((IkReal(49.0000000000000)) * (cj4) * (npz) * (sj3))) +
+                                (((IkReal(-1.00000000000000)) * (x382) * (x383)))));
+                    IkReal x385 = ((npy) * (sj6));
+                    IkReal x386 = ((cj6) * (npx));
+                    IkReal x387 = ((IkReal(1.16666666666667)) * (cj3));
+                    dummyeval[0] = ((((IkReal(1.16666666666667)) * (cj4) * (npz) * (sj3))) + (x385) +
+                                    (((IkReal(-1.00000000000000)) * (x386))) +
+                                    (((IkReal(-1.00000000000000)) * (x386) * (x387))) + (((x385) * (x387))));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst11;
+                        IkReal x388 = ((npy) * (sj6));
+                        IkReal x389 = ((IkReal(1029.00000000000)) * (cj3));
+                        IkReal x390 = ((cj6) * (npx));
+                        gconst11 = IKsign(((((IkReal(-1.00000000000000)) * (x389) * (x390))) +
+                                           (((IkReal(-882.000000000000)) * (x390))) + (((x388) * (x389))) +
+                                           (((IkReal(1029.00000000000)) * (cj4) * (npz) * (sj3))) +
+                                           (((IkReal(882.000000000000)) * (x388)))));
+                        IkReal x391 = ((npy) * (sj6));
+                        IkReal x392 = ((cj6) * (npx));
+                        IkReal x393 = ((IkReal(1.16666666666667)) * (cj3));
+                        dummyeval[0] = ((((IkReal(1.16666666666667)) * (cj4) * (npz) * (sj3))) +
+                                        (((IkReal(-1.00000000000000)) * (x392))) + (x391) + (((x391) * (x393))) +
+                                        (((IkReal(-1.00000000000000)) * (x392) * (x393))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          continue;
+                        }
+                        else
+                        {
+                          {
+                            IkReal j5array[1], cj5array[1], sj5array[1];
+                            bool j5valid[1] = { false };
+                            _nj5 = 1;
+                            IkReal x394 = ((cj4) * (sj3));
+                            IkReal x395 = ((IkReal(1225.00000000000)) * (pp));
+                            IkReal x396 = ((IkReal(2100.00000000000)) * (npz));
+                            if (IKabs(((gconst11) * (((IkReal(66.8850000000000)) + (((npz) * (x396))) +
+                                                      (((IkReal(-1050.00000000000)) * (pp))) +
+                                                      (((IkReal(-1.00000000000000)) * (cj3) * (x395))) +
+                                                      (((IkReal(78.0325000000000)) * (cj3))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((gconst11) * (((((cj6) * (npx) * (x396))) +
+                                                      (((IkReal(-1.00000000000000)) * (x394) * (x395))) +
+                                                      (((IkReal(78.0325000000000)) * (x394))) +
+                                                      (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x396))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j5array[0] =
+                                IKatan2(((gconst11) * (((IkReal(66.8850000000000)) + (((npz) * (x396))) +
+                                                        (((IkReal(-1050.00000000000)) * (pp))) +
+                                                        (((IkReal(-1.00000000000000)) * (cj3) * (x395))) +
+                                                        (((IkReal(78.0325000000000)) * (cj3)))))),
+                                        ((gconst11) * (((((cj6) * (npx) * (x396))) +
+                                                        (((IkReal(-1.00000000000000)) * (x394) * (x395))) +
+                                                        (((IkReal(78.0325000000000)) * (x394))) +
+                                                        (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x396)))))));
+                            sj5array[0] = IKsin(j5array[0]);
+                            cj5array[0] = IKcos(j5array[0]);
+                            if (j5array[0] > IKPI)
+                            {
+                              j5array[0] -= IK2PI;
+                            }
+                            else if (j5array[0] < -IKPI)
+                            {
+                              j5array[0] += IK2PI;
+                            }
+                            j5valid[0] = true;
+                            for (int ij5 = 0; ij5 < 1; ++ij5)
+                            {
+                              if (!j5valid[ij5])
+                              {
+                                continue;
+                              }
+                              _ij5[0] = ij5;
+                              _ij5[1] = -1;
+                              for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                              {
+                                if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j5valid[iij5] = false;
+                                  _ij5[1] = iij5;
+                                  break;
+                                }
+                              }
+                              j5 = j5array[ij5];
+                              cj5 = cj5array[ij5];
+                              sj5 = sj5array[ij5];
+                              {
+                                IkReal evalcond[6];
+                                IkReal x397 = IKcos(j5);
+                                IkReal x398 = IKsin(j5);
+                                IkReal x399 = ((IkReal(1.00000000000000)) * (npy));
+                                IkReal x400 = ((cj6) * (sj4));
+                                IkReal x401 = ((IkReal(0.490000000000000)) * (sj3));
+                                IkReal x402 = ((sj4) * (sj6));
+                                IkReal x403 = ((IkReal(1.00000000000000)) * (npz));
+                                IkReal x404 = ((cj6) * (npx));
+                                IkReal x405 = ((IkReal(0.490000000000000)) * (cj3));
+                                IkReal x406 = ((npz) * (x398));
+                                IkReal x407 = ((cj4) * (x397));
+                                IkReal x408 = ((sj6) * (x398));
+                                evalcond[0] =
+                                    ((((cj4) * (x398) * (x401))) + (((IkReal(-1.00000000000000)) * (x397) * (x405))) +
+                                     (((IkReal(-0.420000000000000)) * (x397))) +
+                                     (((IkReal(-1.00000000000000)) * (x403))));
+                                evalcond[1] =
+                                    ((IkReal(0.0637000000000000)) + (((IkReal(0.840000000000000)) * (x398) * (x404))) +
+                                     (((IkReal(-1.00000000000000)) * (pp))) +
+                                     (((IkReal(-0.840000000000000)) * (npy) * (x408))) +
+                                     (((IkReal(-0.840000000000000)) * (npz) * (x397))));
+                                evalcond[2] =
+                                    ((IkReal(-0.420000000000000)) + (((IkReal(-1.00000000000000)) * (x399) * (x408))) +
+                                     (((IkReal(-1.00000000000000)) * (x397) * (x403))) + (((x398) * (x404))) +
+                                     (((IkReal(-1.00000000000000)) * (x405))));
+                                evalcond[3] = ((((IkReal(-1.00000000000000)) * (x401) * (x407))) +
+                                               (((IkReal(-1.00000000000000)) * (sj6) * (x399))) + (x404) +
+                                               (((IkReal(-1.00000000000000)) * (x398) * (x405))) +
+                                               (((IkReal(-0.420000000000000)) * (x398))));
+                                evalcond[4] = ((((IkReal(-1.00000000000000)) * (x397) * (x399) * (x402))) +
+                                               (((npx) * (x397) * (x400))) + (((cj4) * (npx) * (sj6))) +
+                                               (((cj4) * (cj6) * (npy))) + (((sj4) * (x406))));
+                                evalcond[5] =
+                                    ((((x404) * (x407))) + (((IkReal(-1.00000000000000)) * (sj6) * (x399) * (x407))) +
+                                     (((cj4) * (x406))) + (((IkReal(-1.00000000000000)) * (x399) * (x400))) +
+                                     (((IkReal(-1.00000000000000)) * (npx) * (x402))) +
+                                     (((IkReal(-1.00000000000000)) * (x401))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              rotationfunction0(solutions);
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j5array[1], cj5array[1], sj5array[1];
+                        bool j5valid[1] = { false };
+                        _nj5 = 1;
+                        IkReal x409 = ((cj4) * (sj3));
+                        IkReal x410 = ((IkReal(100.000000000000)) * (npz));
+                        if (IKabs(((gconst10) *
+                                   (((IkReal(-17.6400000000000)) + (((IkReal(-41.1600000000000)) * (cj3))) +
+                                     (((npz) * (x410))) + (((IkReal(-24.0100000000000)) * ((cj3) * (cj3)))))))) <
+                                IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((gconst10) *
+                                   (((((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x410))) +
+                                     (((cj6) * (npx) * (x410))) + (((IkReal(-24.0100000000000)) * (cj3) * (x409))) +
+                                     (((IkReal(-20.5800000000000)) * (x409))))))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j5array[0] = IKatan2(
+                            ((gconst10) * (((IkReal(-17.6400000000000)) + (((IkReal(-41.1600000000000)) * (cj3))) +
+                                            (((npz) * (x410))) + (((IkReal(-24.0100000000000)) * ((cj3) * (cj3))))))),
+                            ((gconst10) *
+                             (((((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x410))) + (((cj6) * (npx) * (x410))) +
+                               (((IkReal(-24.0100000000000)) * (cj3) * (x409))) +
+                               (((IkReal(-20.5800000000000)) * (x409)))))));
+                        sj5array[0] = IKsin(j5array[0]);
+                        cj5array[0] = IKcos(j5array[0]);
+                        if (j5array[0] > IKPI)
+                        {
+                          j5array[0] -= IK2PI;
+                        }
+                        else if (j5array[0] < -IKPI)
+                        {
+                          j5array[0] += IK2PI;
+                        }
+                        j5valid[0] = true;
+                        for (int ij5 = 0; ij5 < 1; ++ij5)
+                        {
+                          if (!j5valid[ij5])
+                          {
+                            continue;
+                          }
+                          _ij5[0] = ij5;
+                          _ij5[1] = -1;
+                          for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                          {
+                            if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j5valid[iij5] = false;
+                              _ij5[1] = iij5;
+                              break;
+                            }
+                          }
+                          j5 = j5array[ij5];
+                          cj5 = cj5array[ij5];
+                          sj5 = sj5array[ij5];
+                          {
+                            IkReal evalcond[6];
+                            IkReal x411 = IKcos(j5);
+                            IkReal x412 = IKsin(j5);
+                            IkReal x413 = ((IkReal(1.00000000000000)) * (npy));
+                            IkReal x414 = ((cj6) * (sj4));
+                            IkReal x415 = ((IkReal(0.490000000000000)) * (sj3));
+                            IkReal x416 = ((sj4) * (sj6));
+                            IkReal x417 = ((IkReal(1.00000000000000)) * (npz));
+                            IkReal x418 = ((cj6) * (npx));
+                            IkReal x419 = ((IkReal(0.490000000000000)) * (cj3));
+                            IkReal x420 = ((npz) * (x412));
+                            IkReal x421 = ((cj4) * (x411));
+                            IkReal x422 = ((sj6) * (x412));
+                            evalcond[0] = ((((cj4) * (x412) * (x415))) + (((IkReal(-0.420000000000000)) * (x411))) +
+                                           (((IkReal(-1.00000000000000)) * (x411) * (x419))) +
+                                           (((IkReal(-1.00000000000000)) * (x417))));
+                            evalcond[1] =
+                                ((IkReal(0.0637000000000000)) + (((IkReal(0.840000000000000)) * (x412) * (x418))) +
+                                 (((IkReal(-1.00000000000000)) * (pp))) +
+                                 (((IkReal(-0.840000000000000)) * (npy) * (x422))) +
+                                 (((IkReal(-0.840000000000000)) * (npz) * (x411))));
+                            evalcond[2] =
+                                ((IkReal(-0.420000000000000)) + (((IkReal(-1.00000000000000)) * (x411) * (x417))) +
+                                 (((x412) * (x418))) + (((IkReal(-1.00000000000000)) * (x413) * (x422))) +
+                                 (((IkReal(-1.00000000000000)) * (x419))));
+                            evalcond[3] = ((((IkReal(-1.00000000000000)) * (sj6) * (x413))) +
+                                           (((IkReal(-1.00000000000000)) * (x412) * (x419))) +
+                                           (((IkReal(-0.420000000000000)) * (x412))) + (x418) +
+                                           (((IkReal(-1.00000000000000)) * (x415) * (x421))));
+                            evalcond[4] = ((((IkReal(-1.00000000000000)) * (x411) * (x413) * (x416))) +
+                                           (((npx) * (x411) * (x414))) + (((sj4) * (x420))) +
+                                           (((cj4) * (npx) * (sj6))) + (((cj4) * (cj6) * (npy))));
+                            evalcond[5] =
+                                ((((IkReal(-1.00000000000000)) * (sj6) * (x413) * (x421))) + (((x418) * (x421))) +
+                                 (((cj4) * (x420))) + (((IkReal(-1.00000000000000)) * (x413) * (x414))) +
+                                 (((IkReal(-1.00000000000000)) * (npx) * (x416))) +
+                                 (((IkReal(-1.00000000000000)) * (x415))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          rotationfunction0(solutions);
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return solutions.GetNumSolutions() > 0;
+  }
+  inline void rotationfunction0(IkSolutionListBase<IkReal>& solutions)
+  {
+    for (int rotationiter = 0; rotationiter < 1; ++rotationiter)
+    {
+      IkReal x78 = ((cj6) * (sj4));
+      IkReal x79 = ((IkReal(1.00000000000000)) * (sj5));
+      IkReal x80 = ((cj4) * (cj5));
+      IkReal x81 = ((IkReal(1.00000000000000)) * (sj3));
+      IkReal x82 = ((cj3) * (sj5));
+      IkReal x83 = ((IkReal(1.00000000000000)) * (sj6));
+      IkReal x84 = ((sj4) * (sj6));
+      IkReal x85 = ((IkReal(1.00000000000000)) * (cj3));
+      IkReal x86 = ((IkReal(-1.00000000000000)) * (cj3));
+      IkReal x87 = ((((cj3) * (x80))) + (((IkReal(-1.00000000000000)) * (sj3) * (x79))));
+      IkReal x88 = ((((cj5) * (sj3))) + (((cj4) * (x82))));
+      IkReal x89 = ((((cj5) * (x84))) + (((IkReal(-1.00000000000000)) * (cj4) * (cj6))));
+      IkReal x90 = ((x82) + (((sj3) * (x80))));
+      IkReal x91 = ((((cj4) * (sj3) * (sj5))) + (((IkReal(-1.00000000000000)) * (cj5) * (x85))));
+      IkReal x92 = ((cj6) * (x87));
+      IkReal x93 = ((((IkReal(-1.00000000000000)) * (cj4) * (x83))) + (((IkReal(-1.00000000000000)) * (cj5) * (x78))));
+      IkReal x94 = ((((IkReal(-1.00000000000000)) * (cj3) * (sj4) * (x83))) + (x92));
+      IkReal x95 = ((((IkReal(-1.00000000000000)) * (x81) * (x84))) + (((cj6) * (x90))));
+      IkReal x96 = ((((IkReal(-1.00000000000000)) * (x83) * (x90))) + (((IkReal(-1.00000000000000)) * (x78) * (x81))));
+      IkReal x97 = ((((x78) * (x86))) + (((IkReal(-1.00000000000000)) * (sj6) * (x87))));
+      new_r00 =
+          ((((r00) * (((((x84) * (x86))) + (x92))))) + (((r01) * (((((IkReal(-1.00000000000000)) * (x83) * (x87))) +
+                                                                   (((IkReal(-1.00000000000000)) * (x78) * (x85))))))) +
+           (((r02) * (x88))));
+      new_r01 = ((((r12) * (x88))) + (((r11) * (x97))) + (((r10) * (x94))));
+      new_r02 = ((((r21) * (x97))) + (((r20) * (x94))) + (((r22) * (x88))));
+      new_r10 = ((((r00) * (x93))) + (((r01) * (x89))) + (((IkReal(-1.00000000000000)) * (r02) * (sj4) * (x79))));
+      new_r11 = ((((r11) * (x89))) + (((r10) * (x93))) + (((IkReal(-1.00000000000000)) * (r12) * (sj4) * (x79))));
+      new_r12 = ((((r21) * (x89))) + (((IkReal(-1.00000000000000)) * (r22) * (sj4) * (x79))) + (((r20) * (x93))));
+      new_r20 = ((((r01) * (x96))) + (((r00) * (x95))) + (((r02) * (x91))));
+      new_r21 = ((((r12) * (x91))) + (((r11) * (x96))) + (((r10) * (x95))));
+      new_r22 = ((((r21) * (x96))) + (((r20) * (x95))) + (((r22) * (x91))));
+      {
+        IkReal j1array[2], cj1array[2], sj1array[2];
+        bool j1valid[2] = { false };
+        _nj1 = 2;
+        cj1array[0] = new_r22;
+        if (cj1array[0] >= -1 - IKFAST_SINCOS_THRESH && cj1array[0] <= 1 + IKFAST_SINCOS_THRESH)
+        {
+          j1valid[0] = j1valid[1] = true;
+          j1array[0] = IKacos(cj1array[0]);
+          sj1array[0] = IKsin(j1array[0]);
+          cj1array[1] = cj1array[0];
+          j1array[1] = -j1array[0];
+          sj1array[1] = -sj1array[0];
+        }
+        else if (isnan(cj1array[0]))
+        {
+          // probably any value will work
+          j1valid[0] = true;
+          cj1array[0] = 1;
+          sj1array[0] = 0;
+          j1array[0] = 0;
+        }
+        for (int ij1 = 0; ij1 < 2; ++ij1)
+        {
+          if (!j1valid[ij1])
+          {
+            continue;
+          }
+          _ij1[0] = ij1;
+          _ij1[1] = -1;
+          for (int iij1 = ij1 + 1; iij1 < 2; ++iij1)
+          {
+            if (j1valid[iij1] && IKabs(cj1array[ij1] - cj1array[iij1]) < IKFAST_SOLUTION_THRESH &&
+                IKabs(sj1array[ij1] - sj1array[iij1]) < IKFAST_SOLUTION_THRESH)
+            {
+              j1valid[iij1] = false;
+              _ij1[1] = iij1;
+              break;
+            }
+          }
+          j1 = j1array[ij1];
+          cj1 = cj1array[ij1];
+          sj1 = sj1array[ij1];
+
+          {
+            IkReal dummyeval[1];
+            IkReal gconst12;
+            gconst12 = IKsign(sj1);
+            dummyeval[0] = sj1;
+            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+            {
+              {
+                IkReal dummyeval[1];
+                IkReal gconst13;
+                gconst13 = IKsign((((new_r12) * (new_r12)) + ((new_r02) * (new_r02))));
+                dummyeval[0] = (((new_r12) * (new_r12)) + ((new_r02) * (new_r02)));
+                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                {
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst14;
+                    gconst14 = IKsign(((((cj1) * ((new_r12) * (new_r12)))) + (((cj1) * ((new_r02) * (new_r02))))));
+                    dummyeval[0] = ((((cj1) * ((new_r12) * (new_r12)))) + (((cj1) * ((new_r02) * (new_r02)))));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal evalcond[7];
+                        evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                       (IKfmod(((IkReal(1.57079632679490)) + (j1)), IkReal(6.28318530717959))));
+                        evalcond[1] = new_r22;
+                        evalcond[2] = new_r22;
+                        if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                            IKabs(evalcond[2]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal j0array[1], cj0array[1], sj0array[1];
+                            bool j0valid[1] = { false };
+                            _nj0 = 1;
+                            if (IKabs(new_r21) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r20) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(IKsqr(new_r21) + IKsqr(new_r20) - 1) <= IKFAST_SINCOS_THRESH)
+                              continue;
+                            j0array[0] = IKatan2(new_r21, new_r20);
+                            sj0array[0] = IKsin(j0array[0]);
+                            cj0array[0] = IKcos(j0array[0]);
+                            if (j0array[0] > IKPI)
+                            {
+                              j0array[0] -= IK2PI;
+                            }
+                            else if (j0array[0] < -IKPI)
+                            {
+                              j0array[0] += IK2PI;
+                            }
+                            j0valid[0] = true;
+                            for (int ij0 = 0; ij0 < 1; ++ij0)
+                            {
+                              if (!j0valid[ij0])
+                              {
+                                continue;
+                              }
+                              _ij0[0] = ij0;
+                              _ij0[1] = -1;
+                              for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                              {
+                                if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j0valid[iij0] = false;
+                                  _ij0[1] = iij0;
+                                  break;
+                                }
+                              }
+                              j0 = j0array[ij0];
+                              cj0 = cj0array[ij0];
+                              sj0 = sj0array[ij0];
+                              {
+                                IkReal evalcond[2];
+                                evalcond[0] = ((((IkReal(-1.00000000000000)) * (IKcos(j0)))) + (new_r20));
+                                evalcond[1] = ((((IkReal(-1.00000000000000)) * (IKsin(j0)))) + (new_r21));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                IkReal dummyeval[1];
+                                IkReal gconst21;
+                                gconst21 = IKsign((((new_r12) * (new_r12)) + ((new_r02) * (new_r02))));
+                                dummyeval[0] = (((new_r12) * (new_r12)) + ((new_r02) * (new_r02)));
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal dummyeval[1];
+                                    IkReal gconst20;
+                                    gconst20 = IKsign(((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) +
+                                                       (((new_r02) * (new_r10)))));
+                                    dummyeval[0] = ((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) +
+                                                    (((new_r02) * (new_r10))));
+                                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                    {
+                                      continue;
+                                    }
+                                    else
+                                    {
+                                      {
+                                        IkReal j2array[1], cj2array[1], sj2array[1];
+                                        bool j2valid[1] = { false };
+                                        _nj2 = 1;
+                                        IkReal x98 = ((gconst20) * (sj0));
+                                        if (IKabs(((new_r12) * (x98))) < IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x98))) <
+                                                IKFAST_ATAN2_MAGTHRESH)
+                                          continue;
+                                        j2array[0] = IKatan2(((new_r12) * (x98)),
+                                                             ((IkReal(-1.00000000000000)) * (new_r02) * (x98)));
+                                        sj2array[0] = IKsin(j2array[0]);
+                                        cj2array[0] = IKcos(j2array[0]);
+                                        if (j2array[0] > IKPI)
+                                        {
+                                          j2array[0] -= IK2PI;
+                                        }
+                                        else if (j2array[0] < -IKPI)
+                                        {
+                                          j2array[0] += IK2PI;
+                                        }
+                                        j2valid[0] = true;
+                                        for (int ij2 = 0; ij2 < 1; ++ij2)
+                                        {
+                                          if (!j2valid[ij2])
+                                          {
+                                            continue;
+                                          }
+                                          _ij2[0] = ij2;
+                                          _ij2[1] = -1;
+                                          for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                                          {
+                                            if (j2valid[iij2] &&
+                                                IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                                IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                            {
+                                              j2valid[iij2] = false;
+                                              _ij2[1] = iij2;
+                                              break;
+                                            }
+                                          }
+                                          j2 = j2array[ij2];
+                                          cj2 = cj2array[ij2];
+                                          sj2 = sj2array[ij2];
+                                          {
+                                            IkReal evalcond[6];
+                                            IkReal x99 = IKsin(j2);
+                                            IkReal x100 = IKcos(j2);
+                                            IkReal x101 = ((IkReal(1.00000000000000)) * (x99));
+                                            evalcond[0] = ((((new_r02) * (x99))) + (((new_r12) * (x100))));
+                                            evalcond[1] = ((((new_r10) * (x100))) + (sj0) + (((new_r00) * (x99))));
+                                            evalcond[2] = ((IkReal(1.00000000000000)) + (((new_r02) * (x100))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r12) * (x101))));
+                                            evalcond[3] =
+                                                ((((new_r01) * (x99))) + (((IkReal(-1.00000000000000)) * (cj0))) +
+                                                 (((new_r11) * (x100))));
+                                            evalcond[4] = ((((IkReal(-1.00000000000000)) * (new_r10) * (x101))) +
+                                                           (((new_r00) * (x100))));
+                                            evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x101))) +
+                                                           (((new_r01) * (x100))));
+                                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                            {
+                                              continue;
+                                            }
+                                          }
+
+                                          {
+                                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                            vinfos[0].jointtype = 1;
+                                            vinfos[0].foffset = j0;
+                                            vinfos[0].indices[0] = _ij0[0];
+                                            vinfos[0].indices[1] = _ij0[1];
+                                            vinfos[0].maxsolutions = _nj0;
+                                            vinfos[1].jointtype = 1;
+                                            vinfos[1].foffset = j1;
+                                            vinfos[1].indices[0] = _ij1[0];
+                                            vinfos[1].indices[1] = _ij1[1];
+                                            vinfos[1].maxsolutions = _nj1;
+                                            vinfos[2].jointtype = 1;
+                                            vinfos[2].foffset = j2;
+                                            vinfos[2].indices[0] = _ij2[0];
+                                            vinfos[2].indices[1] = _ij2[1];
+                                            vinfos[2].maxsolutions = _nj2;
+                                            vinfos[3].jointtype = 1;
+                                            vinfos[3].foffset = j3;
+                                            vinfos[3].indices[0] = _ij3[0];
+                                            vinfos[3].indices[1] = _ij3[1];
+                                            vinfos[3].maxsolutions = _nj3;
+                                            vinfos[4].jointtype = 1;
+                                            vinfos[4].foffset = j4;
+                                            vinfos[4].indices[0] = _ij4[0];
+                                            vinfos[4].indices[1] = _ij4[1];
+                                            vinfos[4].maxsolutions = _nj4;
+                                            vinfos[5].jointtype = 1;
+                                            vinfos[5].foffset = j5;
+                                            vinfos[5].indices[0] = _ij5[0];
+                                            vinfos[5].indices[1] = _ij5[1];
+                                            vinfos[5].maxsolutions = _nj5;
+                                            vinfos[6].jointtype = 1;
+                                            vinfos[6].foffset = j6;
+                                            vinfos[6].indices[0] = _ij6[0];
+                                            vinfos[6].indices[1] = _ij6[1];
+                                            vinfos[6].maxsolutions = _nj6;
+                                            std::vector<int> vfree(0);
+                                            solutions.AddSolution(vinfos, vfree);
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j2array[1], cj2array[1], sj2array[1];
+                                    bool j2valid[1] = { false };
+                                    _nj2 = 1;
+                                    if (IKabs(((gconst21) * (new_r12))) < IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((IkReal(-1.00000000000000)) * (gconst21) * (new_r02))) <
+                                            IKFAST_ATAN2_MAGTHRESH)
+                                      continue;
+                                    j2array[0] = IKatan2(((gconst21) * (new_r12)),
+                                                         ((IkReal(-1.00000000000000)) * (gconst21) * (new_r02)));
+                                    sj2array[0] = IKsin(j2array[0]);
+                                    cj2array[0] = IKcos(j2array[0]);
+                                    if (j2array[0] > IKPI)
+                                    {
+                                      j2array[0] -= IK2PI;
+                                    }
+                                    else if (j2array[0] < -IKPI)
+                                    {
+                                      j2array[0] += IK2PI;
+                                    }
+                                    j2valid[0] = true;
+                                    for (int ij2 = 0; ij2 < 1; ++ij2)
+                                    {
+                                      if (!j2valid[ij2])
+                                      {
+                                        continue;
+                                      }
+                                      _ij2[0] = ij2;
+                                      _ij2[1] = -1;
+                                      for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                                      {
+                                        if (j2valid[iij2] &&
+                                            IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j2valid[iij2] = false;
+                                          _ij2[1] = iij2;
+                                          break;
+                                        }
+                                      }
+                                      j2 = j2array[ij2];
+                                      cj2 = cj2array[ij2];
+                                      sj2 = sj2array[ij2];
+                                      {
+                                        IkReal evalcond[6];
+                                        IkReal x102 = IKsin(j2);
+                                        IkReal x103 = IKcos(j2);
+                                        IkReal x104 = ((IkReal(1.00000000000000)) * (x102));
+                                        evalcond[0] = ((((new_r02) * (x102))) + (((new_r12) * (x103))));
+                                        evalcond[1] = ((((new_r10) * (x103))) + (sj0) + (((new_r00) * (x102))));
+                                        evalcond[2] = ((IkReal(1.00000000000000)) + (((new_r02) * (x103))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r12) * (x104))));
+                                        evalcond[3] =
+                                            ((((new_r01) * (x102))) + (((IkReal(-1.00000000000000)) * (cj0))) +
+                                             (((new_r11) * (x103))));
+                                        evalcond[4] = ((((IkReal(-1.00000000000000)) * (new_r10) * (x104))) +
+                                                       (((new_r00) * (x103))));
+                                        evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x104))) +
+                                                       (((new_r01) * (x103))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        vinfos[6].jointtype = 1;
+                                        vinfos[6].foffset = j6;
+                                        vinfos[6].indices[0] = _ij6[0];
+                                        vinfos[6].indices[1] = _ij6[1];
+                                        vinfos[6].maxsolutions = _nj6;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                         (IKfmod(((IkReal(4.71238898038469)) + (j1)), IkReal(6.28318530717959))));
+                          evalcond[1] = new_r22;
+                          evalcond[2] = ((IkReal(-1.00000000000000)) * (new_r22));
+                          if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                              IKabs(evalcond[2]) < 0.0000010000000000)
+                          {
+                            {
+                              IkReal j0array[1], cj0array[1], sj0array[1];
+                              bool j0valid[1] = { false };
+                              _nj0 = 1;
+                              if (IKabs(((IkReal(-1.00000000000000)) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                                  IKabs(((IkReal(-1.00000000000000)) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH &&
+                                  IKabs(IKsqr(((IkReal(-1.00000000000000)) * (new_r21))) +
+                                        IKsqr(((IkReal(-1.00000000000000)) * (new_r20))) - 1) <= IKFAST_SINCOS_THRESH)
+                                continue;
+                              j0array[0] = IKatan2(((IkReal(-1.00000000000000)) * (new_r21)),
+                                                   ((IkReal(-1.00000000000000)) * (new_r20)));
+                              sj0array[0] = IKsin(j0array[0]);
+                              cj0array[0] = IKcos(j0array[0]);
+                              if (j0array[0] > IKPI)
+                              {
+                                j0array[0] -= IK2PI;
+                              }
+                              else if (j0array[0] < -IKPI)
+                              {
+                                j0array[0] += IK2PI;
+                              }
+                              j0valid[0] = true;
+                              for (int ij0 = 0; ij0 < 1; ++ij0)
+                              {
+                                if (!j0valid[ij0])
+                                {
+                                  continue;
+                                }
+                                _ij0[0] = ij0;
+                                _ij0[1] = -1;
+                                for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                {
+                                  if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                      IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                  {
+                                    j0valid[iij0] = false;
+                                    _ij0[1] = iij0;
+                                    break;
+                                  }
+                                }
+                                j0 = j0array[ij0];
+                                cj0 = cj0array[ij0];
+                                sj0 = sj0array[ij0];
+                                {
+                                  IkReal evalcond[2];
+                                  evalcond[0] = ((IKcos(j0)) + (new_r20));
+                                  evalcond[1] = ((IKsin(j0)) + (new_r21));
+                                  if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001)
+                                  {
+                                    continue;
+                                  }
+                                }
+
+                                {
+                                  IkReal dummyeval[1];
+                                  IkReal gconst24;
+                                  gconst24 = IKsign(((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) +
+                                                     (((new_r02) * (new_r10)))));
+                                  dummyeval[0] = ((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) +
+                                                  (((new_r02) * (new_r10))));
+                                  if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                  {
+                                    {
+                                      IkReal dummyeval[1];
+                                      IkReal gconst25;
+                                      gconst25 = IKsign(((((IkReal(-1.00000000000000)) * ((new_r02) * (new_r02)))) +
+                                                         (((IkReal(-1.00000000000000)) * ((new_r12) * (new_r12))))));
+                                      dummyeval[0] = ((((IkReal(-1.00000000000000)) * ((new_r02) * (new_r02)))) +
+                                                      (((IkReal(-1.00000000000000)) * ((new_r12) * (new_r12)))));
+                                      if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                      {
+                                        continue;
+                                      }
+                                      else
+                                      {
+                                        {
+                                          IkReal j2array[1], cj2array[1], sj2array[1];
+                                          bool j2valid[1] = { false };
+                                          _nj2 = 1;
+                                          if (IKabs(((gconst25) * (new_r12))) < IKFAST_ATAN2_MAGTHRESH &&
+                                              IKabs(((IkReal(-1.00000000000000)) * (gconst25) * (new_r02))) <
+                                                  IKFAST_ATAN2_MAGTHRESH)
+                                            continue;
+                                          j2array[0] = IKatan2(((gconst25) * (new_r12)),
+                                                               ((IkReal(-1.00000000000000)) * (gconst25) * (new_r02)));
+                                          sj2array[0] = IKsin(j2array[0]);
+                                          cj2array[0] = IKcos(j2array[0]);
+                                          if (j2array[0] > IKPI)
+                                          {
+                                            j2array[0] -= IK2PI;
+                                          }
+                                          else if (j2array[0] < -IKPI)
+                                          {
+                                            j2array[0] += IK2PI;
+                                          }
+                                          j2valid[0] = true;
+                                          for (int ij2 = 0; ij2 < 1; ++ij2)
+                                          {
+                                            if (!j2valid[ij2])
+                                            {
+                                              continue;
+                                            }
+                                            _ij2[0] = ij2;
+                                            _ij2[1] = -1;
+                                            for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                                            {
+                                              if (j2valid[iij2] &&
+                                                  IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                                  IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                              {
+                                                j2valid[iij2] = false;
+                                                _ij2[1] = iij2;
+                                                break;
+                                              }
+                                            }
+                                            j2 = j2array[ij2];
+                                            cj2 = cj2array[ij2];
+                                            sj2 = sj2array[ij2];
+                                            {
+                                              IkReal evalcond[6];
+                                              IkReal x105 = IKsin(j2);
+                                              IkReal x106 = IKcos(j2);
+                                              IkReal x107 = ((IkReal(1.00000000000000)) * (x105));
+                                              evalcond[0] = ((((new_r02) * (x105))) + (((new_r12) * (x106))));
+                                              evalcond[1] = ((((new_r10) * (x106))) + (sj0) + (((new_r00) * (x105))));
+                                              evalcond[2] = ((IkReal(-1.00000000000000)) + (((new_r02) * (x106))) +
+                                                             (((IkReal(-1.00000000000000)) * (new_r12) * (x107))));
+                                              evalcond[3] =
+                                                  ((((new_r01) * (x105))) + (((IkReal(-1.00000000000000)) * (cj0))) +
+                                                   (((new_r11) * (x106))));
+                                              evalcond[4] = ((((IkReal(-1.00000000000000)) * (new_r10) * (x107))) +
+                                                             (((new_r00) * (x106))));
+                                              evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x107))) +
+                                                             (((new_r01) * (x106))));
+                                              if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                  IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                                  IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                              {
+                                                continue;
+                                              }
+                                            }
+
+                                            {
+                                              std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                              vinfos[0].jointtype = 1;
+                                              vinfos[0].foffset = j0;
+                                              vinfos[0].indices[0] = _ij0[0];
+                                              vinfos[0].indices[1] = _ij0[1];
+                                              vinfos[0].maxsolutions = _nj0;
+                                              vinfos[1].jointtype = 1;
+                                              vinfos[1].foffset = j1;
+                                              vinfos[1].indices[0] = _ij1[0];
+                                              vinfos[1].indices[1] = _ij1[1];
+                                              vinfos[1].maxsolutions = _nj1;
+                                              vinfos[2].jointtype = 1;
+                                              vinfos[2].foffset = j2;
+                                              vinfos[2].indices[0] = _ij2[0];
+                                              vinfos[2].indices[1] = _ij2[1];
+                                              vinfos[2].maxsolutions = _nj2;
+                                              vinfos[3].jointtype = 1;
+                                              vinfos[3].foffset = j3;
+                                              vinfos[3].indices[0] = _ij3[0];
+                                              vinfos[3].indices[1] = _ij3[1];
+                                              vinfos[3].maxsolutions = _nj3;
+                                              vinfos[4].jointtype = 1;
+                                              vinfos[4].foffset = j4;
+                                              vinfos[4].indices[0] = _ij4[0];
+                                              vinfos[4].indices[1] = _ij4[1];
+                                              vinfos[4].maxsolutions = _nj4;
+                                              vinfos[5].jointtype = 1;
+                                              vinfos[5].foffset = j5;
+                                              vinfos[5].indices[0] = _ij5[0];
+                                              vinfos[5].indices[1] = _ij5[1];
+                                              vinfos[5].maxsolutions = _nj5;
+                                              vinfos[6].jointtype = 1;
+                                              vinfos[6].foffset = j6;
+                                              vinfos[6].indices[0] = _ij6[0];
+                                              vinfos[6].indices[1] = _ij6[1];
+                                              vinfos[6].maxsolutions = _nj6;
+                                              std::vector<int> vfree(0);
+                                              solutions.AddSolution(vinfos, vfree);
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                  else
+                                  {
+                                    {
+                                      IkReal j2array[1], cj2array[1], sj2array[1];
+                                      bool j2valid[1] = { false };
+                                      _nj2 = 1;
+                                      IkReal x108 = ((gconst24) * (sj0));
+                                      if (IKabs(((new_r12) * (x108))) < IKFAST_ATAN2_MAGTHRESH &&
+                                          IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x108))) <
+                                              IKFAST_ATAN2_MAGTHRESH)
+                                        continue;
+                                      j2array[0] = IKatan2(((new_r12) * (x108)),
+                                                           ((IkReal(-1.00000000000000)) * (new_r02) * (x108)));
+                                      sj2array[0] = IKsin(j2array[0]);
+                                      cj2array[0] = IKcos(j2array[0]);
+                                      if (j2array[0] > IKPI)
+                                      {
+                                        j2array[0] -= IK2PI;
+                                      }
+                                      else if (j2array[0] < -IKPI)
+                                      {
+                                        j2array[0] += IK2PI;
+                                      }
+                                      j2valid[0] = true;
+                                      for (int ij2 = 0; ij2 < 1; ++ij2)
+                                      {
+                                        if (!j2valid[ij2])
+                                        {
+                                          continue;
+                                        }
+                                        _ij2[0] = ij2;
+                                        _ij2[1] = -1;
+                                        for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                                        {
+                                          if (j2valid[iij2] &&
+                                              IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                              IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                          {
+                                            j2valid[iij2] = false;
+                                            _ij2[1] = iij2;
+                                            break;
+                                          }
+                                        }
+                                        j2 = j2array[ij2];
+                                        cj2 = cj2array[ij2];
+                                        sj2 = sj2array[ij2];
+                                        {
+                                          IkReal evalcond[6];
+                                          IkReal x109 = IKsin(j2);
+                                          IkReal x110 = IKcos(j2);
+                                          IkReal x111 = ((IkReal(1.00000000000000)) * (x109));
+                                          evalcond[0] = ((((new_r02) * (x109))) + (((new_r12) * (x110))));
+                                          evalcond[1] = ((((new_r10) * (x110))) + (sj0) + (((new_r00) * (x109))));
+                                          evalcond[2] = ((IkReal(-1.00000000000000)) + (((new_r02) * (x110))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r12) * (x111))));
+                                          evalcond[3] = ((((new_r11) * (x110))) + (((new_r01) * (x109))) +
+                                                         (((IkReal(-1.00000000000000)) * (cj0))));
+                                          evalcond[4] = ((((IkReal(-1.00000000000000)) * (new_r10) * (x111))) +
+                                                         (((new_r00) * (x110))));
+                                          evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x111))) +
+                                                         (((new_r01) * (x110))));
+                                          if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                              IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                              IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                          {
+                                            continue;
+                                          }
+                                        }
+
+                                        {
+                                          std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                          vinfos[0].jointtype = 1;
+                                          vinfos[0].foffset = j0;
+                                          vinfos[0].indices[0] = _ij0[0];
+                                          vinfos[0].indices[1] = _ij0[1];
+                                          vinfos[0].maxsolutions = _nj0;
+                                          vinfos[1].jointtype = 1;
+                                          vinfos[1].foffset = j1;
+                                          vinfos[1].indices[0] = _ij1[0];
+                                          vinfos[1].indices[1] = _ij1[1];
+                                          vinfos[1].maxsolutions = _nj1;
+                                          vinfos[2].jointtype = 1;
+                                          vinfos[2].foffset = j2;
+                                          vinfos[2].indices[0] = _ij2[0];
+                                          vinfos[2].indices[1] = _ij2[1];
+                                          vinfos[2].maxsolutions = _nj2;
+                                          vinfos[3].jointtype = 1;
+                                          vinfos[3].foffset = j3;
+                                          vinfos[3].indices[0] = _ij3[0];
+                                          vinfos[3].indices[1] = _ij3[1];
+                                          vinfos[3].maxsolutions = _nj3;
+                                          vinfos[4].jointtype = 1;
+                                          vinfos[4].foffset = j4;
+                                          vinfos[4].indices[0] = _ij4[0];
+                                          vinfos[4].indices[1] = _ij4[1];
+                                          vinfos[4].maxsolutions = _nj4;
+                                          vinfos[5].jointtype = 1;
+                                          vinfos[5].foffset = j5;
+                                          vinfos[5].indices[0] = _ij5[0];
+                                          vinfos[5].indices[1] = _ij5[1];
+                                          vinfos[5].maxsolutions = _nj5;
+                                          vinfos[6].jointtype = 1;
+                                          vinfos[6].foffset = j6;
+                                          vinfos[6].indices[0] = _ij6[0];
+                                          vinfos[6].indices[1] = _ij6[1];
+                                          vinfos[6].maxsolutions = _nj6;
+                                          std::vector<int> vfree(0);
+                                          solutions.AddSolution(vinfos, vfree);
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                          else
+                          {
+                            evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                           (IKfmod(((IkReal(3.14159265358979)) + (j1)), IkReal(6.28318530717959))));
+                            evalcond[1] = ((IkReal(-1.00000000000000)) + (new_r22));
+                            evalcond[2] = new_r20;
+                            evalcond[3] = new_r21;
+                            evalcond[4] = ((IkReal(-1.00000000000000)) * (new_r20));
+                            evalcond[5] = ((IkReal(-1.00000000000000)) * (new_r21));
+                            evalcond[6] = ((IkReal(1.00000000000000)) + (((IkReal(-1.00000000000000)) * (new_r22))));
+                            if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                IKabs(evalcond[2]) < 0.0000010000000000 && IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                IKabs(evalcond[4]) < 0.0000010000000000 && IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                IKabs(evalcond[6]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal j2array[2], cj2array[2], sj2array[2];
+                                bool j2valid[2] = { false };
+                                _nj2 = 2;
+                                if (IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                IkReal x112 = IKatan2(new_r12, new_r02);
+                                j2array[0] = ((IkReal(-1.00000000000000)) * (x112));
+                                sj2array[0] = IKsin(j2array[0]);
+                                cj2array[0] = IKcos(j2array[0]);
+                                j2array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x112))));
+                                sj2array[1] = IKsin(j2array[1]);
+                                cj2array[1] = IKcos(j2array[1]);
+                                if (j2array[0] > IKPI)
+                                {
+                                  j2array[0] -= IK2PI;
+                                }
+                                else if (j2array[0] < -IKPI)
+                                {
+                                  j2array[0] += IK2PI;
+                                }
+                                j2valid[0] = true;
+                                if (j2array[1] > IKPI)
+                                {
+                                  j2array[1] -= IK2PI;
+                                }
+                                else if (j2array[1] < -IKPI)
+                                {
+                                  j2array[1] += IK2PI;
+                                }
+                                j2valid[1] = true;
+                                for (int ij2 = 0; ij2 < 2; ++ij2)
+                                {
+                                  if (!j2valid[ij2])
+                                  {
+                                    continue;
+                                  }
+                                  _ij2[0] = ij2;
+                                  _ij2[1] = -1;
+                                  for (int iij2 = ij2 + 1; iij2 < 2; ++iij2)
+                                  {
+                                    if (j2valid[iij2] &&
+                                        IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j2valid[iij2] = false;
+                                      _ij2[1] = iij2;
+                                      break;
+                                    }
+                                  }
+                                  j2 = j2array[ij2];
+                                  cj2 = cj2array[ij2];
+                                  sj2 = sj2array[ij2];
+                                  {
+                                    IkReal evalcond[1];
+                                    evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r12) * (IKsin(j2)))) +
+                                                   (((new_r02) * (IKcos(j2)))));
+                                    if (IKabs(evalcond[0]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    IkReal j0array[1], cj0array[1], sj0array[1];
+                                    bool j0valid[1] = { false };
+                                    _nj0 = 1;
+                                    if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                              IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                            IKFAST_SINCOS_THRESH)
+                                      continue;
+                                    j0array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                          (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                         ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                    sj0array[0] = IKsin(j0array[0]);
+                                    cj0array[0] = IKcos(j0array[0]);
+                                    if (j0array[0] > IKPI)
+                                    {
+                                      j0array[0] -= IK2PI;
+                                    }
+                                    else if (j0array[0] < -IKPI)
+                                    {
+                                      j0array[0] += IK2PI;
+                                    }
+                                    j0valid[0] = true;
+                                    for (int ij0 = 0; ij0 < 1; ++ij0)
+                                    {
+                                      if (!j0valid[ij0])
+                                      {
+                                        continue;
+                                      }
+                                      _ij0[0] = ij0;
+                                      _ij0[1] = -1;
+                                      for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                      {
+                                        if (j0valid[iij0] &&
+                                            IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j0valid[iij0] = false;
+                                          _ij0[1] = iij0;
+                                          break;
+                                        }
+                                      }
+                                      j0 = j0array[ij0];
+                                      cj0 = cj0array[ij0];
+                                      sj0 = sj0array[ij0];
+                                      {
+                                        IkReal evalcond[4];
+                                        IkReal x113 = IKsin(j0);
+                                        IkReal x114 = ((IkReal(1.00000000000000)) * (sj2));
+                                        IkReal x115 = ((IkReal(1.00000000000000)) * (IKcos(j0)));
+                                        evalcond[0] = ((((new_r00) * (sj2))) + (x113) + (((cj2) * (new_r10))));
+                                        evalcond[1] =
+                                            ((((new_r01) * (sj2))) + (((IkReal(-1.00000000000000)) * (x115))) +
+                                             (((cj2) * (new_r11))));
+                                        evalcond[2] =
+                                            ((((IkReal(-1.00000000000000)) * (new_r10) * (x114))) +
+                                             (((IkReal(-1.00000000000000)) * (x115))) + (((cj2) * (new_r00))));
+                                        evalcond[3] =
+                                            ((((IkReal(-1.00000000000000)) * (new_r11) * (x114))) +
+                                             (((cj2) * (new_r01))) + (((IkReal(-1.00000000000000)) * (x113))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        vinfos[6].jointtype = 1;
+                                        vinfos[6].foffset = j6;
+                                        vinfos[6].indices[0] = _ij6[0];
+                                        vinfos[6].indices[1] = _ij6[1];
+                                        vinfos[6].maxsolutions = _nj6;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              IkReal x116 = ((IkReal(1.00000000000000)) + (new_r22));
+                              evalcond[0] =
+                                  ((IkReal(-3.14159265358979)) +
+                                   (IKfmod(((IkReal(1.11022302462516e-16)) + (j1)), IkReal(6.28318530717959))));
+                              evalcond[1] = x116;
+                              evalcond[2] = new_r20;
+                              evalcond[3] = new_r21;
+                              evalcond[4] = new_r20;
+                              evalcond[5] = new_r21;
+                              evalcond[6] = x116;
+                              if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                  IKabs(evalcond[2]) < 0.0000010000000000 && IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                  IKabs(evalcond[4]) < 0.0000010000000000 && IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                  IKabs(evalcond[6]) < 0.0000010000000000)
+                              {
+                                {
+                                  IkReal j2array[2], cj2array[2], sj2array[2];
+                                  bool j2valid[2] = { false };
+                                  _nj2 = 2;
+                                  if (IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH &&
+                                      IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH)
+                                    continue;
+                                  IkReal x117 = IKatan2(new_r12, new_r02);
+                                  j2array[0] = ((IkReal(-1.00000000000000)) * (x117));
+                                  sj2array[0] = IKsin(j2array[0]);
+                                  cj2array[0] = IKcos(j2array[0]);
+                                  j2array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x117))));
+                                  sj2array[1] = IKsin(j2array[1]);
+                                  cj2array[1] = IKcos(j2array[1]);
+                                  if (j2array[0] > IKPI)
+                                  {
+                                    j2array[0] -= IK2PI;
+                                  }
+                                  else if (j2array[0] < -IKPI)
+                                  {
+                                    j2array[0] += IK2PI;
+                                  }
+                                  j2valid[0] = true;
+                                  if (j2array[1] > IKPI)
+                                  {
+                                    j2array[1] -= IK2PI;
+                                  }
+                                  else if (j2array[1] < -IKPI)
+                                  {
+                                    j2array[1] += IK2PI;
+                                  }
+                                  j2valid[1] = true;
+                                  for (int ij2 = 0; ij2 < 2; ++ij2)
+                                  {
+                                    if (!j2valid[ij2])
+                                    {
+                                      continue;
+                                    }
+                                    _ij2[0] = ij2;
+                                    _ij2[1] = -1;
+                                    for (int iij2 = ij2 + 1; iij2 < 2; ++iij2)
+                                    {
+                                      if (j2valid[iij2] &&
+                                          IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                          IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                      {
+                                        j2valid[iij2] = false;
+                                        _ij2[1] = iij2;
+                                        break;
+                                      }
+                                    }
+                                    j2 = j2array[ij2];
+                                    cj2 = cj2array[ij2];
+                                    sj2 = sj2array[ij2];
+                                    {
+                                      IkReal evalcond[1];
+                                      evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r12) * (IKsin(j2)))) +
+                                                     (((new_r02) * (IKcos(j2)))));
+                                      if (IKabs(evalcond[0]) > 0.000001)
+                                      {
+                                        continue;
+                                      }
+                                    }
+
+                                    {
+                                      IkReal j0array[1], cj0array[1], sj0array[1];
+                                      bool j0valid[1] = { false };
+                                      _nj0 = 1;
+                                      if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                 (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                              IKFAST_ATAN2_MAGTHRESH &&
+                                          IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                              IKFAST_ATAN2_MAGTHRESH &&
+                                          IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                              IKFAST_SINCOS_THRESH)
+                                        continue;
+                                      j0array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                            (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                           ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                      sj0array[0] = IKsin(j0array[0]);
+                                      cj0array[0] = IKcos(j0array[0]);
+                                      if (j0array[0] > IKPI)
+                                      {
+                                        j0array[0] -= IK2PI;
+                                      }
+                                      else if (j0array[0] < -IKPI)
+                                      {
+                                        j0array[0] += IK2PI;
+                                      }
+                                      j0valid[0] = true;
+                                      for (int ij0 = 0; ij0 < 1; ++ij0)
+                                      {
+                                        if (!j0valid[ij0])
+                                        {
+                                          continue;
+                                        }
+                                        _ij0[0] = ij0;
+                                        _ij0[1] = -1;
+                                        for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                        {
+                                          if (j0valid[iij0] &&
+                                              IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                              IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                          {
+                                            j0valid[iij0] = false;
+                                            _ij0[1] = iij0;
+                                            break;
+                                          }
+                                        }
+                                        j0 = j0array[ij0];
+                                        cj0 = cj0array[ij0];
+                                        sj0 = sj0array[ij0];
+                                        {
+                                          IkReal evalcond[4];
+                                          IkReal x118 = IKcos(j0);
+                                          IkReal x119 = IKsin(j0);
+                                          IkReal x120 = ((IkReal(1.00000000000000)) * (sj2));
+                                          evalcond[0] = ((((new_r00) * (sj2))) + (x119) + (((cj2) * (new_r10))));
+                                          evalcond[1] = ((((new_r01) * (sj2))) + (((cj2) * (new_r11))) +
+                                                         (((IkReal(-1.00000000000000)) * (x118))));
+                                          evalcond[2] = ((((IkReal(-1.00000000000000)) * (new_r10) * (x120))) + (x118) +
+                                                         (((cj2) * (new_r00))));
+                                          evalcond[3] = ((x119) + (((cj2) * (new_r01))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r11) * (x120))));
+                                          if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                              IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                          {
+                                            continue;
+                                          }
+                                        }
+
+                                        {
+                                          std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                          vinfos[0].jointtype = 1;
+                                          vinfos[0].foffset = j0;
+                                          vinfos[0].indices[0] = _ij0[0];
+                                          vinfos[0].indices[1] = _ij0[1];
+                                          vinfos[0].maxsolutions = _nj0;
+                                          vinfos[1].jointtype = 1;
+                                          vinfos[1].foffset = j1;
+                                          vinfos[1].indices[0] = _ij1[0];
+                                          vinfos[1].indices[1] = _ij1[1];
+                                          vinfos[1].maxsolutions = _nj1;
+                                          vinfos[2].jointtype = 1;
+                                          vinfos[2].foffset = j2;
+                                          vinfos[2].indices[0] = _ij2[0];
+                                          vinfos[2].indices[1] = _ij2[1];
+                                          vinfos[2].maxsolutions = _nj2;
+                                          vinfos[3].jointtype = 1;
+                                          vinfos[3].foffset = j3;
+                                          vinfos[3].indices[0] = _ij3[0];
+                                          vinfos[3].indices[1] = _ij3[1];
+                                          vinfos[3].maxsolutions = _nj3;
+                                          vinfos[4].jointtype = 1;
+                                          vinfos[4].foffset = j4;
+                                          vinfos[4].indices[0] = _ij4[0];
+                                          vinfos[4].indices[1] = _ij4[1];
+                                          vinfos[4].maxsolutions = _nj4;
+                                          vinfos[5].jointtype = 1;
+                                          vinfos[5].foffset = j5;
+                                          vinfos[5].indices[0] = _ij5[0];
+                                          vinfos[5].indices[1] = _ij5[1];
+                                          vinfos[5].maxsolutions = _nj5;
+                                          vinfos[6].jointtype = 1;
+                                          vinfos[6].foffset = j6;
+                                          vinfos[6].indices[0] = _ij6[0];
+                                          vinfos[6].indices[1] = _ij6[1];
+                                          vinfos[6].maxsolutions = _nj6;
+                                          std::vector<int> vfree(0);
+                                          solutions.AddSolution(vinfos, vfree);
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                              else
+                              {
+                                if (1)
+                                {
+                                  continue;
+                                }
+                                else
+                                {
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j2array[1], cj2array[1], sj2array[1];
+                        bool j2valid[1] = { false };
+                        _nj2 = 1;
+                        IkReal x121 = ((gconst14) * (new_r22) * (sj1));
+                        if (IKabs(((new_r12) * (x121))) < IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x121))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j2array[0] = IKatan2(((new_r12) * (x121)), ((IkReal(-1.00000000000000)) * (new_r02) * (x121)));
+                        sj2array[0] = IKsin(j2array[0]);
+                        cj2array[0] = IKcos(j2array[0]);
+                        if (j2array[0] > IKPI)
+                        {
+                          j2array[0] -= IK2PI;
+                        }
+                        else if (j2array[0] < -IKPI)
+                        {
+                          j2array[0] += IK2PI;
+                        }
+                        j2valid[0] = true;
+                        for (int ij2 = 0; ij2 < 1; ++ij2)
+                        {
+                          if (!j2valid[ij2])
+                          {
+                            continue;
+                          }
+                          _ij2[0] = ij2;
+                          _ij2[1] = -1;
+                          for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                          {
+                            if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j2valid[iij2] = false;
+                              _ij2[1] = iij2;
+                              break;
+                            }
+                          }
+                          j2 = j2array[ij2];
+                          cj2 = cj2array[ij2];
+                          sj2 = sj2array[ij2];
+                          {
+                            IkReal evalcond[6];
+                            IkReal x122 = IKcos(j2);
+                            IkReal x123 = IKsin(j2);
+                            IkReal x124 = ((IkReal(1.00000000000000)) * (cj1));
+                            IkReal x125 = ((sj1) * (x122));
+                            IkReal x126 = ((new_r12) * (x123));
+                            IkReal x127 = ((new_r02) * (x122));
+                            IkReal x128 = ((IkReal(1.00000000000000)) * (sj1) * (x123));
+                            evalcond[0] = ((((new_r02) * (x123))) + (((new_r12) * (x122))));
+                            evalcond[1] = ((sj1) + (x127) + (((IkReal(-1.00000000000000)) * (x126))));
+                            evalcond[2] = ((((cj1) * (x127))) + (((IkReal(-1.00000000000000)) * (x124) * (x126))) +
+                                           (((new_r22) * (sj1))));
+                            evalcond[3] =
+                                ((((IkReal(-1.00000000000000)) * (new_r10) * (x128))) + (((new_r00) * (x125))) +
+                                 (((IkReal(-1.00000000000000)) * (new_r20) * (x124))));
+                            evalcond[4] =
+                                ((((new_r01) * (x125))) + (((IkReal(-1.00000000000000)) * (new_r21) * (x124))) +
+                                 (((IkReal(-1.00000000000000)) * (new_r11) * (x128))));
+                            evalcond[5] =
+                                ((IkReal(1.00000000000000)) + (((IkReal(-1.00000000000000)) * (sj1) * (x126))) +
+                                 (((new_r02) * (x125))) + (((IkReal(-1.00000000000000)) * (new_r22) * (x124))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          {
+                            IkReal dummyeval[1];
+                            IkReal gconst15;
+                            gconst15 = IKsign(sj1);
+                            dummyeval[0] = sj1;
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal dummyeval[1];
+                                dummyeval[0] = sj1;
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal dummyeval[1];
+                                    dummyeval[0] = sj1;
+                                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                    {
+                                      {
+                                        IkReal evalcond[11];
+                                        IkReal x129 = ((((new_r02) * (sj2))) + (((cj2) * (new_r12))));
+                                        IkReal x130 = ((((cj2) * (new_r02))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r12) * (sj2))));
+                                        evalcond[0] =
+                                            ((IkReal(-3.14159265358979)) +
+                                             (IKfmod(((IkReal(3.14159265358979)) + (j1)), IkReal(6.28318530717959))));
+                                        evalcond[1] = ((IkReal(-1.00000000000000)) + (new_r22));
+                                        evalcond[2] = new_r20;
+                                        evalcond[3] = new_r21;
+                                        evalcond[4] = x129;
+                                        evalcond[5] = x129;
+                                        evalcond[6] = x130;
+                                        evalcond[7] = x130;
+                                        evalcond[8] = ((IkReal(-1.00000000000000)) * (new_r20));
+                                        evalcond[9] = ((IkReal(-1.00000000000000)) * (new_r21));
+                                        evalcond[10] =
+                                            ((IkReal(1.00000000000000)) + (((IkReal(-1.00000000000000)) * (new_r22))));
+                                        if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[10]) < 0.0000010000000000)
+                                        {
+                                          {
+                                            IkReal j0array[1], cj0array[1], sj0array[1];
+                                            bool j0valid[1] = { false };
+                                            _nj0 = 1;
+                                            if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                             (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                      IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                                    IKFAST_SINCOS_THRESH)
+                                              continue;
+                                            j0array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                                  (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                                 ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                            sj0array[0] = IKsin(j0array[0]);
+                                            cj0array[0] = IKcos(j0array[0]);
+                                            if (j0array[0] > IKPI)
+                                            {
+                                              j0array[0] -= IK2PI;
+                                            }
+                                            else if (j0array[0] < -IKPI)
+                                            {
+                                              j0array[0] += IK2PI;
+                                            }
+                                            j0valid[0] = true;
+                                            for (int ij0 = 0; ij0 < 1; ++ij0)
+                                            {
+                                              if (!j0valid[ij0])
+                                              {
+                                                continue;
+                                              }
+                                              _ij0[0] = ij0;
+                                              _ij0[1] = -1;
+                                              for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                              {
+                                                if (j0valid[iij0] &&
+                                                    IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                                    IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                                {
+                                                  j0valid[iij0] = false;
+                                                  _ij0[1] = iij0;
+                                                  break;
+                                                }
+                                              }
+                                              j0 = j0array[ij0];
+                                              cj0 = cj0array[ij0];
+                                              sj0 = sj0array[ij0];
+                                              {
+                                                IkReal evalcond[4];
+                                                IkReal x131 = IKsin(j0);
+                                                IkReal x132 = ((IkReal(1.00000000000000)) * (sj2));
+                                                IkReal x133 = ((IkReal(1.00000000000000)) * (IKcos(j0)));
+                                                evalcond[0] = ((((new_r00) * (sj2))) + (x131) + (((cj2) * (new_r10))));
+                                                evalcond[1] =
+                                                    ((((new_r01) * (sj2))) + (((IkReal(-1.00000000000000)) * (x133))) +
+                                                     (((cj2) * (new_r11))));
+                                                evalcond[2] =
+                                                    ((((IkReal(-1.00000000000000)) * (new_r10) * (x132))) +
+                                                     (((IkReal(-1.00000000000000)) * (x133))) + (((cj2) * (new_r00))));
+                                                evalcond[3] =
+                                                    ((((IkReal(-1.00000000000000)) * (new_r11) * (x132))) +
+                                                     (((cj2) * (new_r01))) + (((IkReal(-1.00000000000000)) * (x131))));
+                                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                {
+                                                  continue;
+                                                }
+                                              }
+
+                                              {
+                                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                                vinfos[0].jointtype = 1;
+                                                vinfos[0].foffset = j0;
+                                                vinfos[0].indices[0] = _ij0[0];
+                                                vinfos[0].indices[1] = _ij0[1];
+                                                vinfos[0].maxsolutions = _nj0;
+                                                vinfos[1].jointtype = 1;
+                                                vinfos[1].foffset = j1;
+                                                vinfos[1].indices[0] = _ij1[0];
+                                                vinfos[1].indices[1] = _ij1[1];
+                                                vinfos[1].maxsolutions = _nj1;
+                                                vinfos[2].jointtype = 1;
+                                                vinfos[2].foffset = j2;
+                                                vinfos[2].indices[0] = _ij2[0];
+                                                vinfos[2].indices[1] = _ij2[1];
+                                                vinfos[2].maxsolutions = _nj2;
+                                                vinfos[3].jointtype = 1;
+                                                vinfos[3].foffset = j3;
+                                                vinfos[3].indices[0] = _ij3[0];
+                                                vinfos[3].indices[1] = _ij3[1];
+                                                vinfos[3].maxsolutions = _nj3;
+                                                vinfos[4].jointtype = 1;
+                                                vinfos[4].foffset = j4;
+                                                vinfos[4].indices[0] = _ij4[0];
+                                                vinfos[4].indices[1] = _ij4[1];
+                                                vinfos[4].maxsolutions = _nj4;
+                                                vinfos[5].jointtype = 1;
+                                                vinfos[5].foffset = j5;
+                                                vinfos[5].indices[0] = _ij5[0];
+                                                vinfos[5].indices[1] = _ij5[1];
+                                                vinfos[5].maxsolutions = _nj5;
+                                                vinfos[6].jointtype = 1;
+                                                vinfos[6].foffset = j6;
+                                                vinfos[6].indices[0] = _ij6[0];
+                                                vinfos[6].indices[1] = _ij6[1];
+                                                vinfos[6].maxsolutions = _nj6;
+                                                std::vector<int> vfree(0);
+                                                solutions.AddSolution(vinfos, vfree);
+                                              }
+                                            }
+                                          }
+                                        }
+                                        else
+                                        {
+                                          IkReal x134 = ((IkReal(1.00000000000000)) + (new_r22));
+                                          IkReal x135 = ((new_r12) * (sj2));
+                                          IkReal x136 = ((cj2) * (new_r02));
+                                          IkReal x137 = ((((new_r02) * (sj2))) + (((cj2) * (new_r12))));
+                                          evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                         (IKfmod(((IkReal(1.11022302462516e-16)) + (j1)),
+                                                                 IkReal(6.28318530717959))));
+                                          evalcond[1] = x134;
+                                          evalcond[2] = new_r20;
+                                          evalcond[3] = new_r21;
+                                          evalcond[4] = x137;
+                                          evalcond[5] = x137;
+                                          evalcond[6] = ((x136) + (((IkReal(-1.00000000000000)) * (x135))));
+                                          evalcond[7] = ((x135) + (((IkReal(-1.00000000000000)) * (x136))));
+                                          evalcond[8] = new_r20;
+                                          evalcond[9] = new_r21;
+                                          evalcond[10] = x134;
+                                          if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[10]) < 0.0000010000000000)
+                                          {
+                                            {
+                                              IkReal j0array[1], cj0array[1], sj0array[1];
+                                              bool j0valid[1] = { false };
+                                              _nj0 = 1;
+                                              if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                                      IKFAST_ATAN2_MAGTHRESH &&
+                                                  IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                                      IKFAST_ATAN2_MAGTHRESH &&
+                                                  IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                               (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                        IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                                      IKFAST_SINCOS_THRESH)
+                                                continue;
+                                              j0array[0] =
+                                                  IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                          ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                              sj0array[0] = IKsin(j0array[0]);
+                                              cj0array[0] = IKcos(j0array[0]);
+                                              if (j0array[0] > IKPI)
+                                              {
+                                                j0array[0] -= IK2PI;
+                                              }
+                                              else if (j0array[0] < -IKPI)
+                                              {
+                                                j0array[0] += IK2PI;
+                                              }
+                                              j0valid[0] = true;
+                                              for (int ij0 = 0; ij0 < 1; ++ij0)
+                                              {
+                                                if (!j0valid[ij0])
+                                                {
+                                                  continue;
+                                                }
+                                                _ij0[0] = ij0;
+                                                _ij0[1] = -1;
+                                                for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                                {
+                                                  if (j0valid[iij0] &&
+                                                      IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                                      IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                                  {
+                                                    j0valid[iij0] = false;
+                                                    _ij0[1] = iij0;
+                                                    break;
+                                                  }
+                                                }
+                                                j0 = j0array[ij0];
+                                                cj0 = cj0array[ij0];
+                                                sj0 = sj0array[ij0];
+                                                {
+                                                  IkReal evalcond[4];
+                                                  IkReal x138 = IKcos(j0);
+                                                  IkReal x139 = IKsin(j0);
+                                                  IkReal x140 = ((IkReal(1.00000000000000)) * (sj2));
+                                                  evalcond[0] =
+                                                      ((((new_r00) * (sj2))) + (x139) + (((cj2) * (new_r10))));
+                                                  evalcond[1] = ((((new_r01) * (sj2))) + (((cj2) * (new_r11))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x138))));
+                                                  evalcond[2] =
+                                                      ((x138) + (((IkReal(-1.00000000000000)) * (new_r10) * (x140))) +
+                                                       (((cj2) * (new_r00))));
+                                                  evalcond[3] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x140))) +
+                                                                 (x139) + (((cj2) * (new_r01))));
+                                                  if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                      IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                  {
+                                                    continue;
+                                                  }
+                                                }
+
+                                                {
+                                                  std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                                  vinfos[0].jointtype = 1;
+                                                  vinfos[0].foffset = j0;
+                                                  vinfos[0].indices[0] = _ij0[0];
+                                                  vinfos[0].indices[1] = _ij0[1];
+                                                  vinfos[0].maxsolutions = _nj0;
+                                                  vinfos[1].jointtype = 1;
+                                                  vinfos[1].foffset = j1;
+                                                  vinfos[1].indices[0] = _ij1[0];
+                                                  vinfos[1].indices[1] = _ij1[1];
+                                                  vinfos[1].maxsolutions = _nj1;
+                                                  vinfos[2].jointtype = 1;
+                                                  vinfos[2].foffset = j2;
+                                                  vinfos[2].indices[0] = _ij2[0];
+                                                  vinfos[2].indices[1] = _ij2[1];
+                                                  vinfos[2].maxsolutions = _nj2;
+                                                  vinfos[3].jointtype = 1;
+                                                  vinfos[3].foffset = j3;
+                                                  vinfos[3].indices[0] = _ij3[0];
+                                                  vinfos[3].indices[1] = _ij3[1];
+                                                  vinfos[3].maxsolutions = _nj3;
+                                                  vinfos[4].jointtype = 1;
+                                                  vinfos[4].foffset = j4;
+                                                  vinfos[4].indices[0] = _ij4[0];
+                                                  vinfos[4].indices[1] = _ij4[1];
+                                                  vinfos[4].maxsolutions = _nj4;
+                                                  vinfos[5].jointtype = 1;
+                                                  vinfos[5].foffset = j5;
+                                                  vinfos[5].indices[0] = _ij5[0];
+                                                  vinfos[5].indices[1] = _ij5[1];
+                                                  vinfos[5].maxsolutions = _nj5;
+                                                  vinfos[6].jointtype = 1;
+                                                  vinfos[6].foffset = j6;
+                                                  vinfos[6].indices[0] = _ij6[0];
+                                                  vinfos[6].indices[1] = _ij6[1];
+                                                  vinfos[6].maxsolutions = _nj6;
+                                                  std::vector<int> vfree(0);
+                                                  solutions.AddSolution(vinfos, vfree);
+                                                }
+                                              }
+                                            }
+                                          }
+                                          else
+                                          {
+                                            if (1)
+                                            {
+                                              continue;
+                                            }
+                                            else
+                                            {
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                    else
+                                    {
+                                      {
+                                        IkReal j0array[1], cj0array[1], sj0array[1];
+                                        bool j0valid[1] = { false };
+                                        _nj0 = 1;
+                                        if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(((new_r20) *
+                                                   (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                  IKsqr(((new_r20) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) :
+                                                                                           (IkReal)1.0e30)))) -
+                                                  1) <= IKFAST_SINCOS_THRESH)
+                                          continue;
+                                        j0array[0] = IKatan2(
+                                            ((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                             (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                            ((new_r20) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30))));
+                                        sj0array[0] = IKsin(j0array[0]);
+                                        cj0array[0] = IKcos(j0array[0]);
+                                        if (j0array[0] > IKPI)
+                                        {
+                                          j0array[0] -= IK2PI;
+                                        }
+                                        else if (j0array[0] < -IKPI)
+                                        {
+                                          j0array[0] += IK2PI;
+                                        }
+                                        j0valid[0] = true;
+                                        for (int ij0 = 0; ij0 < 1; ++ij0)
+                                        {
+                                          if (!j0valid[ij0])
+                                          {
+                                            continue;
+                                          }
+                                          _ij0[0] = ij0;
+                                          _ij0[1] = -1;
+                                          for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                          {
+                                            if (j0valid[iij0] &&
+                                                IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                                IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                            {
+                                              j0valid[iij0] = false;
+                                              _ij0[1] = iij0;
+                                              break;
+                                            }
+                                          }
+                                          j0 = j0array[ij0];
+                                          cj0 = cj0array[ij0];
+                                          sj0 = sj0array[ij0];
+                                          {
+                                            IkReal evalcond[8];
+                                            IkReal x141 = IKsin(j0);
+                                            IkReal x142 = IKcos(j0);
+                                            IkReal x143 = ((cj2) * (new_r01));
+                                            IkReal x144 = ((IkReal(1.00000000000000)) * (cj1));
+                                            IkReal x145 = ((IkReal(1.00000000000000)) * (sj1));
+                                            IkReal x146 = ((new_r10) * (sj2));
+                                            IkReal x147 = ((new_r11) * (sj2));
+                                            IkReal x148 = ((cj2) * (new_r00));
+                                            IkReal x149 = ((IkReal(1.00000000000000)) * (x142));
+                                            evalcond[0] =
+                                                ((((IkReal(-1.00000000000000)) * (x142) * (x145))) + (new_r20));
+                                            evalcond[1] =
+                                                ((((IkReal(-1.00000000000000)) * (x141) * (x145))) + (new_r21));
+                                            evalcond[2] = ((((new_r00) * (sj2))) + (x141) + (((cj2) * (new_r10))));
+                                            evalcond[3] = ((((IkReal(-1.00000000000000)) * (x149))) +
+                                                           (((new_r01) * (sj2))) + (((cj2) * (new_r11))));
+                                            evalcond[4] = ((((IkReal(-1.00000000000000)) * (x142) * (x144))) + (x148) +
+                                                           (((IkReal(-1.00000000000000)) * (x146))));
+                                            evalcond[5] = ((x143) + (((IkReal(-1.00000000000000)) * (x147))) +
+                                                           (((IkReal(-1.00000000000000)) * (x141) * (x144))));
+                                            evalcond[6] =
+                                                ((((IkReal(-1.00000000000000)) * (x149))) + (((new_r20) * (sj1))) +
+                                                 (((IkReal(-1.00000000000000)) * (x144) * (x146))) +
+                                                 (((cj1) * (x148))));
+                                            evalcond[7] = ((((IkReal(-1.00000000000000)) * (x144) * (x147))) +
+                                                           (((IkReal(-1.00000000000000)) * (x141))) +
+                                                           (((new_r21) * (sj1))) + (((cj1) * (x143))));
+                                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                                IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                            {
+                                              continue;
+                                            }
+                                          }
+
+                                          {
+                                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                            vinfos[0].jointtype = 1;
+                                            vinfos[0].foffset = j0;
+                                            vinfos[0].indices[0] = _ij0[0];
+                                            vinfos[0].indices[1] = _ij0[1];
+                                            vinfos[0].maxsolutions = _nj0;
+                                            vinfos[1].jointtype = 1;
+                                            vinfos[1].foffset = j1;
+                                            vinfos[1].indices[0] = _ij1[0];
+                                            vinfos[1].indices[1] = _ij1[1];
+                                            vinfos[1].maxsolutions = _nj1;
+                                            vinfos[2].jointtype = 1;
+                                            vinfos[2].foffset = j2;
+                                            vinfos[2].indices[0] = _ij2[0];
+                                            vinfos[2].indices[1] = _ij2[1];
+                                            vinfos[2].maxsolutions = _nj2;
+                                            vinfos[3].jointtype = 1;
+                                            vinfos[3].foffset = j3;
+                                            vinfos[3].indices[0] = _ij3[0];
+                                            vinfos[3].indices[1] = _ij3[1];
+                                            vinfos[3].maxsolutions = _nj3;
+                                            vinfos[4].jointtype = 1;
+                                            vinfos[4].foffset = j4;
+                                            vinfos[4].indices[0] = _ij4[0];
+                                            vinfos[4].indices[1] = _ij4[1];
+                                            vinfos[4].maxsolutions = _nj4;
+                                            vinfos[5].jointtype = 1;
+                                            vinfos[5].foffset = j5;
+                                            vinfos[5].indices[0] = _ij5[0];
+                                            vinfos[5].indices[1] = _ij5[1];
+                                            vinfos[5].maxsolutions = _nj5;
+                                            vinfos[6].jointtype = 1;
+                                            vinfos[6].foffset = j6;
+                                            vinfos[6].indices[0] = _ij6[0];
+                                            vinfos[6].indices[1] = _ij6[1];
+                                            vinfos[6].maxsolutions = _nj6;
+                                            std::vector<int> vfree(0);
+                                            solutions.AddSolution(vinfos, vfree);
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j0array[1], cj0array[1], sj0array[1];
+                                    bool j0valid[1] = { false };
+                                    _nj0 = 1;
+                                    if (IKabs(((new_r21) *
+                                               (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(IKsqr(((new_r21) *
+                                                     (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) +
+                                              IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                            IKFAST_SINCOS_THRESH)
+                                      continue;
+                                    j0array[0] = IKatan2(
+                                        ((new_r21) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30))),
+                                        ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                    sj0array[0] = IKsin(j0array[0]);
+                                    cj0array[0] = IKcos(j0array[0]);
+                                    if (j0array[0] > IKPI)
+                                    {
+                                      j0array[0] -= IK2PI;
+                                    }
+                                    else if (j0array[0] < -IKPI)
+                                    {
+                                      j0array[0] += IK2PI;
+                                    }
+                                    j0valid[0] = true;
+                                    for (int ij0 = 0; ij0 < 1; ++ij0)
+                                    {
+                                      if (!j0valid[ij0])
+                                      {
+                                        continue;
+                                      }
+                                      _ij0[0] = ij0;
+                                      _ij0[1] = -1;
+                                      for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                      {
+                                        if (j0valid[iij0] &&
+                                            IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j0valid[iij0] = false;
+                                          _ij0[1] = iij0;
+                                          break;
+                                        }
+                                      }
+                                      j0 = j0array[ij0];
+                                      cj0 = cj0array[ij0];
+                                      sj0 = sj0array[ij0];
+                                      {
+                                        IkReal evalcond[8];
+                                        IkReal x150 = IKsin(j0);
+                                        IkReal x151 = IKcos(j0);
+                                        IkReal x152 = ((cj2) * (new_r01));
+                                        IkReal x153 = ((IkReal(1.00000000000000)) * (cj1));
+                                        IkReal x154 = ((IkReal(1.00000000000000)) * (sj1));
+                                        IkReal x155 = ((new_r10) * (sj2));
+                                        IkReal x156 = ((new_r11) * (sj2));
+                                        IkReal x157 = ((cj2) * (new_r00));
+                                        IkReal x158 = ((IkReal(1.00000000000000)) * (x151));
+                                        evalcond[0] = ((((IkReal(-1.00000000000000)) * (x151) * (x154))) + (new_r20));
+                                        evalcond[1] = ((((IkReal(-1.00000000000000)) * (x150) * (x154))) + (new_r21));
+                                        evalcond[2] = ((((new_r00) * (sj2))) + (x150) + (((cj2) * (new_r10))));
+                                        evalcond[3] = ((((IkReal(-1.00000000000000)) * (x158))) +
+                                                       (((new_r01) * (sj2))) + (((cj2) * (new_r11))));
+                                        evalcond[4] = ((((IkReal(-1.00000000000000)) * (x151) * (x153))) + (x157) +
+                                                       (((IkReal(-1.00000000000000)) * (x155))));
+                                        evalcond[5] = ((((IkReal(-1.00000000000000)) * (x150) * (x153))) + (x152) +
+                                                       (((IkReal(-1.00000000000000)) * (x156))));
+                                        evalcond[6] =
+                                            ((((IkReal(-1.00000000000000)) * (x158))) + (((new_r20) * (sj1))) +
+                                             (((IkReal(-1.00000000000000)) * (x153) * (x155))) + (((cj1) * (x157))));
+                                        evalcond[7] = ((((IkReal(-1.00000000000000)) * (x153) * (x156))) +
+                                                       (((IkReal(-1.00000000000000)) * (x150))) +
+                                                       (((new_r21) * (sj1))) + (((cj1) * (x152))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                            IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        vinfos[6].jointtype = 1;
+                                        vinfos[6].foffset = j6;
+                                        vinfos[6].indices[0] = _ij6[0];
+                                        vinfos[6].indices[1] = _ij6[1];
+                                        vinfos[6].maxsolutions = _nj6;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              {
+                                IkReal j0array[1], cj0array[1], sj0array[1];
+                                bool j0valid[1] = { false };
+                                _nj0 = 1;
+                                if (IKabs(((gconst15) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((gconst15) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                j0array[0] = IKatan2(((gconst15) * (new_r21)), ((gconst15) * (new_r20)));
+                                sj0array[0] = IKsin(j0array[0]);
+                                cj0array[0] = IKcos(j0array[0]);
+                                if (j0array[0] > IKPI)
+                                {
+                                  j0array[0] -= IK2PI;
+                                }
+                                else if (j0array[0] < -IKPI)
+                                {
+                                  j0array[0] += IK2PI;
+                                }
+                                j0valid[0] = true;
+                                for (int ij0 = 0; ij0 < 1; ++ij0)
+                                {
+                                  if (!j0valid[ij0])
+                                  {
+                                    continue;
+                                  }
+                                  _ij0[0] = ij0;
+                                  _ij0[1] = -1;
+                                  for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                  {
+                                    if (j0valid[iij0] &&
+                                        IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j0valid[iij0] = false;
+                                      _ij0[1] = iij0;
+                                      break;
+                                    }
+                                  }
+                                  j0 = j0array[ij0];
+                                  cj0 = cj0array[ij0];
+                                  sj0 = sj0array[ij0];
+                                  {
+                                    IkReal evalcond[8];
+                                    IkReal x159 = IKsin(j0);
+                                    IkReal x160 = IKcos(j0);
+                                    IkReal x161 = ((cj2) * (new_r01));
+                                    IkReal x162 = ((IkReal(1.00000000000000)) * (cj1));
+                                    IkReal x163 = ((IkReal(1.00000000000000)) * (sj1));
+                                    IkReal x164 = ((new_r10) * (sj2));
+                                    IkReal x165 = ((new_r11) * (sj2));
+                                    IkReal x166 = ((cj2) * (new_r00));
+                                    IkReal x167 = ((IkReal(1.00000000000000)) * (x160));
+                                    evalcond[0] = ((((IkReal(-1.00000000000000)) * (x160) * (x163))) + (new_r20));
+                                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (x159) * (x163))) + (new_r21));
+                                    evalcond[2] = ((((new_r00) * (sj2))) + (x159) + (((cj2) * (new_r10))));
+                                    evalcond[3] = ((((IkReal(-1.00000000000000)) * (x167))) + (((new_r01) * (sj2))) +
+                                                   (((cj2) * (new_r11))));
+                                    evalcond[4] = ((((IkReal(-1.00000000000000)) * (x160) * (x162))) + (x166) +
+                                                   (((IkReal(-1.00000000000000)) * (x164))));
+                                    evalcond[5] = ((((IkReal(-1.00000000000000)) * (x159) * (x162))) + (x161) +
+                                                   (((IkReal(-1.00000000000000)) * (x165))));
+                                    evalcond[6] =
+                                        ((((new_r20) * (sj1))) + (((IkReal(-1.00000000000000)) * (x167))) +
+                                         (((IkReal(-1.00000000000000)) * (x162) * (x164))) + (((cj1) * (x166))));
+                                    evalcond[7] = ((((IkReal(-1.00000000000000)) * (x162) * (x165))) +
+                                                   (((IkReal(-1.00000000000000)) * (x159))) + (((cj1) * (x161))) +
+                                                   (((new_r21) * (sj1))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                        IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                    vinfos[0].jointtype = 1;
+                                    vinfos[0].foffset = j0;
+                                    vinfos[0].indices[0] = _ij0[0];
+                                    vinfos[0].indices[1] = _ij0[1];
+                                    vinfos[0].maxsolutions = _nj0;
+                                    vinfos[1].jointtype = 1;
+                                    vinfos[1].foffset = j1;
+                                    vinfos[1].indices[0] = _ij1[0];
+                                    vinfos[1].indices[1] = _ij1[1];
+                                    vinfos[1].maxsolutions = _nj1;
+                                    vinfos[2].jointtype = 1;
+                                    vinfos[2].foffset = j2;
+                                    vinfos[2].indices[0] = _ij2[0];
+                                    vinfos[2].indices[1] = _ij2[1];
+                                    vinfos[2].maxsolutions = _nj2;
+                                    vinfos[3].jointtype = 1;
+                                    vinfos[3].foffset = j3;
+                                    vinfos[3].indices[0] = _ij3[0];
+                                    vinfos[3].indices[1] = _ij3[1];
+                                    vinfos[3].maxsolutions = _nj3;
+                                    vinfos[4].jointtype = 1;
+                                    vinfos[4].foffset = j4;
+                                    vinfos[4].indices[0] = _ij4[0];
+                                    vinfos[4].indices[1] = _ij4[1];
+                                    vinfos[4].maxsolutions = _nj4;
+                                    vinfos[5].jointtype = 1;
+                                    vinfos[5].foffset = j5;
+                                    vinfos[5].indices[0] = _ij5[0];
+                                    vinfos[5].indices[1] = _ij5[1];
+                                    vinfos[5].maxsolutions = _nj5;
+                                    vinfos[6].jointtype = 1;
+                                    vinfos[6].foffset = j6;
+                                    vinfos[6].indices[0] = _ij6[0];
+                                    vinfos[6].indices[1] = _ij6[1];
+                                    vinfos[6].maxsolutions = _nj6;
+                                    std::vector<int> vfree(0);
+                                    solutions.AddSolution(vinfos, vfree);
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                else
+                {
+                  {
+                    IkReal j2array[1], cj2array[1], sj2array[1];
+                    bool j2valid[1] = { false };
+                    _nj2 = 1;
+                    IkReal x168 = ((gconst13) * (sj1));
+                    if (IKabs(((new_r12) * (x168))) < IKFAST_ATAN2_MAGTHRESH &&
+                        IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x168))) < IKFAST_ATAN2_MAGTHRESH)
+                      continue;
+                    j2array[0] = IKatan2(((new_r12) * (x168)), ((IkReal(-1.00000000000000)) * (new_r02) * (x168)));
+                    sj2array[0] = IKsin(j2array[0]);
+                    cj2array[0] = IKcos(j2array[0]);
+                    if (j2array[0] > IKPI)
+                    {
+                      j2array[0] -= IK2PI;
+                    }
+                    else if (j2array[0] < -IKPI)
+                    {
+                      j2array[0] += IK2PI;
+                    }
+                    j2valid[0] = true;
+                    for (int ij2 = 0; ij2 < 1; ++ij2)
+                    {
+                      if (!j2valid[ij2])
+                      {
+                        continue;
+                      }
+                      _ij2[0] = ij2;
+                      _ij2[1] = -1;
+                      for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                      {
+                        if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                            IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                        {
+                          j2valid[iij2] = false;
+                          _ij2[1] = iij2;
+                          break;
+                        }
+                      }
+                      j2 = j2array[ij2];
+                      cj2 = cj2array[ij2];
+                      sj2 = sj2array[ij2];
+                      {
+                        IkReal evalcond[6];
+                        IkReal x169 = IKcos(j2);
+                        IkReal x170 = IKsin(j2);
+                        IkReal x171 = ((IkReal(1.00000000000000)) * (cj1));
+                        IkReal x172 = ((sj1) * (x169));
+                        IkReal x173 = ((new_r12) * (x170));
+                        IkReal x174 = ((new_r02) * (x169));
+                        IkReal x175 = ((IkReal(1.00000000000000)) * (sj1) * (x170));
+                        evalcond[0] = ((((new_r02) * (x170))) + (((new_r12) * (x169))));
+                        evalcond[1] = ((sj1) + (((IkReal(-1.00000000000000)) * (x173))) + (x174));
+                        evalcond[2] = ((((new_r22) * (sj1))) + (((IkReal(-1.00000000000000)) * (x171) * (x173))) +
+                                       (((cj1) * (x174))));
+                        evalcond[3] = ((((new_r00) * (x172))) + (((IkReal(-1.00000000000000)) * (new_r20) * (x171))) +
+                                       (((IkReal(-1.00000000000000)) * (new_r10) * (x175))));
+                        evalcond[4] = ((((new_r01) * (x172))) + (((IkReal(-1.00000000000000)) * (new_r21) * (x171))) +
+                                       (((IkReal(-1.00000000000000)) * (new_r11) * (x175))));
+                        evalcond[5] = ((IkReal(1.00000000000000)) + (((new_r02) * (x172))) +
+                                       (((IkReal(-1.00000000000000)) * (sj1) * (x173))) +
+                                       (((IkReal(-1.00000000000000)) * (new_r22) * (x171))));
+                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                        {
+                          continue;
+                        }
+                      }
+
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst15;
+                        gconst15 = IKsign(sj1);
+                        dummyeval[0] = sj1;
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal dummyeval[1];
+                            dummyeval[0] = sj1;
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal dummyeval[1];
+                                dummyeval[0] = sj1;
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal evalcond[11];
+                                    IkReal x176 = ((((new_r02) * (sj2))) + (((cj2) * (new_r12))));
+                                    IkReal x177 =
+                                        ((((cj2) * (new_r02))) + (((IkReal(-1.00000000000000)) * (new_r12) * (sj2))));
+                                    evalcond[0] =
+                                        ((IkReal(-3.14159265358979)) +
+                                         (IKfmod(((IkReal(3.14159265358979)) + (j1)), IkReal(6.28318530717959))));
+                                    evalcond[1] = ((IkReal(-1.00000000000000)) + (new_r22));
+                                    evalcond[2] = new_r20;
+                                    evalcond[3] = new_r21;
+                                    evalcond[4] = x176;
+                                    evalcond[5] = x176;
+                                    evalcond[6] = x177;
+                                    evalcond[7] = x177;
+                                    evalcond[8] = ((IkReal(-1.00000000000000)) * (new_r20));
+                                    evalcond[9] = ((IkReal(-1.00000000000000)) * (new_r21));
+                                    evalcond[10] =
+                                        ((IkReal(1.00000000000000)) + (((IkReal(-1.00000000000000)) * (new_r22))));
+                                    if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[10]) < 0.0000010000000000)
+                                    {
+                                      {
+                                        IkReal j0array[1], cj0array[1], sj0array[1];
+                                        bool j0valid[1] = { false };
+                                        _nj0 = 1;
+                                        if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                  IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                                IKFAST_SINCOS_THRESH)
+                                          continue;
+                                        j0array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                              (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                             ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                        sj0array[0] = IKsin(j0array[0]);
+                                        cj0array[0] = IKcos(j0array[0]);
+                                        if (j0array[0] > IKPI)
+                                        {
+                                          j0array[0] -= IK2PI;
+                                        }
+                                        else if (j0array[0] < -IKPI)
+                                        {
+                                          j0array[0] += IK2PI;
+                                        }
+                                        j0valid[0] = true;
+                                        for (int ij0 = 0; ij0 < 1; ++ij0)
+                                        {
+                                          if (!j0valid[ij0])
+                                          {
+                                            continue;
+                                          }
+                                          _ij0[0] = ij0;
+                                          _ij0[1] = -1;
+                                          for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                          {
+                                            if (j0valid[iij0] &&
+                                                IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                                IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                            {
+                                              j0valid[iij0] = false;
+                                              _ij0[1] = iij0;
+                                              break;
+                                            }
+                                          }
+                                          j0 = j0array[ij0];
+                                          cj0 = cj0array[ij0];
+                                          sj0 = sj0array[ij0];
+                                          {
+                                            IkReal evalcond[4];
+                                            IkReal x178 = IKsin(j0);
+                                            IkReal x179 = ((IkReal(1.00000000000000)) * (sj2));
+                                            IkReal x180 = ((IkReal(1.00000000000000)) * (IKcos(j0)));
+                                            evalcond[0] = ((((new_r00) * (sj2))) + (x178) + (((cj2) * (new_r10))));
+                                            evalcond[1] = ((((IkReal(-1.00000000000000)) * (x180))) +
+                                                           (((new_r01) * (sj2))) + (((cj2) * (new_r11))));
+                                            evalcond[2] =
+                                                ((((IkReal(-1.00000000000000)) * (new_r10) * (x179))) +
+                                                 (((IkReal(-1.00000000000000)) * (x180))) + (((cj2) * (new_r00))));
+                                            evalcond[3] = ((((IkReal(-1.00000000000000)) * (x178))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r11) * (x179))) +
+                                                           (((cj2) * (new_r01))));
+                                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                            {
+                                              continue;
+                                            }
+                                          }
+
+                                          {
+                                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                            vinfos[0].jointtype = 1;
+                                            vinfos[0].foffset = j0;
+                                            vinfos[0].indices[0] = _ij0[0];
+                                            vinfos[0].indices[1] = _ij0[1];
+                                            vinfos[0].maxsolutions = _nj0;
+                                            vinfos[1].jointtype = 1;
+                                            vinfos[1].foffset = j1;
+                                            vinfos[1].indices[0] = _ij1[0];
+                                            vinfos[1].indices[1] = _ij1[1];
+                                            vinfos[1].maxsolutions = _nj1;
+                                            vinfos[2].jointtype = 1;
+                                            vinfos[2].foffset = j2;
+                                            vinfos[2].indices[0] = _ij2[0];
+                                            vinfos[2].indices[1] = _ij2[1];
+                                            vinfos[2].maxsolutions = _nj2;
+                                            vinfos[3].jointtype = 1;
+                                            vinfos[3].foffset = j3;
+                                            vinfos[3].indices[0] = _ij3[0];
+                                            vinfos[3].indices[1] = _ij3[1];
+                                            vinfos[3].maxsolutions = _nj3;
+                                            vinfos[4].jointtype = 1;
+                                            vinfos[4].foffset = j4;
+                                            vinfos[4].indices[0] = _ij4[0];
+                                            vinfos[4].indices[1] = _ij4[1];
+                                            vinfos[4].maxsolutions = _nj4;
+                                            vinfos[5].jointtype = 1;
+                                            vinfos[5].foffset = j5;
+                                            vinfos[5].indices[0] = _ij5[0];
+                                            vinfos[5].indices[1] = _ij5[1];
+                                            vinfos[5].maxsolutions = _nj5;
+                                            vinfos[6].jointtype = 1;
+                                            vinfos[6].foffset = j6;
+                                            vinfos[6].indices[0] = _ij6[0];
+                                            vinfos[6].indices[1] = _ij6[1];
+                                            vinfos[6].maxsolutions = _nj6;
+                                            std::vector<int> vfree(0);
+                                            solutions.AddSolution(vinfos, vfree);
+                                          }
+                                        }
+                                      }
+                                    }
+                                    else
+                                    {
+                                      IkReal x181 = ((IkReal(1.00000000000000)) + (new_r22));
+                                      IkReal x182 = ((new_r12) * (sj2));
+                                      IkReal x183 = ((cj2) * (new_r02));
+                                      IkReal x184 = ((((new_r02) * (sj2))) + (((cj2) * (new_r12))));
+                                      evalcond[0] =
+                                          ((IkReal(-3.14159265358979)) +
+                                           (IKfmod(((IkReal(1.11022302462516e-16)) + (j1)), IkReal(6.28318530717959))));
+                                      evalcond[1] = x181;
+                                      evalcond[2] = new_r20;
+                                      evalcond[3] = new_r21;
+                                      evalcond[4] = x184;
+                                      evalcond[5] = x184;
+                                      evalcond[6] = ((((IkReal(-1.00000000000000)) * (x182))) + (x183));
+                                      evalcond[7] = ((((IkReal(-1.00000000000000)) * (x183))) + (x182));
+                                      evalcond[8] = new_r20;
+                                      evalcond[9] = new_r21;
+                                      evalcond[10] = x181;
+                                      if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[10]) < 0.0000010000000000)
+                                      {
+                                        {
+                                          IkReal j0array[1], cj0array[1], sj0array[1];
+                                          bool j0valid[1] = { false };
+                                          _nj0 = 1;
+                                          if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                              IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                              IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                    IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                                  IKFAST_SINCOS_THRESH)
+                                            continue;
+                                          j0array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                                (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                               ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                          sj0array[0] = IKsin(j0array[0]);
+                                          cj0array[0] = IKcos(j0array[0]);
+                                          if (j0array[0] > IKPI)
+                                          {
+                                            j0array[0] -= IK2PI;
+                                          }
+                                          else if (j0array[0] < -IKPI)
+                                          {
+                                            j0array[0] += IK2PI;
+                                          }
+                                          j0valid[0] = true;
+                                          for (int ij0 = 0; ij0 < 1; ++ij0)
+                                          {
+                                            if (!j0valid[ij0])
+                                            {
+                                              continue;
+                                            }
+                                            _ij0[0] = ij0;
+                                            _ij0[1] = -1;
+                                            for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                            {
+                                              if (j0valid[iij0] &&
+                                                  IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                                  IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                              {
+                                                j0valid[iij0] = false;
+                                                _ij0[1] = iij0;
+                                                break;
+                                              }
+                                            }
+                                            j0 = j0array[ij0];
+                                            cj0 = cj0array[ij0];
+                                            sj0 = sj0array[ij0];
+                                            {
+                                              IkReal evalcond[4];
+                                              IkReal x185 = IKcos(j0);
+                                              IkReal x186 = IKsin(j0);
+                                              IkReal x187 = ((IkReal(1.00000000000000)) * (sj2));
+                                              evalcond[0] = ((((new_r00) * (sj2))) + (x186) + (((cj2) * (new_r10))));
+                                              evalcond[1] =
+                                                  ((((new_r01) * (sj2))) + (((IkReal(-1.00000000000000)) * (x185))) +
+                                                   (((cj2) * (new_r11))));
+                                              evalcond[2] =
+                                                  ((x185) + (((IkReal(-1.00000000000000)) * (new_r10) * (x187))) +
+                                                   (((cj2) * (new_r00))));
+                                              evalcond[3] =
+                                                  ((x186) + (((IkReal(-1.00000000000000)) * (new_r11) * (x187))) +
+                                                   (((cj2) * (new_r01))));
+                                              if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                  IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                              {
+                                                continue;
+                                              }
+                                            }
+
+                                            {
+                                              std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                              vinfos[0].jointtype = 1;
+                                              vinfos[0].foffset = j0;
+                                              vinfos[0].indices[0] = _ij0[0];
+                                              vinfos[0].indices[1] = _ij0[1];
+                                              vinfos[0].maxsolutions = _nj0;
+                                              vinfos[1].jointtype = 1;
+                                              vinfos[1].foffset = j1;
+                                              vinfos[1].indices[0] = _ij1[0];
+                                              vinfos[1].indices[1] = _ij1[1];
+                                              vinfos[1].maxsolutions = _nj1;
+                                              vinfos[2].jointtype = 1;
+                                              vinfos[2].foffset = j2;
+                                              vinfos[2].indices[0] = _ij2[0];
+                                              vinfos[2].indices[1] = _ij2[1];
+                                              vinfos[2].maxsolutions = _nj2;
+                                              vinfos[3].jointtype = 1;
+                                              vinfos[3].foffset = j3;
+                                              vinfos[3].indices[0] = _ij3[0];
+                                              vinfos[3].indices[1] = _ij3[1];
+                                              vinfos[3].maxsolutions = _nj3;
+                                              vinfos[4].jointtype = 1;
+                                              vinfos[4].foffset = j4;
+                                              vinfos[4].indices[0] = _ij4[0];
+                                              vinfos[4].indices[1] = _ij4[1];
+                                              vinfos[4].maxsolutions = _nj4;
+                                              vinfos[5].jointtype = 1;
+                                              vinfos[5].foffset = j5;
+                                              vinfos[5].indices[0] = _ij5[0];
+                                              vinfos[5].indices[1] = _ij5[1];
+                                              vinfos[5].maxsolutions = _nj5;
+                                              vinfos[6].jointtype = 1;
+                                              vinfos[6].foffset = j6;
+                                              vinfos[6].indices[0] = _ij6[0];
+                                              vinfos[6].indices[1] = _ij6[1];
+                                              vinfos[6].maxsolutions = _nj6;
+                                              std::vector<int> vfree(0);
+                                              solutions.AddSolution(vinfos, vfree);
+                                            }
+                                          }
+                                        }
+                                      }
+                                      else
+                                      {
+                                        if (1)
+                                        {
+                                          continue;
+                                        }
+                                        else
+                                        {
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j0array[1], cj0array[1], sj0array[1];
+                                    bool j0valid[1] = { false };
+                                    _nj0 = 1;
+                                    if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((new_r20) *
+                                               (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                              IKsqr(((new_r20) *
+                                                     (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) -
+                                              1) <= IKFAST_SINCOS_THRESH)
+                                      continue;
+                                    j0array[0] = IKatan2(
+                                        ((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                         (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                        ((new_r20) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30))));
+                                    sj0array[0] = IKsin(j0array[0]);
+                                    cj0array[0] = IKcos(j0array[0]);
+                                    if (j0array[0] > IKPI)
+                                    {
+                                      j0array[0] -= IK2PI;
+                                    }
+                                    else if (j0array[0] < -IKPI)
+                                    {
+                                      j0array[0] += IK2PI;
+                                    }
+                                    j0valid[0] = true;
+                                    for (int ij0 = 0; ij0 < 1; ++ij0)
+                                    {
+                                      if (!j0valid[ij0])
+                                      {
+                                        continue;
+                                      }
+                                      _ij0[0] = ij0;
+                                      _ij0[1] = -1;
+                                      for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                      {
+                                        if (j0valid[iij0] &&
+                                            IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j0valid[iij0] = false;
+                                          _ij0[1] = iij0;
+                                          break;
+                                        }
+                                      }
+                                      j0 = j0array[ij0];
+                                      cj0 = cj0array[ij0];
+                                      sj0 = sj0array[ij0];
+                                      {
+                                        IkReal evalcond[8];
+                                        IkReal x188 = IKsin(j0);
+                                        IkReal x189 = IKcos(j0);
+                                        IkReal x190 = ((cj2) * (new_r01));
+                                        IkReal x191 = ((IkReal(1.00000000000000)) * (cj1));
+                                        IkReal x192 = ((IkReal(1.00000000000000)) * (sj1));
+                                        IkReal x193 = ((new_r10) * (sj2));
+                                        IkReal x194 = ((new_r11) * (sj2));
+                                        IkReal x195 = ((cj2) * (new_r00));
+                                        IkReal x196 = ((IkReal(1.00000000000000)) * (x189));
+                                        evalcond[0] = ((((IkReal(-1.00000000000000)) * (x189) * (x192))) + (new_r20));
+                                        evalcond[1] = ((((IkReal(-1.00000000000000)) * (x188) * (x192))) + (new_r21));
+                                        evalcond[2] = ((((new_r00) * (sj2))) + (x188) + (((cj2) * (new_r10))));
+                                        evalcond[3] =
+                                            ((((new_r01) * (sj2))) + (((IkReal(-1.00000000000000)) * (x196))) +
+                                             (((cj2) * (new_r11))));
+                                        evalcond[4] = ((((IkReal(-1.00000000000000)) * (x189) * (x191))) +
+                                                       (((IkReal(-1.00000000000000)) * (x193))) + (x195));
+                                        evalcond[5] = ((((IkReal(-1.00000000000000)) * (x188) * (x191))) +
+                                                       (((IkReal(-1.00000000000000)) * (x194))) + (x190));
+                                        evalcond[6] =
+                                            ((((new_r20) * (sj1))) + (((IkReal(-1.00000000000000)) * (x191) * (x193))) +
+                                             (((IkReal(-1.00000000000000)) * (x196))) + (((cj1) * (x195))));
+                                        evalcond[7] = ((((IkReal(-1.00000000000000)) * (x191) * (x194))) +
+                                                       (((IkReal(-1.00000000000000)) * (x188))) + (((cj1) * (x190))) +
+                                                       (((new_r21) * (sj1))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                            IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        vinfos[6].jointtype = 1;
+                                        vinfos[6].foffset = j6;
+                                        vinfos[6].indices[0] = _ij6[0];
+                                        vinfos[6].indices[1] = _ij6[1];
+                                        vinfos[6].maxsolutions = _nj6;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              {
+                                IkReal j0array[1], cj0array[1], sj0array[1];
+                                bool j0valid[1] = { false };
+                                _nj0 = 1;
+                                if (IKabs(((new_r21) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) <
+                                        IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(IKsqr(((new_r21) *
+                                                 (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) +
+                                          IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                        IKFAST_SINCOS_THRESH)
+                                  continue;
+                                j0array[0] =
+                                    IKatan2(((new_r21) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30))),
+                                            ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                sj0array[0] = IKsin(j0array[0]);
+                                cj0array[0] = IKcos(j0array[0]);
+                                if (j0array[0] > IKPI)
+                                {
+                                  j0array[0] -= IK2PI;
+                                }
+                                else if (j0array[0] < -IKPI)
+                                {
+                                  j0array[0] += IK2PI;
+                                }
+                                j0valid[0] = true;
+                                for (int ij0 = 0; ij0 < 1; ++ij0)
+                                {
+                                  if (!j0valid[ij0])
+                                  {
+                                    continue;
+                                  }
+                                  _ij0[0] = ij0;
+                                  _ij0[1] = -1;
+                                  for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                  {
+                                    if (j0valid[iij0] &&
+                                        IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j0valid[iij0] = false;
+                                      _ij0[1] = iij0;
+                                      break;
+                                    }
+                                  }
+                                  j0 = j0array[ij0];
+                                  cj0 = cj0array[ij0];
+                                  sj0 = sj0array[ij0];
+                                  {
+                                    IkReal evalcond[8];
+                                    IkReal x197 = IKsin(j0);
+                                    IkReal x198 = IKcos(j0);
+                                    IkReal x199 = ((cj2) * (new_r01));
+                                    IkReal x200 = ((IkReal(1.00000000000000)) * (cj1));
+                                    IkReal x201 = ((IkReal(1.00000000000000)) * (sj1));
+                                    IkReal x202 = ((new_r10) * (sj2));
+                                    IkReal x203 = ((new_r11) * (sj2));
+                                    IkReal x204 = ((cj2) * (new_r00));
+                                    IkReal x205 = ((IkReal(1.00000000000000)) * (x198));
+                                    evalcond[0] = ((((IkReal(-1.00000000000000)) * (x198) * (x201))) + (new_r20));
+                                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (x197) * (x201))) + (new_r21));
+                                    evalcond[2] = ((((new_r00) * (sj2))) + (x197) + (((cj2) * (new_r10))));
+                                    evalcond[3] = ((((new_r01) * (sj2))) + (((IkReal(-1.00000000000000)) * (x205))) +
+                                                   (((cj2) * (new_r11))));
+                                    evalcond[4] = ((x204) + (((IkReal(-1.00000000000000)) * (x198) * (x200))) +
+                                                   (((IkReal(-1.00000000000000)) * (x202))));
+                                    evalcond[5] = ((((IkReal(-1.00000000000000)) * (x197) * (x200))) + (x199) +
+                                                   (((IkReal(-1.00000000000000)) * (x203))));
+                                    evalcond[6] =
+                                        ((((IkReal(-1.00000000000000)) * (x200) * (x202))) + (((cj1) * (x204))) +
+                                         (((new_r20) * (sj1))) + (((IkReal(-1.00000000000000)) * (x205))));
+                                    evalcond[7] = ((((IkReal(-1.00000000000000)) * (x200) * (x203))) +
+                                                   (((IkReal(-1.00000000000000)) * (x197))) + (((cj1) * (x199))) +
+                                                   (((new_r21) * (sj1))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                        IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                    vinfos[0].jointtype = 1;
+                                    vinfos[0].foffset = j0;
+                                    vinfos[0].indices[0] = _ij0[0];
+                                    vinfos[0].indices[1] = _ij0[1];
+                                    vinfos[0].maxsolutions = _nj0;
+                                    vinfos[1].jointtype = 1;
+                                    vinfos[1].foffset = j1;
+                                    vinfos[1].indices[0] = _ij1[0];
+                                    vinfos[1].indices[1] = _ij1[1];
+                                    vinfos[1].maxsolutions = _nj1;
+                                    vinfos[2].jointtype = 1;
+                                    vinfos[2].foffset = j2;
+                                    vinfos[2].indices[0] = _ij2[0];
+                                    vinfos[2].indices[1] = _ij2[1];
+                                    vinfos[2].maxsolutions = _nj2;
+                                    vinfos[3].jointtype = 1;
+                                    vinfos[3].foffset = j3;
+                                    vinfos[3].indices[0] = _ij3[0];
+                                    vinfos[3].indices[1] = _ij3[1];
+                                    vinfos[3].maxsolutions = _nj3;
+                                    vinfos[4].jointtype = 1;
+                                    vinfos[4].foffset = j4;
+                                    vinfos[4].indices[0] = _ij4[0];
+                                    vinfos[4].indices[1] = _ij4[1];
+                                    vinfos[4].maxsolutions = _nj4;
+                                    vinfos[5].jointtype = 1;
+                                    vinfos[5].foffset = j5;
+                                    vinfos[5].indices[0] = _ij5[0];
+                                    vinfos[5].indices[1] = _ij5[1];
+                                    vinfos[5].maxsolutions = _nj5;
+                                    vinfos[6].jointtype = 1;
+                                    vinfos[6].foffset = j6;
+                                    vinfos[6].indices[0] = _ij6[0];
+                                    vinfos[6].indices[1] = _ij6[1];
+                                    vinfos[6].maxsolutions = _nj6;
+                                    std::vector<int> vfree(0);
+                                    solutions.AddSolution(vinfos, vfree);
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          {
+                            IkReal j0array[1], cj0array[1], sj0array[1];
+                            bool j0valid[1] = { false };
+                            _nj0 = 1;
+                            if (IKabs(((gconst15) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((gconst15) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j0array[0] = IKatan2(((gconst15) * (new_r21)), ((gconst15) * (new_r20)));
+                            sj0array[0] = IKsin(j0array[0]);
+                            cj0array[0] = IKcos(j0array[0]);
+                            if (j0array[0] > IKPI)
+                            {
+                              j0array[0] -= IK2PI;
+                            }
+                            else if (j0array[0] < -IKPI)
+                            {
+                              j0array[0] += IK2PI;
+                            }
+                            j0valid[0] = true;
+                            for (int ij0 = 0; ij0 < 1; ++ij0)
+                            {
+                              if (!j0valid[ij0])
+                              {
+                                continue;
+                              }
+                              _ij0[0] = ij0;
+                              _ij0[1] = -1;
+                              for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                              {
+                                if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j0valid[iij0] = false;
+                                  _ij0[1] = iij0;
+                                  break;
+                                }
+                              }
+                              j0 = j0array[ij0];
+                              cj0 = cj0array[ij0];
+                              sj0 = sj0array[ij0];
+                              {
+                                IkReal evalcond[8];
+                                IkReal x206 = IKsin(j0);
+                                IkReal x207 = IKcos(j0);
+                                IkReal x208 = ((cj2) * (new_r01));
+                                IkReal x209 = ((IkReal(1.00000000000000)) * (cj1));
+                                IkReal x210 = ((IkReal(1.00000000000000)) * (sj1));
+                                IkReal x211 = ((new_r10) * (sj2));
+                                IkReal x212 = ((new_r11) * (sj2));
+                                IkReal x213 = ((cj2) * (new_r00));
+                                IkReal x214 = ((IkReal(1.00000000000000)) * (x207));
+                                evalcond[0] = ((((IkReal(-1.00000000000000)) * (x207) * (x210))) + (new_r20));
+                                evalcond[1] = ((((IkReal(-1.00000000000000)) * (x206) * (x210))) + (new_r21));
+                                evalcond[2] = ((((new_r00) * (sj2))) + (x206) + (((cj2) * (new_r10))));
+                                evalcond[3] = ((((new_r01) * (sj2))) + (((cj2) * (new_r11))) +
+                                               (((IkReal(-1.00000000000000)) * (x214))));
+                                evalcond[4] = ((((IkReal(-1.00000000000000)) * (x207) * (x209))) + (x213) +
+                                               (((IkReal(-1.00000000000000)) * (x211))));
+                                evalcond[5] = ((((IkReal(-1.00000000000000)) * (x206) * (x209))) + (x208) +
+                                               (((IkReal(-1.00000000000000)) * (x212))));
+                                evalcond[6] = ((((new_r20) * (sj1))) + (((cj1) * (x213))) +
+                                               (((IkReal(-1.00000000000000)) * (x214))) +
+                                               (((IkReal(-1.00000000000000)) * (x209) * (x211))));
+                                evalcond[7] = ((((cj1) * (x208))) + (((new_r21) * (sj1))) +
+                                               (((IkReal(-1.00000000000000)) * (x206))) +
+                                               (((IkReal(-1.00000000000000)) * (x209) * (x212))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                    IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                vinfos[0].jointtype = 1;
+                                vinfos[0].foffset = j0;
+                                vinfos[0].indices[0] = _ij0[0];
+                                vinfos[0].indices[1] = _ij0[1];
+                                vinfos[0].maxsolutions = _nj0;
+                                vinfos[1].jointtype = 1;
+                                vinfos[1].foffset = j1;
+                                vinfos[1].indices[0] = _ij1[0];
+                                vinfos[1].indices[1] = _ij1[1];
+                                vinfos[1].maxsolutions = _nj1;
+                                vinfos[2].jointtype = 1;
+                                vinfos[2].foffset = j2;
+                                vinfos[2].indices[0] = _ij2[0];
+                                vinfos[2].indices[1] = _ij2[1];
+                                vinfos[2].maxsolutions = _nj2;
+                                vinfos[3].jointtype = 1;
+                                vinfos[3].foffset = j3;
+                                vinfos[3].indices[0] = _ij3[0];
+                                vinfos[3].indices[1] = _ij3[1];
+                                vinfos[3].maxsolutions = _nj3;
+                                vinfos[4].jointtype = 1;
+                                vinfos[4].foffset = j4;
+                                vinfos[4].indices[0] = _ij4[0];
+                                vinfos[4].indices[1] = _ij4[1];
+                                vinfos[4].maxsolutions = _nj4;
+                                vinfos[5].jointtype = 1;
+                                vinfos[5].foffset = j5;
+                                vinfos[5].indices[0] = _ij5[0];
+                                vinfos[5].indices[1] = _ij5[1];
+                                vinfos[5].maxsolutions = _nj5;
+                                vinfos[6].jointtype = 1;
+                                vinfos[6].foffset = j6;
+                                vinfos[6].indices[0] = _ij6[0];
+                                vinfos[6].indices[1] = _ij6[1];
+                                vinfos[6].maxsolutions = _nj6;
+                                std::vector<int> vfree(0);
+                                solutions.AddSolution(vinfos, vfree);
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            else
+            {
+              {
+                IkReal j0array[1], cj0array[1], sj0array[1];
+                bool j0valid[1] = { false };
+                _nj0 = 1;
+                if (IKabs(((gconst12) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                    IKabs(((gconst12) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH)
+                  continue;
+                j0array[0] = IKatan2(((gconst12) * (new_r21)), ((gconst12) * (new_r20)));
+                sj0array[0] = IKsin(j0array[0]);
+                cj0array[0] = IKcos(j0array[0]);
+                if (j0array[0] > IKPI)
+                {
+                  j0array[0] -= IK2PI;
+                }
+                else if (j0array[0] < -IKPI)
+                {
+                  j0array[0] += IK2PI;
+                }
+                j0valid[0] = true;
+                for (int ij0 = 0; ij0 < 1; ++ij0)
+                {
+                  if (!j0valid[ij0])
+                  {
+                    continue;
+                  }
+                  _ij0[0] = ij0;
+                  _ij0[1] = -1;
+                  for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                  {
+                    if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                        IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                    {
+                      j0valid[iij0] = false;
+                      _ij0[1] = iij0;
+                      break;
+                    }
+                  }
+                  j0 = j0array[ij0];
+                  cj0 = cj0array[ij0];
+                  sj0 = sj0array[ij0];
+                  {
+                    IkReal evalcond[2];
+                    IkReal x215 = ((IkReal(1.00000000000000)) * (sj1));
+                    evalcond[0] = ((new_r20) + (((IkReal(-1.00000000000000)) * (x215) * (IKcos(j0)))));
+                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (x215) * (IKsin(j0)))) + (new_r21));
+                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001)
+                    {
+                      continue;
+                    }
+                  }
+
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst17;
+                    gconst17 = IKsign((((new_r12) * (new_r12)) + ((new_r02) * (new_r02))));
+                    dummyeval[0] = (((new_r12) * (new_r12)) + ((new_r02) * (new_r02)));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst16;
+                        gconst16 = IKsign(
+                            ((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) + (((new_r02) * (new_r10)))));
+                        dummyeval[0] =
+                            ((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) + (((new_r02) * (new_r10))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          continue;
+                        }
+                        else
+                        {
+                          {
+                            IkReal j2array[1], cj2array[1], sj2array[1];
+                            bool j2valid[1] = { false };
+                            _nj2 = 1;
+                            IkReal x216 = ((gconst16) * (sj0));
+                            if (IKabs(((new_r12) * (x216))) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x216))) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j2array[0] =
+                                IKatan2(((new_r12) * (x216)), ((IkReal(-1.00000000000000)) * (new_r02) * (x216)));
+                            sj2array[0] = IKsin(j2array[0]);
+                            cj2array[0] = IKcos(j2array[0]);
+                            if (j2array[0] > IKPI)
+                            {
+                              j2array[0] -= IK2PI;
+                            }
+                            else if (j2array[0] < -IKPI)
+                            {
+                              j2array[0] += IK2PI;
+                            }
+                            j2valid[0] = true;
+                            for (int ij2 = 0; ij2 < 1; ++ij2)
+                            {
+                              if (!j2valid[ij2])
+                              {
+                                continue;
+                              }
+                              _ij2[0] = ij2;
+                              _ij2[1] = -1;
+                              for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                              {
+                                if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j2valid[iij2] = false;
+                                  _ij2[1] = iij2;
+                                  break;
+                                }
+                              }
+                              j2 = j2array[ij2];
+                              cj2 = cj2array[ij2];
+                              sj2 = sj2array[ij2];
+                              {
+                                IkReal evalcond[12];
+                                IkReal x217 = IKsin(j2);
+                                IkReal x218 = IKcos(j2);
+                                IkReal x219 = ((IkReal(1.00000000000000)) * (cj0));
+                                IkReal x220 = ((IkReal(1.00000000000000)) * (cj1));
+                                IkReal x221 = ((IkReal(1.00000000000000)) * (x217));
+                                IkReal x222 = ((new_r01) * (x218));
+                                IkReal x223 = ((new_r00) * (x218));
+                                IkReal x224 = ((new_r02) * (x218));
+                                evalcond[0] = ((((new_r02) * (x217))) + (((new_r12) * (x218))));
+                                evalcond[1] = ((sj0) + (((new_r00) * (x217))) + (((new_r10) * (x218))));
+                                evalcond[2] = ((sj1) + (x224) + (((IkReal(-1.00000000000000)) * (new_r12) * (x221))));
+                                evalcond[3] = ((((new_r01) * (x217))) + (((IkReal(-1.00000000000000)) * (x219))) +
+                                               (((new_r11) * (x218))));
+                                evalcond[4] = ((((IkReal(-1.00000000000000)) * (cj1) * (x219))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r10) * (x221))) + (x223));
+                                evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x221))) +
+                                               (((IkReal(-1.00000000000000)) * (sj0) * (x220))) + (x222));
+                                evalcond[6] = ((((IkReal(-1.00000000000000)) * (new_r12) * (x217) * (x220))) +
+                                               (((cj1) * (x224))) + (((new_r22) * (sj1))));
+                                evalcond[7] =
+                                    ((((IkReal(-1.00000000000000)) * (new_r10) * (sj1) * (x221))) + (((sj1) * (x223))) +
+                                     (((IkReal(-1.00000000000000)) * (new_r20) * (x220))));
+                                evalcond[8] =
+                                    ((((sj1) * (x222))) + (((IkReal(-1.00000000000000)) * (new_r11) * (sj1) * (x221))) +
+                                     (((IkReal(-1.00000000000000)) * (new_r21) * (x220))));
+                                evalcond[9] = ((IkReal(1.00000000000000)) + (((sj1) * (x224))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r22) * (x220))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r12) * (sj1) * (x221))));
+                                evalcond[10] = ((((new_r20) * (sj1))) + (((cj1) * (x223))) +
+                                                (((IkReal(-1.00000000000000)) * (new_r10) * (x217) * (x220))) +
+                                                (((IkReal(-1.00000000000000)) * (x219))));
+                                evalcond[11] = ((((IkReal(-1.00000000000000)) * (sj0))) + (((cj1) * (x222))) +
+                                                (((IkReal(-1.00000000000000)) * (new_r11) * (x217) * (x220))) +
+                                                (((new_r21) * (sj1))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                    IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001 ||
+                                    IKabs(evalcond[8]) > 0.000001 || IKabs(evalcond[9]) > 0.000001 ||
+                                    IKabs(evalcond[10]) > 0.000001 || IKabs(evalcond[11]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                vinfos[0].jointtype = 1;
+                                vinfos[0].foffset = j0;
+                                vinfos[0].indices[0] = _ij0[0];
+                                vinfos[0].indices[1] = _ij0[1];
+                                vinfos[0].maxsolutions = _nj0;
+                                vinfos[1].jointtype = 1;
+                                vinfos[1].foffset = j1;
+                                vinfos[1].indices[0] = _ij1[0];
+                                vinfos[1].indices[1] = _ij1[1];
+                                vinfos[1].maxsolutions = _nj1;
+                                vinfos[2].jointtype = 1;
+                                vinfos[2].foffset = j2;
+                                vinfos[2].indices[0] = _ij2[0];
+                                vinfos[2].indices[1] = _ij2[1];
+                                vinfos[2].maxsolutions = _nj2;
+                                vinfos[3].jointtype = 1;
+                                vinfos[3].foffset = j3;
+                                vinfos[3].indices[0] = _ij3[0];
+                                vinfos[3].indices[1] = _ij3[1];
+                                vinfos[3].maxsolutions = _nj3;
+                                vinfos[4].jointtype = 1;
+                                vinfos[4].foffset = j4;
+                                vinfos[4].indices[0] = _ij4[0];
+                                vinfos[4].indices[1] = _ij4[1];
+                                vinfos[4].maxsolutions = _nj4;
+                                vinfos[5].jointtype = 1;
+                                vinfos[5].foffset = j5;
+                                vinfos[5].indices[0] = _ij5[0];
+                                vinfos[5].indices[1] = _ij5[1];
+                                vinfos[5].maxsolutions = _nj5;
+                                vinfos[6].jointtype = 1;
+                                vinfos[6].foffset = j6;
+                                vinfos[6].indices[0] = _ij6[0];
+                                vinfos[6].indices[1] = _ij6[1];
+                                vinfos[6].maxsolutions = _nj6;
+                                std::vector<int> vfree(0);
+                                solutions.AddSolution(vinfos, vfree);
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j2array[1], cj2array[1], sj2array[1];
+                        bool j2valid[1] = { false };
+                        _nj2 = 1;
+                        IkReal x225 = ((gconst17) * (sj1));
+                        if (IKabs(((new_r12) * (x225))) < IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x225))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j2array[0] = IKatan2(((new_r12) * (x225)), ((IkReal(-1.00000000000000)) * (new_r02) * (x225)));
+                        sj2array[0] = IKsin(j2array[0]);
+                        cj2array[0] = IKcos(j2array[0]);
+                        if (j2array[0] > IKPI)
+                        {
+                          j2array[0] -= IK2PI;
+                        }
+                        else if (j2array[0] < -IKPI)
+                        {
+                          j2array[0] += IK2PI;
+                        }
+                        j2valid[0] = true;
+                        for (int ij2 = 0; ij2 < 1; ++ij2)
+                        {
+                          if (!j2valid[ij2])
+                          {
+                            continue;
+                          }
+                          _ij2[0] = ij2;
+                          _ij2[1] = -1;
+                          for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                          {
+                            if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j2valid[iij2] = false;
+                              _ij2[1] = iij2;
+                              break;
+                            }
+                          }
+                          j2 = j2array[ij2];
+                          cj2 = cj2array[ij2];
+                          sj2 = sj2array[ij2];
+                          {
+                            IkReal evalcond[12];
+                            IkReal x226 = IKsin(j2);
+                            IkReal x227 = IKcos(j2);
+                            IkReal x228 = ((IkReal(1.00000000000000)) * (cj0));
+                            IkReal x229 = ((IkReal(1.00000000000000)) * (cj1));
+                            IkReal x230 = ((IkReal(1.00000000000000)) * (x226));
+                            IkReal x231 = ((new_r01) * (x227));
+                            IkReal x232 = ((new_r00) * (x227));
+                            IkReal x233 = ((new_r02) * (x227));
+                            evalcond[0] = ((((new_r02) * (x226))) + (((new_r12) * (x227))));
+                            evalcond[1] = ((((new_r00) * (x226))) + (sj0) + (((new_r10) * (x227))));
+                            evalcond[2] = ((sj1) + (((IkReal(-1.00000000000000)) * (new_r12) * (x230))) + (x233));
+                            evalcond[3] = ((((new_r01) * (x226))) + (((new_r11) * (x227))) +
+                                           (((IkReal(-1.00000000000000)) * (x228))));
+                            evalcond[4] = ((x232) + (((IkReal(-1.00000000000000)) * (cj1) * (x228))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r10) * (x230))));
+                            evalcond[5] = ((((IkReal(-1.00000000000000)) * (sj0) * (x229))) + (x231) +
+                                           (((IkReal(-1.00000000000000)) * (new_r11) * (x230))));
+                            evalcond[6] = ((((IkReal(-1.00000000000000)) * (new_r12) * (x226) * (x229))) +
+                                           (((cj1) * (x233))) + (((new_r22) * (sj1))));
+                            evalcond[7] = ((((sj1) * (x232))) + (((IkReal(-1.00000000000000)) * (new_r20) * (x229))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r10) * (sj1) * (x230))));
+                            evalcond[8] =
+                                ((((sj1) * (x231))) + (((IkReal(-1.00000000000000)) * (new_r11) * (sj1) * (x230))) +
+                                 (((IkReal(-1.00000000000000)) * (new_r21) * (x229))));
+                            evalcond[9] = ((IkReal(1.00000000000000)) + (((sj1) * (x233))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r22) * (x229))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r12) * (sj1) * (x230))));
+                            evalcond[10] = ((((cj1) * (x232))) + (((new_r20) * (sj1))) +
+                                            (((IkReal(-1.00000000000000)) * (new_r10) * (x226) * (x229))) +
+                                            (((IkReal(-1.00000000000000)) * (x228))));
+                            evalcond[11] =
+                                ((((cj1) * (x231))) + (((IkReal(-1.00000000000000)) * (sj0))) +
+                                 (((IkReal(-1.00000000000000)) * (new_r11) * (x226) * (x229))) + (((new_r21) * (sj1))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001 ||
+                                IKabs(evalcond[8]) > 0.000001 || IKabs(evalcond[9]) > 0.000001 ||
+                                IKabs(evalcond[10]) > 0.000001 || IKabs(evalcond[11]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          {
+                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                            vinfos[0].jointtype = 1;
+                            vinfos[0].foffset = j0;
+                            vinfos[0].indices[0] = _ij0[0];
+                            vinfos[0].indices[1] = _ij0[1];
+                            vinfos[0].maxsolutions = _nj0;
+                            vinfos[1].jointtype = 1;
+                            vinfos[1].foffset = j1;
+                            vinfos[1].indices[0] = _ij1[0];
+                            vinfos[1].indices[1] = _ij1[1];
+                            vinfos[1].maxsolutions = _nj1;
+                            vinfos[2].jointtype = 1;
+                            vinfos[2].foffset = j2;
+                            vinfos[2].indices[0] = _ij2[0];
+                            vinfos[2].indices[1] = _ij2[1];
+                            vinfos[2].maxsolutions = _nj2;
+                            vinfos[3].jointtype = 1;
+                            vinfos[3].foffset = j3;
+                            vinfos[3].indices[0] = _ij3[0];
+                            vinfos[3].indices[1] = _ij3[1];
+                            vinfos[3].maxsolutions = _nj3;
+                            vinfos[4].jointtype = 1;
+                            vinfos[4].foffset = j4;
+                            vinfos[4].indices[0] = _ij4[0];
+                            vinfos[4].indices[1] = _ij4[1];
+                            vinfos[4].maxsolutions = _nj4;
+                            vinfos[5].jointtype = 1;
+                            vinfos[5].foffset = j5;
+                            vinfos[5].indices[0] = _ij5[0];
+                            vinfos[5].indices[1] = _ij5[1];
+                            vinfos[5].maxsolutions = _nj5;
+                            vinfos[6].jointtype = 1;
+                            vinfos[6].foffset = j6;
+                            vinfos[6].indices[0] = _ij6[0];
+                            vinfos[6].indices[1] = _ij6[1];
+                            vinfos[6].maxsolutions = _nj6;
+                            std::vector<int> vfree(0);
+                            solutions.AddSolution(vinfos, vfree);
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
 
 /// solves the inverse kinematics equations.
 /// \param pfree is an array specifying the free joints of the chain.
-IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions) {
-IKSolver solver;
-return solver.ComputeIk(eetrans,eerot,pfree,solutions);
+IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree,
+                          IkSolutionListBase<IkReal>& solutions)
+{
+  IKSolver solver;
+  return solver.ComputeIk(eetrans, eerot, pfree, solutions);
 }
 
-IKFAST_API const char* GetKinematicsHash() { return "<robot:genericrobot - motoman_sia20d (72a5dabf099b6c11c75f8620052123af)>"; }
+IKFAST_API const char* GetKinematicsHash()
+{
+  return "<robot:genericrobot - motoman_sia20d (72a5dabf099b6c11c75f8620052123af)>";
+}
 
-IKFAST_API const char* GetIkFastVersion() { return IKFAST_STRINGIZE(IKFAST_VERSION); }
+IKFAST_API const char* GetIkFastVersion()
+{
+  return IKFAST_STRINGIZE(IKFAST_VERSION);
+}
 
 #ifdef IKFAST_NAMESPACE
-} // end namespace
+}  // end namespace
 #endif
 
 #ifndef IKFAST_NO_MAIN
@@ -4253,41 +5595,54 @@ using namespace IKFAST_NAMESPACE;
 #endif
 int main(int argc, char** argv)
 {
-    if( argc != 12+GetNumFreeParameters()+1 ) {
-        printf("\nUsage: ./ik r00 r01 r02 t0 r10 r11 r12 t1 r20 r21 r22 t2 free0 ...\n\n"
-               "Returns the ik solutions given the transformation of the end effector specified by\n"
-               "a 3x3 rotation R (rXX), and a 3x1 translation (tX).\n"
-               "There are %d free parameters that have to be specified.\n\n",GetNumFreeParameters());
-        return 1;
-    }
+  if (argc != 12 + GetNumFreeParameters() + 1)
+  {
+    printf("\nUsage: ./ik r00 r01 r02 t0 r10 r11 r12 t1 r20 r21 r22 t2 free0 ...\n\n"
+           "Returns the ik solutions given the transformation of the end effector specified by\n"
+           "a 3x3 rotation R (rXX), and a 3x1 translation (tX).\n"
+           "There are %d free parameters that have to be specified.\n\n",
+           GetNumFreeParameters());
+    return 1;
+  }
 
-    IkSolutionList<IkReal> solutions;
-    std::vector<IkReal> vfree(GetNumFreeParameters());
-    IkReal eerot[9],eetrans[3];
-    eerot[0] = atof(argv[1]); eerot[1] = atof(argv[2]); eerot[2] = atof(argv[3]); eetrans[0] = atof(argv[4]);
-    eerot[3] = atof(argv[5]); eerot[4] = atof(argv[6]); eerot[5] = atof(argv[7]); eetrans[1] = atof(argv[8]);
-    eerot[6] = atof(argv[9]); eerot[7] = atof(argv[10]); eerot[8] = atof(argv[11]); eetrans[2] = atof(argv[12]);
-    for(std::size_t i = 0; i < vfree.size(); ++i)
-        vfree[i] = atof(argv[13+i]);
-    bool bSuccess = ComputeIk(eetrans, eerot, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
+  IkSolutionList<IkReal> solutions;
+  std::vector<IkReal> vfree(GetNumFreeParameters());
+  IkReal eerot[9], eetrans[3];
+  eerot[0] = atof(argv[1]);
+  eerot[1] = atof(argv[2]);
+  eerot[2] = atof(argv[3]);
+  eetrans[0] = atof(argv[4]);
+  eerot[3] = atof(argv[5]);
+  eerot[4] = atof(argv[6]);
+  eerot[5] = atof(argv[7]);
+  eetrans[1] = atof(argv[8]);
+  eerot[6] = atof(argv[9]);
+  eerot[7] = atof(argv[10]);
+  eerot[8] = atof(argv[11]);
+  eetrans[2] = atof(argv[12]);
+  for (std::size_t i = 0; i < vfree.size(); ++i)
+    vfree[i] = atof(argv[13 + i]);
+  bool bSuccess = ComputeIk(eetrans, eerot, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
 
-    if( !bSuccess ) {
-        fprintf(stderr,"Failed to get ik solution\n");
-        return -1;
-    }
+  if (!bSuccess)
+  {
+    fprintf(stderr, "Failed to get ik solution\n");
+    return -1;
+  }
 
-    printf("Found %d ik solutions:\n", (int)solutions.GetNumSolutions());
-    std::vector<IkReal> solvalues(GetNumJoints());
-    for(std::size_t i = 0; i < solutions.GetNumSolutions(); ++i) {
-        const IkSolutionBase<IkReal>& sol = solutions.GetSolution(i);
-        printf("sol%d (free=%d): ", (int)i, (int)sol.GetFree().size());
-        std::vector<IkReal> vsolfree(sol.GetFree().size());
-        sol.GetSolution(&solvalues[0],vsolfree.size()>0?&vsolfree[0]:NULL);
-        for( std::size_t j = 0; j < solvalues.size(); ++j)
-            printf("%.15f, ", solvalues[j]);
-        printf("\n");
-    }
-    return 0;
+  printf("Found %d ik solutions:\n", (int)solutions.GetNumSolutions());
+  std::vector<IkReal> solvalues(GetNumJoints());
+  for (std::size_t i = 0; i < solutions.GetNumSolutions(); ++i)
+  {
+    const IkSolutionBase<IkReal>& sol = solutions.GetSolution(i);
+    printf("sol%d (free=%d): ", (int)i, (int)sol.GetFree().size());
+    std::vector<IkReal> vsolfree(sol.GetFree().size());
+    sol.GetSolution(&solvalues[0], vsolfree.size() > 0 ? &vsolfree[0] : NULL);
+    for (std::size_t j = 0; j < solvalues.size(); ++j)
+      printf("%.15f, ", solvalues[j]);
+    printf("\n");
+  }
+  return 0;
 }
 
 #endif

--- a/motoman_sia20d_ikfast_manipulator_plugin/include/ikfast.h
+++ b/motoman_sia20d_ikfast_manipulator_plugin/include/ikfast.h
@@ -17,7 +17,8 @@
 
     The file is divided into two sections:
     - <b>Common</b> - the abstract classes section that all ikfast share regardless of their settings
-    - <b>Library Specific</b> - the library-specific definitions, which depends on the precision/settings that the library was compiled with
+    - <b>Library Specific</b> - the library-specific definitions, which depends on the precision/settings that the
+   library was compiled with
 
     The defines are as follows, they are also used for the ikfast C++ class:
 
@@ -25,14 +26,15 @@
    - IKFAST_HAS_LIBRARY - if defined, will include library-specific functions. by default this is off
    - IKFAST_CLIBRARY - Define this linking statically or dynamically to get correct visibility.
    - IKFAST_NO_MAIN - Remove the ``main`` function, usually used with IKFAST_CLIBRARY
-   - IKFAST_ASSERT - Define in order to get a custom assert called when NaNs, divides by zero, and other invalid conditions are detected.
+   - IKFAST_ASSERT - Define in order to get a custom assert called when NaNs, divides by zero, and other invalid
+   conditions are detected.
    - IKFAST_REAL - Use to force a custom real number type for IkReal.
    - IKFAST_NAMESPACE - Enclose all functions and classes in this namespace, the ``main`` function is excluded.
 
  */
-#include <vector>
 #include <list>
 #include <stdexcept>
+#include <vector>
 
 #ifndef IKFAST_HEADER_COMMON
 #define IKFAST_HEADER_COMMON
@@ -40,52 +42,57 @@
 /// should be the same as ikfast.__version__
 #define IKFAST_VERSION 61
 
-namespace ikfast {
-
+namespace ikfast
+{
 /// \brief holds the solution for a single dof
 template <typename T>
 class IkSingleDOFSolutionBase
 {
 public:
-    IkSingleDOFSolutionBase() : fmul(0), foffset(0), freeind(-1), maxsolutions(1) {
-        indices[0] = indices[1] = indices[2] = indices[3] = indices[4] = -1;
-    }
-    T fmul, foffset; ///< joint value is fmul*sol[freeind]+foffset
-    signed char freeind; ///< if >= 0, mimics another joint
-    unsigned char jointtype; ///< joint type, 0x01 is revolute, 0x11 is slider
-    unsigned char maxsolutions; ///< max possible indices, 0 if controlled by free index or a free joint itself
-    unsigned char indices[5]; ///< unique index of the solution used to keep track on what part it came from. sometimes a solution can be repeated for different indices. store at least another repeated root
+  IkSingleDOFSolutionBase() : fmul(0), foffset(0), freeind(-1), maxsolutions(1)
+  {
+    indices[0] = indices[1] = indices[2] = indices[3] = indices[4] = -1;
+  }
+  T fmul, foffset;             ///< joint value is fmul*sol[freeind]+foffset
+  signed char freeind;         ///< if >= 0, mimics another joint
+  unsigned char jointtype;     ///< joint type, 0x01 is revolute, 0x11 is slider
+  unsigned char maxsolutions;  ///< max possible indices, 0 if controlled by free index or a free joint itself
+  unsigned char indices[5];  ///< unique index of the solution used to keep track on what part it came from. sometimes a
+                             /// solution can be repeated for different indices. store at least another repeated root
 };
 
 /// \brief The discrete solutions are returned in this structure.
 ///
 /// Sometimes the joint axes of the robot can align allowing an infinite number of solutions.
-/// Stores all these solutions in the form of free variables that the user has to set when querying the solution. Its prototype is:
+/// Stores all these solutions in the form of free variables that the user has to set when querying the solution. Its
+/// prototype is:
 template <typename T>
 class IkSolutionBase
 {
 public:
-    virtual ~IkSolutionBase() {
-    }
-    /// \brief gets a concrete solution
-    ///
-    /// \param[out] solution the result
-    /// \param[in] freevalues values for the free parameters \se GetFree
-    virtual void GetSolution(T* solution, const T* freevalues) const = 0;
+  virtual ~IkSolutionBase()
+  {
+  }
+  /// \brief gets a concrete solution
+  ///
+  /// \param[out] solution the result
+  /// \param[in] freevalues values for the free parameters \se GetFree
+  virtual void GetSolution(T* solution, const T* freevalues) const = 0;
 
-    /// \brief std::vector version of \ref GetSolution
-    virtual void GetSolution(std::vector<T>& solution, const std::vector<T>& freevalues) const {
-        solution.resize(GetDOF());
-        GetSolution(&solution.at(0), freevalues.size() > 0 ? &freevalues.at(0) : NULL);
-    }
+  /// \brief std::vector version of \ref GetSolution
+  virtual void GetSolution(std::vector<T>& solution, const std::vector<T>& freevalues) const
+  {
+    solution.resize(GetDOF());
+    GetSolution(&solution.at(0), freevalues.size() > 0 ? &freevalues.at(0) : NULL);
+  }
 
-    /// \brief Gets the indices of the configuration space that have to be preset before a full solution can be returned
-    ///
-    /// \return vector of indices indicating the free parameters
-    virtual const std::vector<int>& GetFree() const = 0;
+  /// \brief Gets the indices of the configuration space that have to be preset before a full solution can be returned
+  ///
+  /// \return vector of indices indicating the free parameters
+  virtual const std::vector<int>& GetFree() const = 0;
 
-    /// \brief the dof of the solution
-    virtual const int GetDOF() const = 0;
+  /// \brief the dof of the solution
+  virtual const int GetDOF() const = 0;
 };
 
 /// \brief manages all the solutions
@@ -93,23 +100,26 @@ template <typename T>
 class IkSolutionListBase
 {
 public:
-    virtual ~IkSolutionListBase() {
-    }
+  virtual ~IkSolutionListBase()
+  {
+  }
 
-    /// \brief add one solution and return its index for later retrieval
-    ///
-    /// \param vinfos Solution data for each degree of freedom of the manipulator
-    /// \param vfree If the solution represents an infinite space, holds free parameters of the solution that users can freely set.
-    virtual size_t AddSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree) = 0;
+  /// \brief add one solution and return its index for later retrieval
+  ///
+  /// \param vinfos Solution data for each degree of freedom of the manipulator
+  /// \param vfree If the solution represents an infinite space, holds free parameters of the solution that users can
+  /// freely set.
+  virtual size_t AddSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree) = 0;
 
-    /// \brief returns the solution pointer
-    virtual const IkSolutionBase<T>& GetSolution(size_t index) const = 0;
+  /// \brief returns the solution pointer
+  virtual const IkSolutionBase<T>& GetSolution(size_t index) const = 0;
 
-    /// \brief returns the number of solutions stored
-    virtual size_t GetNumSolutions() const = 0;
+  /// \brief returns the number of solutions stored
+  virtual size_t GetNumSolutions() const = 0;
 
-    /// \brief clears all current solutions, note that any memory addresses returned from \ref GetSolution will be invalidated.
-    virtual void Clear() = 0;
+  /// \brief clears all current solutions, note that any memory addresses returned from \ref GetSolution will be
+  /// invalidated.
+  virtual void Clear() = 0;
 };
 
 /// \brief holds function pointers for all the exported functions of ikfast
@@ -117,28 +127,39 @@ template <typename T>
 class IkFastFunctions
 {
 public:
-    IkFastFunctions() : _ComputeIk(NULL), _ComputeFk(NULL), _GetNumFreeParameters(NULL), _GetFreeParameters(NULL), _GetNumJoints(NULL), _GetIkRealSize(NULL), _GetIkFastVersion(NULL), _GetIkType(NULL), _GetKinematicsHash(NULL) {
-    }
-    virtual ~IkFastFunctions() {
-    }
-    typedef bool (*ComputeIkFn)(const T*, const T*, const T*, IkSolutionListBase<T>&);
-    ComputeIkFn _ComputeIk;
-    typedef void (*ComputeFkFn)(const T*, T*, T*);
-    ComputeFkFn _ComputeFk;
-    typedef int (*GetNumFreeParametersFn)();
-    GetNumFreeParametersFn _GetNumFreeParameters;
-    typedef int* (*GetFreeParametersFn)();
-    GetFreeParametersFn _GetFreeParameters;
-    typedef int (*GetNumJointsFn)();
-    GetNumJointsFn _GetNumJoints;
-    typedef int (*GetIkRealSizeFn)();
-    GetIkRealSizeFn _GetIkRealSize;
-    typedef const char* (*GetIkFastVersionFn)();
-    GetIkFastVersionFn _GetIkFastVersion;
-    typedef int (*GetIkTypeFn)();
-    GetIkTypeFn _GetIkType;
-    typedef const char* (*GetKinematicsHashFn)();
-    GetKinematicsHashFn _GetKinematicsHash;
+  IkFastFunctions()
+    : _ComputeIk(NULL)
+    , _ComputeFk(NULL)
+    , _GetNumFreeParameters(NULL)
+    , _GetFreeParameters(NULL)
+    , _GetNumJoints(NULL)
+    , _GetIkRealSize(NULL)
+    , _GetIkFastVersion(NULL)
+    , _GetIkType(NULL)
+    , _GetKinematicsHash(NULL)
+  {
+  }
+  virtual ~IkFastFunctions()
+  {
+  }
+  typedef bool (*ComputeIkFn)(const T*, const T*, const T*, IkSolutionListBase<T>&);
+  ComputeIkFn _ComputeIk;
+  typedef void (*ComputeFkFn)(const T*, T*, T*);
+  ComputeFkFn _ComputeFk;
+  typedef int (*GetNumFreeParametersFn)();
+  GetNumFreeParametersFn _GetNumFreeParameters;
+  typedef int* (*GetFreeParametersFn)();
+  GetFreeParametersFn _GetFreeParameters;
+  typedef int (*GetNumJointsFn)();
+  GetNumJointsFn _GetNumJoints;
+  typedef int (*GetIkRealSizeFn)();
+  GetIkRealSizeFn _GetIkRealSize;
+  typedef const char* (*GetIkFastVersionFn)();
+  GetIkFastVersionFn _GetIkFastVersion;
+  typedef int (*GetIkTypeFn)();
+  GetIkTypeFn _GetIkType;
+  typedef const char* (*GetKinematicsHashFn)();
+  GetKinematicsHashFn _GetKinematicsHash;
 };
 
 // Implementations of the abstract classes, user doesn't need to use them
@@ -148,80 +169,103 @@ template <typename T>
 class IkSolution : public IkSolutionBase<T>
 {
 public:
-    IkSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree) {
-        _vbasesol = vinfos;
-        _vfree = vfree;
-    }
+  IkSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree)
+  {
+    _vbasesol = vinfos;
+    _vfree = vfree;
+  }
 
-    virtual void GetSolution(T* solution, const T* freevalues) const {
-        for(std::size_t i = 0; i < _vbasesol.size(); ++i) {
-            if( _vbasesol[i].freeind < 0 )
-                solution[i] = _vbasesol[i].foffset;
-            else {
-                solution[i] = freevalues[_vbasesol[i].freeind]*_vbasesol[i].fmul + _vbasesol[i].foffset;
-                if( solution[i] > T(3.14159265358979) ) {
-                    solution[i] -= T(6.28318530717959);
-                }
-                else if( solution[i] < T(-3.14159265358979) ) {
-                    solution[i] += T(6.28318530717959);
-                }
-            }
+  virtual void GetSolution(T* solution, const T* freevalues) const
+  {
+    for (std::size_t i = 0; i < _vbasesol.size(); ++i)
+    {
+      if (_vbasesol[i].freeind < 0)
+        solution[i] = _vbasesol[i].foffset;
+      else
+      {
+        solution[i] = freevalues[_vbasesol[i].freeind] * _vbasesol[i].fmul + _vbasesol[i].foffset;
+        if (solution[i] > T(3.14159265358979))
+        {
+          solution[i] -= T(6.28318530717959);
         }
-    }
-
-    virtual void GetSolution(std::vector<T>& solution, const std::vector<T>& freevalues) const {
-        solution.resize(GetDOF());
-        GetSolution(&solution.at(0), freevalues.size() > 0 ? &freevalues.at(0) : NULL);
-    }
-
-    virtual const std::vector<int>& GetFree() const {
-        return _vfree;
-    }
-    virtual const int GetDOF() const {
-        return static_cast<int>(_vbasesol.size());
-    }
-
-    virtual void Validate() const {
-        for(size_t i = 0; i < _vbasesol.size(); ++i) {
-            if( _vbasesol[i].maxsolutions == (unsigned char)-1) {
-                throw std::runtime_error("max solutions for joint not initialized");
-            }
-            if( _vbasesol[i].maxsolutions > 0 ) {
-                if( _vbasesol[i].indices[0] >= _vbasesol[i].maxsolutions ) {
-                    throw std::runtime_error("index >= max solutions for joint");
-                }
-                if( _vbasesol[i].indices[1] != (unsigned char)-1 && _vbasesol[i].indices[1] >= _vbasesol[i].maxsolutions ) {
-                    throw std::runtime_error("2nd index >= max solutions for joint");
-                }
-            }
+        else if (solution[i] < T(-3.14159265358979))
+        {
+          solution[i] += T(6.28318530717959);
         }
+      }
     }
+  }
 
-    virtual void GetSolutionIndices(std::vector<unsigned int>& v) const {
-        v.resize(0);
-        v.push_back(0);
-        for(int i = (int)_vbasesol.size()-1; i >= 0; --i) {
-            if( _vbasesol[i].maxsolutions != (unsigned char)-1 && _vbasesol[i].maxsolutions > 1 ) {
-                for(size_t j = 0; j < v.size(); ++j) {
-                    v[j] *= _vbasesol[i].maxsolutions;
-                }
-                size_t orgsize=v.size();
-                if( _vbasesol[i].indices[1] != (unsigned char)-1 ) {
-                    for(size_t j = 0; j < orgsize; ++j) {
-                        v.push_back(v[j]+_vbasesol[i].indices[1]);
-                    }
-                }
-                if( _vbasesol[i].indices[0] != (unsigned char)-1 ) {
-                    for(size_t j = 0; j < orgsize; ++j) {
-                        v[j] += _vbasesol[i].indices[0];
-                    }
-                }
-            }
+  virtual void GetSolution(std::vector<T>& solution, const std::vector<T>& freevalues) const
+  {
+    solution.resize(GetDOF());
+    GetSolution(&solution.at(0), freevalues.size() > 0 ? &freevalues.at(0) : NULL);
+  }
+
+  virtual const std::vector<int>& GetFree() const
+  {
+    return _vfree;
+  }
+  virtual const int GetDOF() const
+  {
+    return static_cast<int>(_vbasesol.size());
+  }
+
+  virtual void Validate() const
+  {
+    for (size_t i = 0; i < _vbasesol.size(); ++i)
+    {
+      if (_vbasesol[i].maxsolutions == (unsigned char)-1)
+      {
+        throw std::runtime_error("max solutions for joint not initialized");
+      }
+      if (_vbasesol[i].maxsolutions > 0)
+      {
+        if (_vbasesol[i].indices[0] >= _vbasesol[i].maxsolutions)
+        {
+          throw std::runtime_error("index >= max solutions for joint");
         }
+        if (_vbasesol[i].indices[1] != (unsigned char)-1 && _vbasesol[i].indices[1] >= _vbasesol[i].maxsolutions)
+        {
+          throw std::runtime_error("2nd index >= max solutions for joint");
+        }
+      }
     }
+  }
 
-    std::vector< IkSingleDOFSolutionBase<T> > _vbasesol;       ///< solution and their offsets if joints are mimiced
-    std::vector<int> _vfree;
+  virtual void GetSolutionIndices(std::vector<unsigned int>& v) const
+  {
+    v.resize(0);
+    v.push_back(0);
+    for (int i = (int)_vbasesol.size() - 1; i >= 0; --i)
+    {
+      if (_vbasesol[i].maxsolutions != (unsigned char)-1 && _vbasesol[i].maxsolutions > 1)
+      {
+        for (size_t j = 0; j < v.size(); ++j)
+        {
+          v[j] *= _vbasesol[i].maxsolutions;
+        }
+        size_t orgsize = v.size();
+        if (_vbasesol[i].indices[1] != (unsigned char)-1)
+        {
+          for (size_t j = 0; j < orgsize; ++j)
+          {
+            v.push_back(v[j] + _vbasesol[i].indices[1]);
+          }
+        }
+        if (_vbasesol[i].indices[0] != (unsigned char)-1)
+        {
+          for (size_t j = 0; j < orgsize; ++j)
+          {
+            v[j] += _vbasesol[i].indices[0];
+          }
+        }
+      }
+    }
+  }
+
+  std::vector<IkSingleDOFSolutionBase<T> > _vbasesol;  ///< solution and their offsets if joints are mimiced
+  std::vector<int> _vfree;
 };
 
 /// \brief Default implementation of \ref IkSolutionListBase
@@ -229,38 +273,40 @@ template <typename T>
 class IkSolutionList : public IkSolutionListBase<T>
 {
 public:
-    virtual size_t AddSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree)
+  virtual size_t AddSolution(const std::vector<IkSingleDOFSolutionBase<T> >& vinfos, const std::vector<int>& vfree)
+  {
+    size_t index = _listsolutions.size();
+    _listsolutions.push_back(IkSolution<T>(vinfos, vfree));
+    return index;
+  }
+
+  virtual const IkSolutionBase<T>& GetSolution(size_t index) const
+  {
+    if (index >= _listsolutions.size())
     {
-        size_t index = _listsolutions.size();
-        _listsolutions.push_back(IkSolution<T>(vinfos,vfree));
-        return index;
+      throw std::runtime_error("GetSolution index is invalid");
     }
+    typename std::list<IkSolution<T> >::const_iterator it = _listsolutions.begin();
+    std::advance(it, index);
+    return *it;
+  }
 
-    virtual const IkSolutionBase<T>& GetSolution(size_t index) const
-    {
-        if( index >= _listsolutions.size() ) {
-            throw std::runtime_error("GetSolution index is invalid");
-        }
-        typename std::list< IkSolution<T> >::const_iterator it = _listsolutions.begin();
-        std::advance(it,index);
-        return *it;
-    }
+  virtual size_t GetNumSolutions() const
+  {
+    return _listsolutions.size();
+  }
 
-    virtual size_t GetNumSolutions() const {
-        return _listsolutions.size();
-    }
-
-    virtual void Clear() {
-        _listsolutions.clear();
-    }
+  virtual void Clear()
+  {
+    _listsolutions.clear();
+  }
 
 protected:
-    std::list< IkSolution<T> > _listsolutions;
+  std::list<IkSolution<T> > _listsolutions;
 };
-
 }
 
-#endif // OPENRAVE_IKFAST_HEADER
+#endif  // OPENRAVE_IKFAST_HEADER
 
 // The following code is dependent on the C++ library linking with.
 #ifdef IKFAST_HAS_LIBRARY
@@ -277,7 +323,8 @@ protected:
 #endif
 
 #ifdef IKFAST_NAMESPACE
-namespace IKFAST_NAMESPACE {
+namespace IKFAST_NAMESPACE
+{
 #endif
 
 #ifdef IKFAST_REAL
@@ -292,10 +339,13 @@ typedef double IkReal;
    - ``eerot``
    - For **Transform6D** it is 9 values for the 3x3 rotation matrix.
    - For **Direction3D**, **Ray4D**, and **TranslationDirection5D**, the first 3 values represent the target direction.
-   - For **TranslationXAxisAngle4D**, **TranslationYAxisAngle4D**, and **TranslationZAxisAngle4D** the first value represents the angle.
-   - For **TranslationLocalGlobal6D**, the diagonal elements ([0],[4],[8]) are the local translation inside the end effector coordinate system.
+   - For **TranslationXAxisAngle4D**, **TranslationYAxisAngle4D**, and **TranslationZAxisAngle4D** the first value
+   represents the angle.
+   - For **TranslationLocalGlobal6D**, the diagonal elements ([0],[4],[8]) are the local translation inside the end
+   effector coordinate system.
  */
-IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, ikfast::IkSolutionListBase<IkReal>& solutions);
+IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree,
+                          ikfast::IkSolutionListBase<IkReal>& solutions);
 
 /// \brief Computes the end effector coordinates given the joint values. This function is used to double check ik.
 IKFAST_API void ComputeFk(const IkReal* joints, IkReal* eetrans, IkReal* eerot);
@@ -325,4 +375,4 @@ IKFAST_API const char* GetKinematicsHash();
 }
 #endif
 
-#endif // IKFAST_HAS_LIBRARY
+#endif  // IKFAST_HAS_LIBRARY

--- a/motoman_sia20d_ikfast_manipulator_plugin/src/test_motoman_sia20d_manipulator_ikfast_moveit_plugin.cpp
+++ b/motoman_sia20d_ikfast_manipulator_plugin/src/test_motoman_sia20d_manipulator_ikfast_moveit_plugin.cpp
@@ -2,7 +2,8 @@
  *
  * Software License Agreement (BSD License)
  *
- * Copyright (c) 2013, Dave Coleman, CU Boulder; Jeremy Zoss, SwRI; David Butterworth, KAIST; Mathias Lüdtke, Fraunhofer IPA
+ * Copyright (c) 2013, Dave Coleman, CU Boulder; Jeremy Zoss, SwRI; David Butterworth, KAIST; Mathias Lüdtke, Fraunhofer
+ *IPA
  * All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -45,69 +46,94 @@
  *
  */
 
-#include <ros/ros.h>
 #include <moveit/kinematics_base/kinematics_base.h>
-#include <urdf/model.h>
+#include <ros/ros.h>
 #include <tf_conversions/tf_kdl.h>
+#include <urdf/model.h>
 
 // Need a floating point tolerance when checking joint limits, in case the joint starts at limit
 const double LIMIT_TOLERANCE = .0000001;
 /// \brief Search modes for searchPositionIK(), see there
-enum SEARCH_MODE { OPTIMIZE_FREE_JOINT=1, OPTIMIZE_MAX_JOINT=2 };
+enum SEARCH_MODE
+{
+  OPTIMIZE_FREE_JOINT = 1,
+  OPTIMIZE_MAX_JOINT = 2
+};
 
 namespace ikfast_kinematics_plugin
 {
-
-#define IKFAST_NO_MAIN // Don't include main() from IKFast
+#define IKFAST_NO_MAIN  // Don't include main() from IKFast
 
 /// \brief The types of inverse kinematics parameterizations supported.
 ///
 /// The minimum degree of freedoms required is set in the upper 4 bits of each type.
 /// The number of values used to represent the parameterization ( >= dof ) is the next 4 bits.
 /// The lower bits contain a unique id of the type.
-enum IkParameterizationType {
-    IKP_None=0,
-    IKP_Transform6D=0x67000001,     ///< end effector reaches desired 6D transformation
-    IKP_Rotation3D=0x34000002,     ///< end effector reaches desired 3D rotation
-    IKP_Translation3D=0x33000003,     ///< end effector origin reaches desired 3D translation
-    IKP_Direction3D=0x23000004,     ///< direction on end effector coordinate system reaches desired direction
-    IKP_Ray4D=0x46000005,     ///< ray on end effector coordinate system reaches desired global ray
-    IKP_Lookat3D=0x23000006,     ///< direction on end effector coordinate system points to desired 3D position
-    IKP_TranslationDirection5D=0x56000007,     ///< end effector origin and direction reaches desired 3D translation and direction. Can be thought of as Ray IK where the origin of the ray must coincide.
-    IKP_TranslationXY2D=0x22000008,     ///< 2D translation along XY plane
-    IKP_TranslationXYOrientation3D=0x33000009,     ///< 2D translation along XY plane and 1D rotation around Z axis. The offset of the rotation is measured starting at +X, so at +X is it 0, at +Y it is pi/2.
-    IKP_TranslationLocalGlobal6D=0x3600000a,     ///< local point on end effector origin reaches desired 3D global point
+enum IkParameterizationType
+{
+  IKP_None = 0,
+  IKP_Transform6D = 0x67000001,    ///< end effector reaches desired 6D transformation
+  IKP_Rotation3D = 0x34000002,     ///< end effector reaches desired 3D rotation
+  IKP_Translation3D = 0x33000003,  ///< end effector origin reaches desired 3D translation
+  IKP_Direction3D = 0x23000004,    ///< direction on end effector coordinate system reaches desired direction
+  IKP_Ray4D = 0x46000005,          ///< ray on end effector coordinate system reaches desired global ray
+  IKP_Lookat3D = 0x23000006,       ///< direction on end effector coordinate system points to desired 3D position
+  IKP_TranslationDirection5D = 0x56000007,  ///< end effector origin and direction reaches desired 3D translation and
+                                            /// direction. Can be thought of as Ray IK where the origin of the ray must
+  /// coincide.
+  IKP_TranslationXY2D = 0x22000008,             ///< 2D translation along XY plane
+  IKP_TranslationXYOrientation3D = 0x33000009,  ///< 2D translation along XY plane and 1D rotation around Z axis. The
+                                                /// offset of the rotation is measured starting at +X, so at +X is it 0,
+  /// at +Y it is pi/2.
+  IKP_TranslationLocalGlobal6D = 0x3600000a,  ///< local point on end effector origin reaches desired 3D global point
 
-    IKP_TranslationXAxisAngle4D=0x4400000b, ///< end effector origin reaches desired 3D translation, manipulator direction makes a specific angle with x-axis  like a cone, angle is from 0-pi. Axes defined in the manipulator base link's coordinate system)
-    IKP_TranslationYAxisAngle4D=0x4400000c, ///< end effector origin reaches desired 3D translation, manipulator direction makes a specific angle with y-axis  like a cone, angle is from 0-pi. Axes defined in the manipulator base link's coordinate system)
-    IKP_TranslationZAxisAngle4D=0x4400000d, ///< end effector origin reaches desired 3D translation, manipulator direction makes a specific angle with z-axis like a cone, angle is from 0-pi. Axes are defined in the manipulator base link's coordinate system.
+  IKP_TranslationXAxisAngle4D = 0x4400000b,  ///< end effector origin reaches desired 3D translation, manipulator
+  /// direction makes a specific angle with x-axis  like a cone, angle is from
+  /// 0-pi. Axes defined in the manipulator base link's coordinate system)
+  IKP_TranslationYAxisAngle4D = 0x4400000c,  ///< end effector origin reaches desired 3D translation, manipulator
+  /// direction makes a specific angle with y-axis  like a cone, angle is from
+  /// 0-pi. Axes defined in the manipulator base link's coordinate system)
+  IKP_TranslationZAxisAngle4D = 0x4400000d,  ///< end effector origin reaches desired 3D translation, manipulator
+                                             /// direction makes a specific angle with z-axis like a cone, angle is from
+  /// 0-pi. Axes are defined in the manipulator base link's coordinate system.
 
-    IKP_TranslationXAxisAngleZNorm4D=0x4400000e, ///< end effector origin reaches desired 3D translation, manipulator direction needs to be orthogonal to z-axis and be rotated at a certain angle starting from the x-axis (defined in the manipulator base link's coordinate system)
-    IKP_TranslationYAxisAngleXNorm4D=0x4400000f, ///< end effector origin reaches desired 3D translation, manipulator direction needs to be orthogonal to x-axis and be rotated at a certain angle starting from the y-axis (defined in the manipulator base link's coordinate system)
-    IKP_TranslationZAxisAngleYNorm4D=0x44000010, ///< end effector origin reaches desired 3D translation, manipulator direction needs to be orthogonal to y-axis and be rotated at a certain angle starting from the z-axis (defined in the manipulator base link's coordinate system)
+  IKP_TranslationXAxisAngleZNorm4D = 0x4400000e,  ///< end effector origin reaches desired 3D translation, manipulator
+                                                  /// direction needs to be orthogonal to z-axis and be rotated at a
+  /// certain angle starting from the x-axis (defined in the manipulator
+  /// base link's coordinate system)
+  IKP_TranslationYAxisAngleXNorm4D = 0x4400000f,  ///< end effector origin reaches desired 3D translation, manipulator
+                                                  /// direction needs to be orthogonal to x-axis and be rotated at a
+  /// certain angle starting from the y-axis (defined in the manipulator
+  /// base link's coordinate system)
+  IKP_TranslationZAxisAngleYNorm4D = 0x44000010,  ///< end effector origin reaches desired 3D translation, manipulator
+                                                  /// direction needs to be orthogonal to y-axis and be rotated at a
+  /// certain angle starting from the z-axis (defined in the manipulator
+  /// base link's coordinate system)
 
-    IKP_NumberOfParameterizations=16,     ///< number of parameterizations (does not count IKP_None)
+  IKP_NumberOfParameterizations = 16,  ///< number of parameterizations (does not count IKP_None)
 
-    IKP_VelocityDataBit = 0x00008000, ///< bit is set if the data represents the time-derivate velocity of an IkParameterization
-    IKP_Transform6DVelocity = IKP_Transform6D|IKP_VelocityDataBit,
-    IKP_Rotation3DVelocity = IKP_Rotation3D|IKP_VelocityDataBit,
-    IKP_Translation3DVelocity = IKP_Translation3D|IKP_VelocityDataBit,
-    IKP_Direction3DVelocity = IKP_Direction3D|IKP_VelocityDataBit,
-    IKP_Ray4DVelocity = IKP_Ray4D|IKP_VelocityDataBit,
-    IKP_Lookat3DVelocity = IKP_Lookat3D|IKP_VelocityDataBit,
-    IKP_TranslationDirection5DVelocity = IKP_TranslationDirection5D|IKP_VelocityDataBit,
-    IKP_TranslationXY2DVelocity = IKP_TranslationXY2D|IKP_VelocityDataBit,
-    IKP_TranslationXYOrientation3DVelocity = IKP_TranslationXYOrientation3D|IKP_VelocityDataBit,
-    IKP_TranslationLocalGlobal6DVelocity = IKP_TranslationLocalGlobal6D|IKP_VelocityDataBit,
-    IKP_TranslationXAxisAngle4DVelocity = IKP_TranslationXAxisAngle4D|IKP_VelocityDataBit,
-    IKP_TranslationYAxisAngle4DVelocity = IKP_TranslationYAxisAngle4D|IKP_VelocityDataBit,
-    IKP_TranslationZAxisAngle4DVelocity = IKP_TranslationZAxisAngle4D|IKP_VelocityDataBit,
-    IKP_TranslationXAxisAngleZNorm4DVelocity = IKP_TranslationXAxisAngleZNorm4D|IKP_VelocityDataBit,
-    IKP_TranslationYAxisAngleXNorm4DVelocity = IKP_TranslationYAxisAngleXNorm4D|IKP_VelocityDataBit,
-    IKP_TranslationZAxisAngleYNorm4DVelocity = IKP_TranslationZAxisAngleYNorm4D|IKP_VelocityDataBit,
+  IKP_VelocityDataBit =
+      0x00008000,  ///< bit is set if the data represents the time-derivate velocity of an IkParameterization
+  IKP_Transform6DVelocity = IKP_Transform6D | IKP_VelocityDataBit,
+  IKP_Rotation3DVelocity = IKP_Rotation3D | IKP_VelocityDataBit,
+  IKP_Translation3DVelocity = IKP_Translation3D | IKP_VelocityDataBit,
+  IKP_Direction3DVelocity = IKP_Direction3D | IKP_VelocityDataBit,
+  IKP_Ray4DVelocity = IKP_Ray4D | IKP_VelocityDataBit,
+  IKP_Lookat3DVelocity = IKP_Lookat3D | IKP_VelocityDataBit,
+  IKP_TranslationDirection5DVelocity = IKP_TranslationDirection5D | IKP_VelocityDataBit,
+  IKP_TranslationXY2DVelocity = IKP_TranslationXY2D | IKP_VelocityDataBit,
+  IKP_TranslationXYOrientation3DVelocity = IKP_TranslationXYOrientation3D | IKP_VelocityDataBit,
+  IKP_TranslationLocalGlobal6DVelocity = IKP_TranslationLocalGlobal6D | IKP_VelocityDataBit,
+  IKP_TranslationXAxisAngle4DVelocity = IKP_TranslationXAxisAngle4D | IKP_VelocityDataBit,
+  IKP_TranslationYAxisAngle4DVelocity = IKP_TranslationYAxisAngle4D | IKP_VelocityDataBit,
+  IKP_TranslationZAxisAngle4DVelocity = IKP_TranslationZAxisAngle4D | IKP_VelocityDataBit,
+  IKP_TranslationXAxisAngleZNorm4DVelocity = IKP_TranslationXAxisAngleZNorm4D | IKP_VelocityDataBit,
+  IKP_TranslationYAxisAngleXNorm4DVelocity = IKP_TranslationYAxisAngleXNorm4D | IKP_VelocityDataBit,
+  IKP_TranslationZAxisAngleYNorm4DVelocity = IKP_TranslationZAxisAngleYNorm4D | IKP_VelocityDataBit,
 
-    IKP_UniqueIdMask = 0x0000ffff, ///< the mask for the unique ids
-    IKP_CustomDataBit = 0x00010000, ///< bit is set if the ikparameterization contains custom data, this is only used when serializing the ik parameterizations
+  IKP_UniqueIdMask = 0x0000ffff,   ///< the mask for the unique ids
+  IKP_CustomDataBit = 0x00010000,  ///< bit is set if the ikparameterization contains custom data, this is only used
+                                   /// when serializing the ik parameterizations
 };
 
 // Code generated by IKFast56/61
@@ -122,20 +148,24 @@ class IKFastKinematicsPlugin : public kinematics::KinematicsBase
   std::vector<std::string> link_names_;
   size_t num_joints_;
   std::vector<int> free_params_;
-  bool active_; // Internal variable that indicates whether solvers are configured and ready
+  bool active_;  // Internal variable that indicates whether solvers are configured and ready
 
-  const std::vector<std::string>& getJointNames() const { return joint_names_; }
-  const std::vector<std::string>& getLinkNames() const { return link_names_; }
+  const std::vector<std::string>& getJointNames() const
+  {
+    return joint_names_;
+  }
+  const std::vector<std::string>& getLinkNames() const
+  {
+    return link_names_;
+  }
 
 public:
-
   /** @class
    *  @brief Interface for an IKFast kinematics plugin
    */
-  IKFastKinematicsPlugin():
-    active_(false)
+  IKFastKinematicsPlugin() : active_(false)
   {
-    srand( time(NULL) );
+    srand(time(NULL));
     supported_methods_.push_back(kinematics::DiscretizationMethods::NO_DISCRETIZATION);
     supported_methods_.push_back(kinematics::DiscretizationMethods::ALL_DISCRETIZED);
     supported_methods_.push_back(kinematics::DiscretizationMethods::ALL_RANDOM_SAMPLED);
@@ -151,11 +181,9 @@ public:
    */
 
   // Returns the first IK solution that is within joint limits, this is called by get_ik() service
-  bool getPositionIK(const geometry_msgs::Pose &ik_pose,
-                     const std::vector<double> &ik_seed_state,
-                     std::vector<double> &solution,
-                     moveit_msgs::MoveItErrorCodes &error_code,
-                     const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+  bool getPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+                     std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                     const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, compute the set joint angles solutions that are able to reach it.
@@ -172,11 +200,9 @@ public:
    *                other will result in failure.
    * @return True if a valid set of solutions was found, false otherwise.
    */
-  bool getPositionIK(const std::vector<geometry_msgs::Pose> &ik_poses,
-                             const std::vector<double> &ik_seed_state,
-                             std::vector< std::vector<double> >& solutions,
-                             kinematics::KinematicsResult& result,
-                             const kinematics::KinematicsQueryOptions &options) const;
+  bool getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
+                     std::vector<std::vector<double> >& solutions, kinematics::KinematicsResult& result,
+                     const kinematics::KinematicsQueryOptions& options) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -186,12 +212,9 @@ public:
    * @param ik_seed_state an initial guess solution for the inverse kinematics
    * @return True if a valid solution was found, false otherwise
    */
-  bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                        const std::vector<double> &ik_seed_state,
-                        double timeout,
-                        std::vector<double> &solution,
-                        moveit_msgs::MoveItErrorCodes &error_code,
-                        const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                        const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -202,13 +225,10 @@ public:
    * @param the distance that the redundancy can be from the current position
    * @return True if a valid solution was found, false otherwise
    */
-  bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                        const std::vector<double> &ik_seed_state,
-                        double timeout,
-                        const std::vector<double> &consistency_limits,
-                        std::vector<double> &solution,
-                        moveit_msgs::MoveItErrorCodes &error_code,
-                        const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        const std::vector<double>& consistency_limits, std::vector<double>& solution,
+                        moveit_msgs::MoveItErrorCodes& error_code,
+                        const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -218,13 +238,10 @@ public:
    * @param ik_seed_state an initial guess solution for the inverse kinematics
    * @return True if a valid solution was found, false otherwise
    */
-  bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                        const std::vector<double> &ik_seed_state,
-                        double timeout,
-                        std::vector<double> &solution,
-                        const IKCallbackFn &solution_callback,
-                        moveit_msgs::MoveItErrorCodes &error_code,
-                        const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                        moveit_msgs::MoveItErrorCodes& error_code,
+                        const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -236,14 +253,10 @@ public:
    * @param consistency_limit the distance that the redundancy can be from the current position
    * @return True if a valid solution was found, false otherwise
    */
-  bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                        const std::vector<double> &ik_seed_state,
-                        double timeout,
-                        const std::vector<double> &consistency_limits,
-                        std::vector<double> &solution,
-                        const IKCallbackFn &solution_callback,
-                        moveit_msgs::MoveItErrorCodes &error_code,
-                        const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+  bool searchPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state, double timeout,
+                        const std::vector<double>& consistency_limits, std::vector<double>& solution,
+                        const IKCallbackFn& solution_callback, moveit_msgs::MoveItErrorCodes& error_code,
+                        const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const;
 
   /**
    * @brief Given a set of joint angles and a set of links, compute their pose
@@ -253,79 +266,72 @@ public:
    * @param poses The resultant set of poses (in the frame returned by getBaseFrame())
    * @return True if a valid solution was found, false otherwise
    */
-  bool getPositionFK(const std::vector<std::string> &link_names,
-                     const std::vector<double> &joint_angles,
-                     std::vector<geometry_msgs::Pose> &poses) const;
-
+  bool getPositionFK(const std::vector<std::string>& link_names, const std::vector<double>& joint_angles,
+                     std::vector<geometry_msgs::Pose>& poses) const;
 
   /**
    * @brief Sets the discretization value for the redundant joint.
    *
-   * Since this ikfast implementation allows for one redundant joint then only the first entry will be in the discretization map will be used.
+   * Since this ikfast implementation allows for one redundant joint then only the first entry will be in the
+   * discretization map will be used.
    * Calling this method replaces previous discretization settings.
    *
    * @param discretization a map of joint indices and discretization value pairs.
    */
-  void setSearchDiscretization(const std::map<int,double>& discretization);
+  void setSearchDiscretization(const std::map<int, double>& discretization);
 
   /**
    * @brief Overrides the default method to prevent changing the redundant joints
    */
-  bool setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices);
-
+  bool setRedundantJoints(const std::vector<unsigned int>& redundant_joint_indices);
 
 private:
-
-  bool initialize(const std::string &robot_description,
-                  const std::string& group_name,
-                  const std::string& base_name,
-                  const std::string& tip_name,
-                  double search_discretization);
+  bool initialize(const std::string& robot_description, const std::string& group_name, const std::string& base_name,
+                  const std::string& tip_name, double search_discretization);
 
   /**
    * @brief Calls the IK solver from IKFast
    * @return The number of solutions found
    */
-  int solve(KDL::Frame &pose_frame, const std::vector<double> &vfree, IkSolutionList<IkReal> &solutions) const;
+  int solve(KDL::Frame& pose_frame, const std::vector<double>& vfree, IkSolutionList<IkReal>& solutions) const;
 
   /**
    * @brief Gets a specific solution from the set
    */
-  void getSolution(const IkSolutionList<IkReal> &solutions, int i, std::vector<double>& solution) const;
+  void getSolution(const IkSolutionList<IkReal>& solutions, int i, std::vector<double>& solution) const;
 
-  double harmonize(const std::vector<double> &ik_seed_state, std::vector<double> &solution) const;
-  //void getOrderedSolutions(const std::vector<double> &ik_seed_state, std::vector<std::vector<double> >& solslist);
-  void getClosestSolution(const IkSolutionList<IkReal> &solutions, const std::vector<double> &ik_seed_state, std::vector<double> &solution) const;
-  void fillFreeParams(int count, int *array);
-  bool getCount(int &count, const int &max_count, const int &min_count) const;
+  double harmonize(const std::vector<double>& ik_seed_state, std::vector<double>& solution) const;
+  // void getOrderedSolutions(const std::vector<double> &ik_seed_state, std::vector<std::vector<double> >& solslist);
+  void getClosestSolution(const IkSolutionList<IkReal>& solutions, const std::vector<double>& ik_seed_state,
+                          std::vector<double>& solution) const;
+  void fillFreeParams(int count, int* array);
+  bool getCount(int& count, const int& max_count, const int& min_count) const;
 
   bool sampleRedundantJoint(kinematics::DiscretizationMethod method, std::vector<double>& sampled_joint_vals) const;
 
-}; // end class
+};  // end class
 
-bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
-                                        const std::string& group_name,
-                                        const std::string& base_name,
-                                        const std::string& tip_name,
+bool IKFastKinematicsPlugin::initialize(const std::string& robot_description, const std::string& group_name,
+                                        const std::string& base_name, const std::string& tip_name,
                                         double search_discretization)
 {
   setValues(robot_description, group_name, base_name, tip_name, search_discretization);
 
-  ros::NodeHandle node_handle("~/"+group_name);
+  ros::NodeHandle node_handle("~/" + group_name);
 
   std::string robot;
-  node_handle.param("robot",robot,std::string());
+  node_handle.param("robot", robot, std::string());
 
   // IKFast56/61
-  fillFreeParams( GetNumFreeParameters(), GetFreeParameters() );
+  fillFreeParams(GetNumFreeParameters(), GetFreeParameters());
   num_joints_ = GetNumJoints();
 
-  if(free_params_.size() > 1)
+  if (free_params_.size() > 1)
   {
     ROS_FATAL("Only one free joint parameter supported!");
     return false;
   }
-  else if(free_params_.size() == 1)
+  else if (free_params_.size() == 1)
   {
     redundant_joint_indices_.clear();
     redundant_joint_indices_.push_back(free_params_[0]);
@@ -335,44 +341,46 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
   urdf::Model robot_model;
   std::string xml_string;
 
-  std::string urdf_xml,full_urdf_xml;
-  node_handle.param("urdf_xml",urdf_xml,robot_description);
-  node_handle.searchParam(urdf_xml,full_urdf_xml);
+  std::string urdf_xml, full_urdf_xml;
+  node_handle.param("urdf_xml", urdf_xml, robot_description);
+  node_handle.searchParam(urdf_xml, full_urdf_xml);
 
-  ROS_DEBUG_NAMED("ikfast","Reading xml file from parameter server");
+  ROS_DEBUG_NAMED("ikfast", "Reading xml file from parameter server");
   if (!node_handle.getParam(full_urdf_xml, xml_string))
   {
-    ROS_FATAL_NAMED("ikfast","Could not load the xml from parameter server: %s", urdf_xml.c_str());
+    ROS_FATAL_NAMED("ikfast", "Could not load the xml from parameter server: %s", urdf_xml.c_str());
     return false;
   }
 
-  node_handle.param(full_urdf_xml,xml_string,std::string());
+  node_handle.param(full_urdf_xml, xml_string, std::string());
   robot_model.initString(xml_string);
 
-  ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "Reading joints and links from URDF");
 
   boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
-  while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
+  while (link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
-    ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
+    ROS_DEBUG_NAMED("ikfast", "Link %s", link->name.c_str());
     link_names_.push_back(link->name);
     boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
-    if(joint)
+    if (joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)
       {
-        ROS_DEBUG_STREAM_NAMED("ikfast","Adding joint " << joint->name );
+        ROS_DEBUG_STREAM_NAMED("ikfast", "Adding joint " << joint->name);
 
         joint_names_.push_back(joint->name);
         float lower, upper;
         int hasLimits;
-        if ( joint->type != urdf::Joint::CONTINUOUS )
+        if (joint->type != urdf::Joint::CONTINUOUS)
         {
-          if(joint->safety)
+          if (joint->safety)
           {
             lower = joint->safety->soft_lower_limit;
             upper = joint->safety->soft_upper_limit;
-          } else {
+          }
+          else
+          {
             lower = joint->limits->lower;
             upper = joint->limits->upper;
           }
@@ -384,7 +392,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
           upper = M_PI;
           hasLimits = 0;
         }
-        if(hasLimits)
+        if (hasLimits)
         {
           joint_has_limits_vector_.push_back(true);
           joint_min_vector_.push_back(lower);
@@ -397,80 +405,82 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
           joint_max_vector_.push_back(M_PI);
         }
       }
-    } else
+    }
+    else
     {
-      ROS_WARN_NAMED("ikfast","no joint corresponding to %s",link->name.c_str());
+      ROS_WARN_NAMED("ikfast", "no joint corresponding to %s", link->name.c_str());
     }
     link = link->getParent();
   }
 
-  if(joint_names_.size() != num_joints_)
+  if (joint_names_.size() != num_joints_)
   {
-    ROS_FATAL_STREAM_NAMED("ikfast","Joint numbers mismatch: URDF has " << joint_names_.size() << " and IKFast has " << num_joints_);
+    ROS_FATAL_STREAM_NAMED("ikfast", "Joint numbers mismatch: URDF has " << joint_names_.size() << " and IKFast has "
+                                                                         << num_joints_);
     return false;
   }
 
-  std::reverse(link_names_.begin(),link_names_.end());
-  std::reverse(joint_names_.begin(),joint_names_.end());
-  std::reverse(joint_min_vector_.begin(),joint_min_vector_.end());
-  std::reverse(joint_max_vector_.begin(),joint_max_vector_.end());
+  std::reverse(link_names_.begin(), link_names_.end());
+  std::reverse(joint_names_.begin(), joint_names_.end());
+  std::reverse(joint_min_vector_.begin(), joint_min_vector_.end());
+  std::reverse(joint_max_vector_.begin(), joint_max_vector_.end());
   std::reverse(joint_has_limits_vector_.begin(), joint_has_limits_vector_.end());
 
-  for(size_t i=0; i <num_joints_; ++i)
-    ROS_DEBUG_STREAM_NAMED("ikfast",joint_names_[i] << " " << joint_min_vector_[i] << " " << joint_max_vector_[i] << " " << joint_has_limits_vector_[i]);
+  for (size_t i = 0; i < num_joints_; ++i)
+    ROS_DEBUG_STREAM_NAMED("ikfast", joint_names_[i] << " " << joint_min_vector_[i] << " " << joint_max_vector_[i]
+                                                     << " " << joint_has_limits_vector_[i]);
 
   active_ = true;
   return true;
 }
 
-void IKFastKinematicsPlugin::setSearchDiscretization(const std::map<int,double>& discretization)
+void IKFastKinematicsPlugin::setSearchDiscretization(const std::map<int, double>& discretization)
 {
-
-  if(discretization.empty())
+  if (discretization.empty())
   {
     ROS_ERROR("The 'discretization' map is empty");
     return;
   }
 
-  if(redundant_joint_indices_.empty())
+  if (redundant_joint_indices_.empty())
   {
     ROS_ERROR_STREAM("This group's solver doesn't support redundant joints");
     return;
   }
 
-  if(discretization.begin()->first != redundant_joint_indices_[0])
+  if (discretization.begin()->first != redundant_joint_indices_[0])
   {
     std::string redundant_joint = joint_names_[free_params_[0]];
-    ROS_ERROR_STREAM("Attempted to discretize a non-redundant joint "<<discretization.begin()->first<<", only joint '"<<
-                     redundant_joint<<"' with index " <<redundant_joint_indices_[0]<<" is redundant.");
+    ROS_ERROR_STREAM("Attempted to discretize a non-redundant joint "
+                     << discretization.begin()->first << ", only joint '" << redundant_joint << "' with index "
+                     << redundant_joint_indices_[0] << " is redundant.");
     return;
   }
 
-  if(discretization.begin()->second <= 0.0)
+  if (discretization.begin()->second <= 0.0)
   {
-	  ROS_ERROR_STREAM("Discretization can not takes values that are <= 0");
-	  return;
+    ROS_ERROR_STREAM("Discretization can not takes values that are <= 0");
+    return;
   }
-
 
   redundant_joint_discretization_.clear();
   redundant_joint_discretization_[redundant_joint_indices_[0]] = discretization.begin()->second;
 }
 
-bool IKFastKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices)
+bool IKFastKinematicsPlugin::setRedundantJoints(const std::vector<unsigned int>& redundant_joint_indices)
 {
-
   ROS_ERROR_STREAM("Changing the redundant joints isn't permitted by this group's solver ");
   return false;
 }
 
-int IKFastKinematicsPlugin::solve(KDL::Frame &pose_frame, const std::vector<double> &vfree, IkSolutionList<IkReal> &solutions) const
+int IKFastKinematicsPlugin::solve(KDL::Frame& pose_frame, const std::vector<double>& vfree,
+                                  IkSolutionList<IkReal>& solutions) const
 {
   // IKFast56/61
   solutions.Clear();
 
   double trans[3];
-  trans[0] = pose_frame.p[0];//-.18;
+  trans[0] = pose_frame.p[0];  //-.18;
   trans[1] = pose_frame.p[1];
   trans[2] = pose_frame.p[2];
 
@@ -486,15 +496,15 @@ int IKFastKinematicsPlugin::solve(KDL::Frame &pose_frame, const std::vector<doub
       mult = pose_frame.M;
 
       double vals[9];
-      vals[0] = mult(0,0);
-      vals[1] = mult(0,1);
-      vals[2] = mult(0,2);
-      vals[3] = mult(1,0);
-      vals[4] = mult(1,1);
-      vals[5] = mult(1,2);
-      vals[6] = mult(2,0);
-      vals[7] = mult(2,1);
-      vals[8] = mult(2,2);
+      vals[0] = mult(0, 0);
+      vals[1] = mult(0, 1);
+      vals[2] = mult(0, 2);
+      vals[3] = mult(1, 0);
+      vals[4] = mult(1, 1);
+      vals[5] = mult(1, 2);
+      vals[6] = mult(2, 0);
+      vals[7] = mult(2, 1);
+      vals[8] = mult(2, 2);
 
       // IKFast56/61
       ComputeIk(trans, vals, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
@@ -503,7 +513,8 @@ int IKFastKinematicsPlugin::solve(KDL::Frame &pose_frame, const std::vector<doub
     case IKP_Direction3D:
     case IKP_Ray4D:
     case IKP_TranslationDirection5D:
-      // For **Direction3D**, **Ray4D**, and **TranslationDirection5D**, the first 3 values represent the target direction.
+      // For **Direction3D**, **Ray4D**, and **TranslationDirection5D**, the first 3 values represent the target
+      // direction.
 
       direction = pose_frame.M * KDL::Vector(0, 0, 1);
       ComputeIk(trans, direction.data, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
@@ -512,12 +523,14 @@ int IKFastKinematicsPlugin::solve(KDL::Frame &pose_frame, const std::vector<doub
     case IKP_TranslationXAxisAngle4D:
     case IKP_TranslationYAxisAngle4D:
     case IKP_TranslationZAxisAngle4D:
-      // For **TranslationXAxisAngle4D**, **TranslationYAxisAngle4D**, and **TranslationZAxisAngle4D**, the first value represents the angle.
+      // For **TranslationXAxisAngle4D**, **TranslationYAxisAngle4D**, and **TranslationZAxisAngle4D**, the first value
+      // represents the angle.
       ROS_ERROR_NAMED("ikfast", "IK for this IkParameterizationType not implemented yet.");
       return 0;
 
     case IKP_TranslationLocalGlobal6D:
-      // For **TranslationLocalGlobal6D**, the diagonal elements ([0],[4],[8]) are the local translation inside the end effector coordinate system.
+      // For **TranslationLocalGlobal6D**, the diagonal elements ([0],[4],[8]) are the local translation inside the end
+      // effector coordinate system.
       ROS_ERROR_NAMED("ikfast", "IK for this IkParameterizationType not implemented yet.");
       return 0;
 
@@ -532,46 +545,52 @@ int IKFastKinematicsPlugin::solve(KDL::Frame &pose_frame, const std::vector<doub
       return 0;
 
     default:
-      ROS_ERROR_NAMED("ikfast", "Unknown IkParameterizationType! Was the solver generated with an incompatible version of Openrave?");
+      ROS_ERROR_NAMED("ikfast", "Unknown IkParameterizationType! Was the solver generated with an incompatible version "
+                                "of Openrave?");
       return 0;
   }
 }
 
-void IKFastKinematicsPlugin::getSolution(const IkSolutionList<IkReal> &solutions, int i, std::vector<double>& solution) const
+void IKFastKinematicsPlugin::getSolution(const IkSolutionList<IkReal>& solutions, int i,
+                                         std::vector<double>& solution) const
 {
   solution.clear();
   solution.resize(num_joints_);
 
   // IKFast56/61
   const IkSolutionBase<IkReal>& sol = solutions.GetSolution(i);
-  std::vector<IkReal> vsolfree( sol.GetFree().size() );
-  sol.GetSolution(&solution[0],vsolfree.size()>0?&vsolfree[0]:NULL);
+  std::vector<IkReal> vsolfree(sol.GetFree().size());
+  sol.GetSolution(&solution[0], vsolfree.size() > 0 ? &vsolfree[0] : NULL);
 
   // std::cout << "solution " << i << ":" ;
   // for(int j=0;j<num_joints_; ++j)
   //   std::cout << " " << solution[j];
   // std::cout << std::endl;
 
-  //ROS_ERROR("%f %d",solution[2],vsolfree.size());
+  // ROS_ERROR("%f %d",solution[2],vsolfree.size());
 }
 
-double IKFastKinematicsPlugin::harmonize(const std::vector<double> &ik_seed_state, std::vector<double> &solution) const
+double IKFastKinematicsPlugin::harmonize(const std::vector<double>& ik_seed_state, std::vector<double>& solution) const
 {
   double dist_sqr = 0;
   std::vector<double> ss = ik_seed_state;
-  for(size_t i=0; i< ik_seed_state.size(); ++i)
+  for (size_t i = 0; i < ik_seed_state.size(); ++i)
   {
-    while(ss[i] > 2*M_PI) {
-      ss[i] -= 2*M_PI;
+    while (ss[i] > 2 * M_PI)
+    {
+      ss[i] -= 2 * M_PI;
     }
-    while(ss[i] < 2*M_PI) {
-      ss[i] += 2*M_PI;
+    while (ss[i] < 2 * M_PI)
+    {
+      ss[i] += 2 * M_PI;
     }
-    while(solution[i] > 2*M_PI) {
-      solution[i] -= 2*M_PI;
+    while (solution[i] > 2 * M_PI)
+    {
+      solution[i] -= 2 * M_PI;
     }
-    while(solution[i] < 2*M_PI) {
-      solution[i] += 2*M_PI;
+    while (solution[i] < 2 * M_PI)
+    {
+      solution[i] += 2 * M_PI;
     }
     dist_sqr += fabs(ik_seed_state[i] - solution[i]);
   }
@@ -601,48 +620,53 @@ double IKFastKinematicsPlugin::harmonize(const std::vector<double> &ik_seed_stat
 //   }
 // }
 
-void IKFastKinematicsPlugin::getClosestSolution(const IkSolutionList<IkReal> &solutions, const std::vector<double> &ik_seed_state, std::vector<double> &solution) const
+void IKFastKinematicsPlugin::getClosestSolution(const IkSolutionList<IkReal>& solutions,
+                                                const std::vector<double>& ik_seed_state,
+                                                std::vector<double>& solution) const
 {
   double mindist = DBL_MAX;
   int minindex = -1;
   std::vector<double> sol;
 
   // IKFast56/61
-  for(size_t i=0; i < solutions.GetNumSolutions(); ++i)
+  for (size_t i = 0; i < solutions.GetNumSolutions(); ++i)
   {
-    getSolution(solutions, i,sol);
+    getSolution(solutions, i, sol);
     double dist = harmonize(ik_seed_state, sol);
-    ROS_INFO_STREAM_NAMED("ikfast","Dist " << i << " dist " << dist);
-    //std::cout << "dist[" << i << "]= " << dist << std::endl;
-    if(minindex == -1 || dist<mindist){
+    ROS_INFO_STREAM_NAMED("ikfast", "Dist " << i << " dist " << dist);
+    // std::cout << "dist[" << i << "]= " << dist << std::endl;
+    if (minindex == -1 || dist < mindist)
+    {
       minindex = i;
       mindist = dist;
     }
   }
-  if(minindex >= 0){
-    getSolution(solutions, minindex,solution);
+  if (minindex >= 0)
+  {
+    getSolution(solutions, minindex, solution);
     harmonize(ik_seed_state, solution);
   }
 }
 
-void IKFastKinematicsPlugin::fillFreeParams(int count, int *array)
+void IKFastKinematicsPlugin::fillFreeParams(int count, int* array)
 {
   free_params_.clear();
-  for(int i=0; i<count;++i) free_params_.push_back(array[i]);
+  for (int i = 0; i < count; ++i)
+    free_params_.push_back(array[i]);
 }
 
-bool IKFastKinematicsPlugin::getCount(int &count, const int &max_count, const int &min_count) const
+bool IKFastKinematicsPlugin::getCount(int& count, const int& max_count, const int& min_count) const
 {
-  if(count > 0)
+  if (count > 0)
   {
-    if(-count >= min_count)
+    if (-count >= min_count)
     {
       count = -count;
       return true;
     }
-    else if(count+1 <= max_count)
+    else if (count + 1 <= max_count)
     {
-      count = count+1;
+      count = count + 1;
       return true;
     }
     else
@@ -652,14 +676,14 @@ bool IKFastKinematicsPlugin::getCount(int &count, const int &max_count, const in
   }
   else
   {
-    if(1-count <= max_count)
+    if (1 - count <= max_count)
     {
-      count = 1-count;
+      count = 1 - count;
       return true;
     }
-    else if(count-1 >= min_count)
+    else if (count - 1 >= min_count)
     {
-      count = count -1;
+      count = count - 1;
       return true;
     }
     else
@@ -667,11 +691,12 @@ bool IKFastKinematicsPlugin::getCount(int &count, const int &max_count, const in
   }
 }
 
-bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string> &link_names,
-                                           const std::vector<double> &joint_angles,
-                                           std::vector<geometry_msgs::Pose> &poses) const
+bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_names,
+                                           const std::vector<double>& joint_angles,
+                                           std::vector<geometry_msgs::Pose>& poses) const
 {
-  if (GetIkType() != IKP_Transform6D) {
+  if (GetIkType() != IKP_Transform6D)
+  {
     // ComputeFk() is the inverse function of ComputeIk(), so the format of
     // eerot differs depending on IK type. The Transform6D IK type is the only
     // one for which a 3x3 rotation matrix is returned, which means we can only
@@ -681,173 +706,150 @@ bool IKFastKinematicsPlugin::getPositionFK(const std::vector<std::string> &link_
   }
 
   KDL::Frame p_out;
-  if(link_names.size() == 0) {
-    ROS_WARN_STREAM_NAMED("ikfast","Link names with nothing");
+  if (link_names.size() == 0)
+  {
+    ROS_WARN_STREAM_NAMED("ikfast", "Link names with nothing");
     return false;
   }
 
-  if(link_names.size()!=1 || link_names[0]!=getTipFrame()){
-    ROS_ERROR_NAMED("ikfast","Can compute FK for %s only",getTipFrame().c_str());
+  if (link_names.size() != 1 || link_names[0] != getTipFrame())
+  {
+    ROS_ERROR_NAMED("ikfast", "Can compute FK for %s only", getTipFrame().c_str());
     return false;
   }
 
   bool valid = true;
 
-  IkReal eerot[9],eetrans[3];
+  IkReal eerot[9], eetrans[3];
   IkReal angles[joint_angles.size()];
-  for (unsigned char i=0; i < joint_angles.size(); i++)
+  for (unsigned char i = 0; i < joint_angles.size(); i++)
     angles[i] = joint_angles[i];
 
   // IKFast56/61
-  ComputeFk(angles,eetrans,eerot);
+  ComputeFk(angles, eetrans, eerot);
 
-  for(int i=0; i<3;++i)
+  for (int i = 0; i < 3; ++i)
     p_out.p.data[i] = eetrans[i];
 
-  for(int i=0; i<9;++i)
+  for (int i = 0; i < 9; ++i)
     p_out.M.data[i] = eerot[i];
 
   poses.resize(1);
-  tf::poseKDLToMsg(p_out,poses[0]);
+  tf::poseKDLToMsg(p_out, poses[0]);
 
   return valid;
 }
 
-bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                                           const std::vector<double> &ik_seed_state,
-                                           double timeout,
-                                           std::vector<double> &solution,
-                                           moveit_msgs::MoveItErrorCodes &error_code,
-                                           const kinematics::KinematicsQueryOptions &options) const
+bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                              const std::vector<double>& ik_seed_state, double timeout,
+                                              std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                                              const kinematics::KinematicsQueryOptions& options) const
 {
-  const IKCallbackFn solution_callback = 0; 
+  const IKCallbackFn solution_callback = 0;
   std::vector<double> consistency_limits;
 
-  return searchPositionIK(ik_pose,
-                          ik_seed_state,
-                          timeout,
-                          consistency_limits,
-                          solution,
-                          solution_callback,
-                          error_code,
-                          options);
-}
-    
-bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                                           const std::vector<double> &ik_seed_state,
-                                           double timeout,
-                                           const std::vector<double> &consistency_limits,
-                                           std::vector<double> &solution,
-                                           moveit_msgs::MoveItErrorCodes &error_code,
-                                           const kinematics::KinematicsQueryOptions &options) const
-{
-  const IKCallbackFn solution_callback = 0; 
-  return searchPositionIK(ik_pose,
-                          ik_seed_state,
-                          timeout,
-                          consistency_limits,
-                          solution,
-                          solution_callback,
-                          error_code,
+  return searchPositionIK(ik_pose, ik_seed_state, timeout, consistency_limits, solution, solution_callback, error_code,
                           options);
 }
 
-bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                                           const std::vector<double> &ik_seed_state,
-                                           double timeout,
-                                           std::vector<double> &solution,
-                                           const IKCallbackFn &solution_callback,
-                                           moveit_msgs::MoveItErrorCodes &error_code,
-                                           const kinematics::KinematicsQueryOptions &options) const
+bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                              const std::vector<double>& ik_seed_state, double timeout,
+                                              const std::vector<double>& consistency_limits,
+                                              std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                                              const kinematics::KinematicsQueryOptions& options) const
+{
+  const IKCallbackFn solution_callback = 0;
+  return searchPositionIK(ik_pose, ik_seed_state, timeout, consistency_limits, solution, solution_callback, error_code,
+                          options);
+}
+
+bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                              const std::vector<double>& ik_seed_state, double timeout,
+                                              std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                                              moveit_msgs::MoveItErrorCodes& error_code,
+                                              const kinematics::KinematicsQueryOptions& options) const
 {
   std::vector<double> consistency_limits;
-  return searchPositionIK(ik_pose,
-                          ik_seed_state,
-                          timeout,
-                          consistency_limits,
-                          solution,
-                          solution_callback,
-                          error_code,
+  return searchPositionIK(ik_pose, ik_seed_state, timeout, consistency_limits, solution, solution_callback, error_code,
                           options);
 }
 
-bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
-                                              const std::vector<double> &ik_seed_state,
-                                              double timeout,
-                                              const std::vector<double> &consistency_limits,
-                                              std::vector<double> &solution,
-                                              const IKCallbackFn &solution_callback,
-                                              moveit_msgs::MoveItErrorCodes &error_code,
-                                              const kinematics::KinematicsQueryOptions &options) const
+bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose& ik_pose,
+                                              const std::vector<double>& ik_seed_state, double timeout,
+                                              const std::vector<double>& consistency_limits,
+                                              std::vector<double>& solution, const IKCallbackFn& solution_callback,
+                                              moveit_msgs::MoveItErrorCodes& error_code,
+                                              const kinematics::KinematicsQueryOptions& options) const
 {
-  ROS_DEBUG_STREAM_NAMED("ikfast","searchPositionIK");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "searchPositionIK");
 
   /// search_mode is currently fixed during code generation
   SEARCH_MODE search_mode = OPTIMIZE_MAX_JOINT;
 
   // Check if there are no redundant joints
-  if(free_params_.size()==0)
+  if (free_params_.size() == 0)
   {
-    ROS_DEBUG_STREAM_NAMED("ikfast","No need to search since no free params/redundant joints");
+    ROS_DEBUG_STREAM_NAMED("ikfast", "No need to search since no free params/redundant joints");
 
     // Find first IK solution, within joint limits
-    if(!getPositionIK(ik_pose, ik_seed_state, solution, error_code))
+    if (!getPositionIK(ik_pose, ik_seed_state, solution, error_code))
     {
-      ROS_DEBUG_STREAM_NAMED("ikfast","No solution whatsoever");
+      ROS_DEBUG_STREAM_NAMED("ikfast", "No solution whatsoever");
       error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
       return false;
     }
 
     // check for collisions if a callback is provided
-    if( !solution_callback.empty() )
+    if (!solution_callback.empty())
     {
       solution_callback(ik_pose, solution, error_code);
-      if(error_code.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
+      if (error_code.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
       {
-        ROS_DEBUG_STREAM_NAMED("ikfast","Solution passes callback");
+        ROS_DEBUG_STREAM_NAMED("ikfast", "Solution passes callback");
         return true;
       }
       else
       {
-        ROS_DEBUG_STREAM_NAMED("ikfast","Solution has error code " << error_code);
+        ROS_DEBUG_STREAM_NAMED("ikfast", "Solution has error code " << error_code);
         return false;
       }
     }
     else
     {
-      return true; // no collision check callback provided
+      return true;  // no collision check callback provided
     }
   }
 
   // -------------------------------------------------------------------------------------------------
   // Error Checking
-  if(!active_)
+  if (!active_)
   {
-    ROS_ERROR_STREAM_NAMED("ikfast","Kinematics not active");
+    ROS_ERROR_STREAM_NAMED("ikfast", "Kinematics not active");
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
-  if(ik_seed_state.size() != num_joints_)
+  if (ik_seed_state.size() != num_joints_)
   {
-    ROS_ERROR_STREAM_NAMED("ikfast","Seed state must have size " << num_joints_ << " instead of size " << ik_seed_state.size());
+    ROS_ERROR_STREAM_NAMED("ikfast", "Seed state must have size " << num_joints_ << " instead of size "
+                                                                  << ik_seed_state.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
 
-  if(!consistency_limits.empty() && consistency_limits.size() != num_joints_)
+  if (!consistency_limits.empty() && consistency_limits.size() != num_joints_)
   {
-    ROS_ERROR_STREAM_NAMED("ikfast","Consistency limits be empty or must have size " << num_joints_ << " instead of size " << consistency_limits.size());
+    ROS_ERROR_STREAM_NAMED("ikfast", "Consistency limits be empty or must have size "
+                                         << num_joints_ << " instead of size " << consistency_limits.size());
     error_code.val = error_code.NO_IK_SOLUTION;
     return false;
   }
-
 
   // -------------------------------------------------------------------------------------------------
   // Initialize
 
   KDL::Frame frame;
-  tf::poseMsgToKDL(ik_pose,frame);
+  tf::poseMsgToKDL(ik_pose, frame);
 
   std::vector<double> vfree(free_params_.size());
 
@@ -862,66 +864,69 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
   int num_positive_increments;
   int num_negative_increments;
 
-  if(!consistency_limits.empty())
+  if (!consistency_limits.empty())
   {
     // moveit replaced consistency_limit (scalar) w/ consistency_limits (vector)
     // Assume [0]th free_params element for now.  Probably wrong.
-    double max_limit = fmin(joint_max_vector_[free_params_[0]], initial_guess+consistency_limits[free_params_[0]]);
-    double min_limit = fmax(joint_min_vector_[free_params_[0]], initial_guess-consistency_limits[free_params_[0]]);
+    double max_limit = fmin(joint_max_vector_[free_params_[0]], initial_guess + consistency_limits[free_params_[0]]);
+    double min_limit = fmax(joint_min_vector_[free_params_[0]], initial_guess - consistency_limits[free_params_[0]]);
 
-    num_positive_increments = (int)((max_limit-initial_guess)/search_discretization_);
-    num_negative_increments = (int)((initial_guess-min_limit)/search_discretization_);
+    num_positive_increments = (int)((max_limit - initial_guess) / search_discretization_);
+    num_negative_increments = (int)((initial_guess - min_limit) / search_discretization_);
   }
-  else // no consitency limits provided
+  else  // no consitency limits provided
   {
-    num_positive_increments = (joint_max_vector_[free_params_[0]]-initial_guess)/search_discretization_;
-    num_negative_increments = (initial_guess-joint_min_vector_[free_params_[0]])/search_discretization_;
+    num_positive_increments = (joint_max_vector_[free_params_[0]] - initial_guess) / search_discretization_;
+    num_negative_increments = (initial_guess - joint_min_vector_[free_params_[0]]) / search_discretization_;
   }
 
   // -------------------------------------------------------------------------------------------------
   // Begin searching
 
-  ROS_DEBUG_STREAM_NAMED("ikfast","Free param is " << free_params_[0] << " initial guess is " << initial_guess << ", # positive increments: " << num_positive_increments << ", # negative increments: " << num_negative_increments);
+  ROS_DEBUG_STREAM_NAMED("ikfast", "Free param is " << free_params_[0] << " initial guess is " << initial_guess
+                                                    << ", # positive increments: " << num_positive_increments
+                                                    << ", # negative increments: " << num_negative_increments);
   if ((search_mode & OPTIMIZE_MAX_JOINT) && (num_positive_increments + num_negative_increments) > 1000)
-      ROS_WARN_STREAM_ONCE_NAMED("ikfast", "Large search space, consider increasing the search discretization");
-  
+    ROS_WARN_STREAM_ONCE_NAMED("ikfast", "Large search space, consider increasing the search discretization");
+
   double best_costs = -1.0;
   std::vector<double> best_solution;
   int nattempts = 0, nvalid = 0;
 
-  while(true)
+  while (true)
   {
     IkSolutionList<IkReal> solutions;
-    int numsol = solve(frame,vfree, solutions);
+    int numsol = solve(frame, vfree, solutions);
 
-    ROS_DEBUG_STREAM_NAMED("ikfast","Found " << numsol << " solutions from IKFast");
+    ROS_DEBUG_STREAM_NAMED("ikfast", "Found " << numsol << " solutions from IKFast");
 
-    //ROS_INFO("%f",vfree[0]);
+    // ROS_INFO("%f",vfree[0]);
 
-    if( numsol > 0 )
+    if (numsol > 0)
     {
-      for(int s = 0; s < numsol; ++s)
+      for (int s = 0; s < numsol; ++s)
       {
         nattempts++;
         std::vector<double> sol;
-        getSolution(solutions,s,sol);
+        getSolution(solutions, s, sol);
 
         bool obeys_limits = true;
-        for(unsigned int i = 0; i < sol.size(); i++)
+        for (unsigned int i = 0; i < sol.size(); i++)
         {
-          if(joint_has_limits_vector_[i] && (sol[i] < joint_min_vector_[i] || sol[i] > joint_max_vector_[i]))
+          if (joint_has_limits_vector_[i] && (sol[i] < joint_min_vector_[i] || sol[i] > joint_max_vector_[i]))
           {
             obeys_limits = false;
             break;
           }
-          //ROS_INFO_STREAM_NAMED("ikfast","Num " << i << " value " << sol[i] << " has limits " << joint_has_limits_vector_[i] << " " << joint_min_vector_[i] << " " << joint_max_vector_[i]);
+          // ROS_INFO_STREAM_NAMED("ikfast","Num " << i << " value " << sol[i] << " has limits " <<
+          // joint_has_limits_vector_[i] << " " << joint_min_vector_[i] << " " << joint_max_vector_[i]);
         }
-        if(obeys_limits)
+        if (obeys_limits)
         {
-          getSolution(solutions,s,solution);
+          getSolution(solutions, s, solution);
 
           // This solution is within joint limits, now check if in collision (if callback provided)
-          if(!solution_callback.empty())
+          if (!solution_callback.empty())
           {
             solution_callback(ik_pose, solution, error_code);
           }
@@ -930,14 +935,14 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
             error_code.val = error_code.SUCCESS;
           }
 
-          if(error_code.val == error_code.SUCCESS)
+          if (error_code.val == error_code.SUCCESS)
           {
             nvalid++;
             if (search_mode & OPTIMIZE_MAX_JOINT)
             {
               // Costs for solution: Largest joint motion
               double costs = 0.0;
-              for(unsigned int i = 0; i < solution.size(); i++)
+              for (unsigned int i = 0; i < solution.size(); i++)
               {
                 double d = fabs(ik_seed_state[i] - solution[i]);
                 if (d > costs)
@@ -957,15 +962,15 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
       }
     }
 
-    if(!getCount(counter, num_positive_increments, -num_negative_increments))
+    if (!getCount(counter, num_positive_increments, -num_negative_increments))
     {
       // Everything searched
       error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
       break;
     }
 
-    vfree[0] = initial_guess+search_discretization_*counter;
-    //ROS_DEBUG_STREAM_NAMED("ikfast","Attempt " << counter << " with 0th free joint having value " << vfree[0]);
+    vfree[0] = initial_guess + search_discretization_ * counter;
+    // ROS_DEBUG_STREAM_NAMED("ikfast","Attempt " << counter << " with 0th free joint having value " << vfree[0]);
   }
 
   ROS_DEBUG_STREAM_NAMED("ikfast", "Valid solutions: " << nvalid << "/" << nattempts);
@@ -983,61 +988,62 @@ bool IKFastKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose
 }
 
 // Used when there are no redundant joints - aka no free params
-bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose &ik_pose,
-                                           const std::vector<double> &ik_seed_state,
-                                           std::vector<double> &solution,
-                                           moveit_msgs::MoveItErrorCodes &error_code,
-                                           const kinematics::KinematicsQueryOptions &options) const
+bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose& ik_pose, const std::vector<double>& ik_seed_state,
+                                           std::vector<double>& solution, moveit_msgs::MoveItErrorCodes& error_code,
+                                           const kinematics::KinematicsQueryOptions& options) const
 {
-  ROS_DEBUG_STREAM_NAMED("ikfast","getPositionIK");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "getPositionIK");
 
-  if(!active_)
+  if (!active_)
   {
-    ROS_ERROR("kinematics not active");    
+    ROS_ERROR("kinematics not active");
     return false;
   }
 
   std::vector<double> vfree(free_params_.size());
-  for(std::size_t i = 0; i < free_params_.size(); ++i)
+  for (std::size_t i = 0; i < free_params_.size(); ++i)
   {
     int p = free_params_[i];
-    ROS_ERROR("%u is %f",p,ik_seed_state[p]);  // DTC
+    ROS_ERROR("%u is %f", p, ik_seed_state[p]);  // DTC
     vfree[i] = ik_seed_state[p];
   }
 
   KDL::Frame frame;
-  tf::poseMsgToKDL(ik_pose,frame);
+  tf::poseMsgToKDL(ik_pose, frame);
 
   IkSolutionList<IkReal> solutions;
-  int numsol = solve(frame,vfree,solutions);
+  int numsol = solve(frame, vfree, solutions);
 
-  ROS_DEBUG_STREAM_NAMED("ikfast","Found " << numsol << " solutions from IKFast");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "Found " << numsol << " solutions from IKFast");
 
-  if(numsol)
+  if (numsol)
   {
-    for(int s = 0; s < numsol; ++s)
+    for (int s = 0; s < numsol; ++s)
     {
       std::vector<double> sol;
-      getSolution(solutions,s,sol);
-      ROS_DEBUG_NAMED("ikfast","Sol %d: %e   %e   %e   %e   %e   %e", s, sol[0], sol[1], sol[2], sol[3], sol[4], sol[5]);
+      getSolution(solutions, s, sol);
+      ROS_DEBUG_NAMED("ikfast", "Sol %d: %e   %e   %e   %e   %e   %e", s, sol[0], sol[1], sol[2], sol[3], sol[4],
+                      sol[5]);
 
       bool obeys_limits = true;
-      for(unsigned int i = 0; i < sol.size(); i++)
+      for (unsigned int i = 0; i < sol.size(); i++)
       {
         // Add tolerance to limit check
-        if(joint_has_limits_vector_[i] && ( (sol[i] < (joint_min_vector_[i]-LIMIT_TOLERANCE)) ||
-                                            (sol[i] > (joint_max_vector_[i]+LIMIT_TOLERANCE)) ) )
+        if (joint_has_limits_vector_[i] && ((sol[i] < (joint_min_vector_[i] - LIMIT_TOLERANCE)) ||
+                                            (sol[i] > (joint_max_vector_[i] + LIMIT_TOLERANCE))))
         {
           // One element of solution is not within limits
           obeys_limits = false;
-          ROS_DEBUG_STREAM_NAMED("ikfast","Not in limits! " << i << " value " << sol[i] << " has limit: " << joint_has_limits_vector_[i] << "  being  " << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
+          ROS_DEBUG_STREAM_NAMED("ikfast", "Not in limits! " << i << " value " << sol[i] << " has limit: "
+                                                             << joint_has_limits_vector_[i] << "  being  "
+                                                             << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
           break;
         }
       }
-      if(obeys_limits)
+      if (obeys_limits)
       {
         // All elements of solution obey limits
-        getSolution(solutions,s,solution);
+        getSolution(solutions, s, solution);
         error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
         return true;
       }
@@ -1045,139 +1051,139 @@ bool IKFastKinematicsPlugin::getPositionIK(const geometry_msgs::Pose &ik_pose,
   }
   else
   {
-    ROS_DEBUG_STREAM_NAMED("ikfast","No IK solution");
+    ROS_DEBUG_STREAM_NAMED("ikfast", "No IK solution");
   }
 
   error_code.val = moveit_msgs::MoveItErrorCodes::NO_IK_SOLUTION;
   return false;
 }
 
-bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose> &ik_poses,
-                                           const std::vector<double> &ik_seed_state,
-                                           std::vector< std::vector<double> >& solutions,
+bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
+                                           const std::vector<double>& ik_seed_state,
+                                           std::vector<std::vector<double> >& solutions,
                                            kinematics::KinematicsResult& result,
-                                           const kinematics::KinematicsQueryOptions &options) const
+                                           const kinematics::KinematicsQueryOptions& options) const
 {
-  ROS_DEBUG_STREAM_NAMED("ikfast","getPositionIK with multiple solutions");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "getPositionIK with multiple solutions");
 
-  if(!active_)
+  if (!active_)
   {
     ROS_ERROR("kinematics not active");
     result.kinematic_error = kinematics::KinematicErrors::SOLVER_NOT_ACTIVE;
     return false;
   }
 
-  if(ik_poses.empty())
+  if (ik_poses.empty())
   {
     ROS_ERROR("ik_poses is empty");
     result.kinematic_error = kinematics::KinematicErrors::EMPTY_TIP_POSES;
     return false;
   }
 
-  if(ik_poses.size() > 1)
+  if (ik_poses.size() > 1)
   {
     ROS_ERROR("ik_poses contains multiple entries, only one is allowed");
     result.kinematic_error = kinematics::KinematicErrors::MULTIPLE_TIPS_NOT_SUPPORTED;
     return false;
   }
 
-  if(ik_seed_state.size() < num_joints_)
+  if (ik_seed_state.size() < num_joints_)
   {
-    ROS_ERROR_STREAM("ik_seed_state only has "<<ik_seed_state.size()<<" entries, this ikfast solver requires "<<num_joints_);
+    ROS_ERROR_STREAM("ik_seed_state only has " << ik_seed_state.size() << " entries, this ikfast solver requires "
+                                               << num_joints_);
     return false;
   }
 
   KDL::Frame frame;
-  tf::poseMsgToKDL(ik_poses[0],frame);
+  tf::poseMsgToKDL(ik_poses[0], frame);
 
   // solving ik
-  std::vector< IkSolutionList<IkReal> > solution_set;
+  std::vector<IkSolutionList<IkReal> > solution_set;
   IkSolutionList<IkReal> ik_solutions;
   std::vector<double> vfree;
   int numsol = 0;
   std::vector<double> sampled_joint_vals;
-  if(!redundant_joint_indices_.empty())
+  if (!redundant_joint_indices_.empty())
   {
     // initializing from seed
     sampled_joint_vals.push_back(ik_seed_state[redundant_joint_indices_[0]]);
 
     // checking joint limits when using no discretization
-    if(options.discretization_method == kinematics::DiscretizationMethods::NO_DISCRETIZATION &&
+    if (options.discretization_method == kinematics::DiscretizationMethods::NO_DISCRETIZATION &&
         joint_has_limits_vector_[redundant_joint_indices_.front()])
     {
       double joint_min = joint_min_vector_[redundant_joint_indices_.front()];
       double joint_max = joint_max_vector_[redundant_joint_indices_.front()];
 
       double jv = sampled_joint_vals[0];
-      if(!( (jv > (joint_min - LIMIT_TOLERANCE)) && (jv < (joint_max + LIMIT_TOLERANCE)) ))
+      if (!((jv > (joint_min - LIMIT_TOLERANCE)) && (jv < (joint_max + LIMIT_TOLERANCE))))
       {
         result.kinematic_error = kinematics::KinematicErrors::IK_SEED_OUTSIDE_LIMITS;
         ROS_ERROR_STREAM("ik seed is out of bounds");
         return false;
       }
-
     }
 
-
     // computing all solutions sets for each sampled value of the redundant joint
-    if(!sampleRedundantJoint(options.discretization_method,sampled_joint_vals))
+    if (!sampleRedundantJoint(options.discretization_method, sampled_joint_vals))
     {
       result.kinematic_error = kinematics::KinematicErrors::UNSUPORTED_DISCRETIZATION_REQUESTED;
       return false;
     }
 
-    for(unsigned int i = 0; i < sampled_joint_vals.size(); i++)
+    for (unsigned int i = 0; i < sampled_joint_vals.size(); i++)
     {
       vfree.clear();
       vfree.push_back(sampled_joint_vals[i]);
-      numsol += solve(frame,vfree,ik_solutions);
+      numsol += solve(frame, vfree, ik_solutions);
       solution_set.push_back(ik_solutions);
     }
   }
   else
   {
     // computing for single solution set
-    numsol = solve(frame,vfree,ik_solutions);
+    numsol = solve(frame, vfree, ik_solutions);
     solution_set.push_back(ik_solutions);
   }
 
-  ROS_DEBUG_STREAM_NAMED("ikfast","Found " << numsol << " solutions from IKFast");
+  ROS_DEBUG_STREAM_NAMED("ikfast", "Found " << numsol << " solutions from IKFast");
   bool solutions_found = false;
   std::stringstream ss;
-  if( numsol > 0 )
+  if (numsol > 0)
   {
-    for(unsigned int r = 0; r < solution_set.size() ; r++)
+    for (unsigned int r = 0; r < solution_set.size(); r++)
     {
-
       ik_solutions = solution_set[r];
       numsol = ik_solutions.GetNumSolutions();
-      for(int s = 0; s < numsol; ++s)
+      for (int s = 0; s < numsol; ++s)
       {
         std::vector<double> sol;
-        getSolution(ik_solutions,s,sol);
+        getSolution(ik_solutions, s, sol);
         ss.str("");
-        ss<<"[";
-        for(unsigned int i = 0 ; i < sol.size() ; i++)
+        ss << "[";
+        for (unsigned int i = 0; i < sol.size(); i++)
         {
-          ss<<sol[i]<<" ";
+          ss << sol[i] << " ";
         }
-        ss<<"]";
-        ROS_DEBUG_NAMED("ikfast","Sol %d: %s", s, ss.str().c_str());
+        ss << "]";
+        ROS_DEBUG_NAMED("ikfast", "Sol %d: %s", s, ss.str().c_str());
 
         bool obeys_limits = true;
-        for(unsigned int i = 0; i < sol.size(); i++)
+        for (unsigned int i = 0; i < sol.size(); i++)
         {
           // Add tolerance to limit check
-          if(joint_has_limits_vector_[i] && ( (sol[i] < (joint_min_vector_[i]-LIMIT_TOLERANCE)) ||
-                                              (sol[i] > (joint_max_vector_[i]+LIMIT_TOLERANCE)) ) )
+          if (joint_has_limits_vector_[i] && ((sol[i] < (joint_min_vector_[i] - LIMIT_TOLERANCE)) ||
+                                              (sol[i] > (joint_max_vector_[i] + LIMIT_TOLERANCE))))
           {
             // One element of solution is not within limits
             obeys_limits = false;
-            ROS_DEBUG_STREAM_NAMED("ikfast","Not in limits! " << i << " value " << sol[i] << " has limit: " << joint_has_limits_vector_[i] << "  being  " << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
+            ROS_DEBUG_STREAM_NAMED(
+                "ikfast", "Not in limits! " << i << " value " << sol[i] << " has limit: " << joint_has_limits_vector_[i]
+                                            << "  being  " << joint_min_vector_[i] << " to " << joint_max_vector_[i]);
             break;
           }
         }
-        if(obeys_limits)
+        if (obeys_limits)
         {
           // All elements of solution obey limits
           solutions_found = true;
@@ -1186,7 +1192,7 @@ bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose
       }
     }
 
-    if(solutions_found)
+    if (solutions_found)
     {
       result.kinematic_error = kinematics::KinematicErrors::OK;
       return true;
@@ -1194,65 +1200,64 @@ bool IKFastKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose
   }
   else
   {
-    ROS_DEBUG_STREAM_NAMED("ikfast","No IK solution");
+    ROS_DEBUG_STREAM_NAMED("ikfast", "No IK solution");
   }
 
   result.kinematic_error = kinematics::KinematicErrors::NO_SOLUTION;
   return false;
 }
 
-bool IKFastKinematicsPlugin::sampleRedundantJoint(kinematics::DiscretizationMethod method, std::vector<double>& sampled_joint_vals) const
+bool IKFastKinematicsPlugin::sampleRedundantJoint(kinematics::DiscretizationMethod method,
+                                                  std::vector<double>& sampled_joint_vals) const
 {
   double joint_min = -M_PI;
   double joint_max = M_PI;
-  int index =  redundant_joint_indices_.front();
+  int index = redundant_joint_indices_.front();
   double joint_dscrt = redundant_joint_discretization_.at(index);
 
-  if(joint_has_limits_vector_[redundant_joint_indices_.front()])
+  if (joint_has_limits_vector_[redundant_joint_indices_.front()])
   {
     joint_min = joint_min_vector_[index];
     joint_max = joint_max_vector_[index];
   }
 
-
-  switch(method)
+  switch (method)
   {
     case kinematics::DiscretizationMethods::ALL_DISCRETIZED:
     {
-      int steps = std::ceil((joint_max - joint_min)/joint_dscrt);
-      for(unsigned int i = 0; i < steps;i++)
+      int steps = std::ceil((joint_max - joint_min) / joint_dscrt);
+      for (unsigned int i = 0; i < steps; i++)
       {
-        sampled_joint_vals.push_back(joint_min + joint_dscrt*i);
+        sampled_joint_vals.push_back(joint_min + joint_dscrt * i);
       }
       sampled_joint_vals.push_back(joint_max);
     }
-      break;
+    break;
     case kinematics::DiscretizationMethods::ALL_RANDOM_SAMPLED:
     {
-      int steps = std::ceil((joint_max - joint_min)/joint_dscrt);
+      int steps = std::ceil((joint_max - joint_min) / joint_dscrt);
       steps = steps > 0 ? steps : 1;
       double diff = joint_max - joint_min;
-      for(int i = 0; i < steps; i++)
+      for (int i = 0; i < steps; i++)
       {
-        sampled_joint_vals.push_back( ((diff*std::rand())/(static_cast<double>(RAND_MAX))) + joint_min );
+        sampled_joint_vals.push_back(((diff * std::rand()) / (static_cast<double>(RAND_MAX))) + joint_min);
       }
     }
 
-      break;
+    break;
     case kinematics::DiscretizationMethods::NO_DISCRETIZATION:
 
       break;
     default:
-      ROS_ERROR_STREAM("Discretization method "<<method<<" is not supported");
+      ROS_ERROR_STREAM("Discretization method " << method << " is not supported");
       return false;
   }
 
   return true;
 }
 
+}  // end namespace
 
-} // end namespace
-
-//register IKFastKinematicsPlugin as a KinematicsBase implementation
+// register IKFastKinematicsPlugin as a KinematicsBase implementation
 #include <pluginlib/class_list_macros.h>
 PLUGINLIB_EXPORT_CLASS(ikfast_kinematics_plugin::IKFastKinematicsPlugin, kinematics::KinematicsBase);

--- a/motoman_sia20d_ikfast_manipulator_plugin/src/test_motoman_sia20d_manipulator_ikfast_solver.cpp
+++ b/motoman_sia20d_ikfast_manipulator_plugin/src/test_motoman_sia20d_manipulator_ikfast_solver.cpp
@@ -5,7 +5,7 @@
 /// you may not use this file except in compliance with the License.
 /// You may obtain a copy of the License at
 ///     http://www.apache.org/licenses/LICENSE-2.0
-/// 
+///
 /// Unless required by applicable law or agreed to in writing, software
 /// distributed under the License is distributed on an "AS IS" BASIS,
 /// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,26 +18,26 @@
 /// To compile without any main function as a shared object (might need -llapack):
 ///     gcc -fPIC -lstdc++ -DIKFAST_NO_MAIN -DIKFAST_CLIBRARY -shared -Wl,-soname,libik.so -o libik.so ik.cpp
 #define IKFAST_HAS_LIBRARY
-#include "ikfast.h" // found inside share/openrave-X.Y/python/ikfast.h
+#include "ikfast.h"  // found inside share/openrave-X.Y/python/ikfast.h
 using namespace ikfast;
 
 // check if the included ikfast version matches what this file was compiled with
 #define IKFAST_COMPILE_ASSERT(x) extern int __dummy[(int)x]
-IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
+IKFAST_COMPILE_ASSERT(IKFAST_VERSION == 61);
 
-#include <cmath>
-#include <vector>
-#include <limits>
 #include <algorithm>
+#include <cmath>
 #include <complex>
+#include <limits>
+#include <vector>
 
 #define IKFAST_STRINGIZE2(s) #s
 #define IKFAST_STRINGIZE(s) IKFAST_STRINGIZE2(s)
 
 #ifndef IKFAST_ASSERT
-#include <stdexcept>
-#include <sstream>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 
 #ifdef _MSC_VER
 #ifndef __PRETTY_FUNCTION__
@@ -49,7 +49,16 @@ IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
 #define __PRETTY_FUNCTION__ __func__
 #endif
 
-#define IKFAST_ASSERT(b) { if( !(b) ) { std::stringstream ss; ss << "ikfast exception: " << __FILE__ << ":" << __LINE__ << ": " <<__PRETTY_FUNCTION__ << ": Assertion '" << #b << "' failed"; throw std::runtime_error(ss.str()); } }
+#define IKFAST_ASSERT(b)                                                                                               \
+  {                                                                                                                    \
+    if (!(b))                                                                                                          \
+    {                                                                                                                  \
+      std::stringstream ss;                                                                                            \
+      ss << "ikfast exception: " << __FILE__ << ":" << __LINE__ << ": " << __PRETTY_FUNCTION__ << ": Assertion '"      \
+         << #b << "' failed";                                                                                          \
+      throw std::runtime_error(ss.str());                                                                              \
+    }                                                                                                                  \
+  }
 
 #endif
 
@@ -59,40 +68,61 @@ IKFAST_COMPILE_ASSERT(IKFAST_VERSION==61);
 #define IKFAST_ALIGNED16(x) x __attribute((aligned(16)))
 #endif
 
-#define IK2PI  ((IkReal)6.28318530717959)
-#define IKPI  ((IkReal)3.14159265358979)
-#define IKPI_2  ((IkReal)1.57079632679490)
+#define IK2PI ((IkReal)6.28318530717959)
+#define IKPI ((IkReal)3.14159265358979)
+#define IKPI_2 ((IkReal)1.57079632679490)
 
 #ifdef _MSC_VER
 #ifndef isnan
 #define isnan _isnan
 #endif
-#endif // _MSC_VER
+#endif  // _MSC_VER
 
 // lapack routines
 extern "C" {
-  void dgetrf_ (const int* m, const int* n, double* a, const int* lda, int* ipiv, int* info);
-  void zgetrf_ (const int* m, const int* n, std::complex<double>* a, const int* lda, int* ipiv, int* info);
-  void dgetri_(const int* n, const double* a, const int* lda, int* ipiv, double* work, const int* lwork, int* info);
-  void dgesv_ (const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b, const int* ldb, int* info);
-  void dgetrs_(const char *trans, const int *n, const int *nrhs, double *a, const int *lda, int *ipiv, double *b, const int *ldb, int *info);
-  void dgeev_(const char *jobvl, const char *jobvr, const int *n, double *a, const int *lda, double *wr, double *wi,double *vl, const int *ldvl, double *vr, const int *ldvr, double *work, const int *lwork, int *info);
+void dgetrf_(const int* m, const int* n, double* a, const int* lda, int* ipiv, int* info);
+void zgetrf_(const int* m, const int* n, std::complex<double>* a, const int* lda, int* ipiv, int* info);
+void dgetri_(const int* n, const double* a, const int* lda, int* ipiv, double* work, const int* lwork, int* info);
+void dgesv_(const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b, const int* ldb, int* info);
+void dgetrs_(const char* trans, const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double* b,
+             const int* ldb, int* info);
+void dgeev_(const char* jobvl, const char* jobvr, const int* n, double* a, const int* lda, double* wr, double* wi,
+            double* vl, const int* ldvl, double* vr, const int* ldvr, double* work, const int* lwork, int* info);
 }
 
-using namespace std; // necessary to get std math routines
+using namespace std;  // necessary to get std math routines
 
 #ifdef IKFAST_NAMESPACE
-namespace IKFAST_NAMESPACE {
+namespace IKFAST_NAMESPACE
+{
 #endif
 
-inline float IKabs(float f) { return fabsf(f); }
-inline double IKabs(double f) { return fabs(f); }
+inline float IKabs(float f)
+{
+  return fabsf(f);
+}
+inline double IKabs(double f)
+{
+  return fabs(f);
+}
 
-inline float IKsqr(float f) { return f*f; }
-inline double IKsqr(double f) { return f*f; }
+inline float IKsqr(float f)
+{
+  return f * f;
+}
+inline double IKsqr(double f)
+{
+  return f * f;
+}
 
-inline float IKlog(float f) { return logf(f); }
-inline double IKlog(double f) { return log(f); }
+inline float IKlog(float f)
+{
+  return logf(f);
+}
+inline double IKlog(double f)
+{
+  return log(f);
+}
 
 // allows asin and acos to exceed 1
 #ifndef IKFAST_SINCOS_THRESH
@@ -111,4138 +141,5450 @@ inline double IKlog(double f) { return log(f); }
 
 inline float IKasin(float f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return float(-IKPI_2);
-else if( f >= 1 ) return float(IKPI_2);
-return asinf(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return float(-IKPI_2);
+  else if (f >= 1)
+    return float(IKPI_2);
+  return asinf(f);
 }
 inline double IKasin(double f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return -IKPI_2;
-else if( f >= 1 ) return IKPI_2;
-return asin(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return -IKPI_2;
+  else if (f >= 1)
+    return IKPI_2;
+  return asin(f);
 }
 
 // return positive value in [0,y)
 inline float IKfmod(float x, float y)
 {
-    while(x < 0) {
-        x += y;
-    }
-    return fmodf(x,y);
+  while (x < 0)
+  {
+    x += y;
+  }
+  return fmodf(x, y);
 }
 
 // return positive value in [0,y)
 inline double IKfmod(double x, double y)
 {
-    while(x < 0) {
-        x += y;
-    }
-    return fmod(x,y);
+  while (x < 0)
+  {
+    x += y;
+  }
+  return fmod(x, y);
 }
 
 inline float IKacos(float f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return float(IKPI);
-else if( f >= 1 ) return float(0);
-return acosf(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return float(IKPI);
+  else if (f >= 1)
+    return float(0);
+  return acosf(f);
 }
 inline double IKacos(double f)
 {
-IKFAST_ASSERT( f > -1-IKFAST_SINCOS_THRESH && f < 1+IKFAST_SINCOS_THRESH ); // any more error implies something is wrong with the solver
-if( f <= -1 ) return IKPI;
-else if( f >= 1 ) return 0;
-return acos(f);
+  IKFAST_ASSERT(f > -1 - IKFAST_SINCOS_THRESH &&
+                f < 1 + IKFAST_SINCOS_THRESH);  // any more error implies something is wrong with the solver
+  if (f <= -1)
+    return IKPI;
+  else if (f >= 1)
+    return 0;
+  return acos(f);
 }
-inline float IKsin(float f) { return sinf(f); }
-inline double IKsin(double f) { return sin(f); }
-inline float IKcos(float f) { return cosf(f); }
-inline double IKcos(double f) { return cos(f); }
-inline float IKtan(float f) { return tanf(f); }
-inline double IKtan(double f) { return tan(f); }
-inline float IKsqrt(float f) { if( f <= 0.0f ) return 0.0f; return sqrtf(f); }
-inline double IKsqrt(double f) { if( f <= 0.0 ) return 0.0; return sqrt(f); }
-inline float IKatan2(float fy, float fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
-        return float(IKPI_2);
-    }
-    else if( isnan(fx) ) {
-        return 0;
-    }
-    return atan2f(fy,fx);
+inline float IKsin(float f)
+{
+  return sinf(f);
 }
-inline double IKatan2(double fy, double fx) {
-    if( isnan(fy) ) {
-        IKFAST_ASSERT(!isnan(fx)); // if both are nan, probably wrong value will be returned
-        return IKPI_2;
-    }
-    else if( isnan(fx) ) {
-        return 0;
-    }
-    return atan2(fy,fx);
+inline double IKsin(double f)
+{
+  return sin(f);
+}
+inline float IKcos(float f)
+{
+  return cosf(f);
+}
+inline double IKcos(double f)
+{
+  return cos(f);
+}
+inline float IKtan(float f)
+{
+  return tanf(f);
+}
+inline double IKtan(double f)
+{
+  return tan(f);
+}
+inline float IKsqrt(float f)
+{
+  if (f <= 0.0f)
+    return 0.0f;
+  return sqrtf(f);
+}
+inline double IKsqrt(double f)
+{
+  if (f <= 0.0)
+    return 0.0;
+  return sqrt(f);
+}
+inline float IKatan2(float fy, float fx)
+{
+  if (isnan(fy))
+  {
+    IKFAST_ASSERT(!isnan(fx));  // if both are nan, probably wrong value will be returned
+    return float(IKPI_2);
+  }
+  else if (isnan(fx))
+  {
+    return 0;
+  }
+  return atan2f(fy, fx);
+}
+inline double IKatan2(double fy, double fx)
+{
+  if (isnan(fy))
+  {
+    IKFAST_ASSERT(!isnan(fx));  // if both are nan, probably wrong value will be returned
+    return IKPI_2;
+  }
+  else if (isnan(fx))
+  {
+    return 0;
+  }
+  return atan2(fy, fx);
 }
 
-inline float IKsign(float f) {
-    if( f > 0 ) {
-        return float(1);
-    }
-    else if( f < 0 ) {
-        return float(-1);
-    }
-    return 0;
+inline float IKsign(float f)
+{
+  if (f > 0)
+  {
+    return float(1);
+  }
+  else if (f < 0)
+  {
+    return float(-1);
+  }
+  return 0;
 }
 
-inline double IKsign(double f) {
-    if( f > 0 ) {
-        return 1.0;
-    }
-    else if( f < 0 ) {
-        return -1.0;
-    }
-    return 0;
+inline double IKsign(double f)
+{
+  if (f > 0)
+  {
+    return 1.0;
+  }
+  else if (f < 0)
+  {
+    return -1.0;
+  }
+  return 0;
 }
 
 /// solves the forward kinematics equations.
 /// \param pfree is an array specifying the free joints of the chain.
-IKFAST_API void ComputeFk(const IkReal* j, IkReal* eetrans, IkReal* eerot) {
-IkReal x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63;
-x0=IKcos(j[0]);
-x1=IKcos(j[3]);
-x2=IKcos(j[1]);
-x3=IKcos(j[2]);
-x4=IKsin(j[1]);
-x5=IKsin(j[3]);
-x6=IKsin(j[0]);
-x7=IKsin(j[2]);
-x8=IKsin(j[4]);
-x9=IKcos(j[4]);
-x10=IKcos(j[6]);
-x11=IKsin(j[6]);
-x12=IKsin(j[5]);
-x13=IKcos(j[5]);
-x14=((IkReal(1.00000000000000))*(x7));
-x15=((IkReal(1.00000000000000))*(x1));
-x16=((IkReal(0.180000000000000))*(x9));
-x17=((IkReal(0.420000000000000))*(x2));
-x18=((IkReal(1.00000000000000))*(x9));
-x19=((IkReal(1.00000000000000))*(x2));
-x20=((IkReal(0.180000000000000))*(x1));
-x21=((IkReal(1.00000000000000))*(x13));
-x22=((IkReal(1.00000000000000))*(x8));
-x23=((IkReal(0.180000000000000))*(x5));
-x24=((IkReal(1.00000000000000))*(x5));
-x25=((IkReal(0.420000000000000))*(x1));
-x26=((IkReal(1.00000000000000))*(x12));
-x27=((x0)*(x7));
-x28=((IkReal(-1.00000000000000))*(x13));
-x29=((x3)*(x6));
-x30=((x0)*(x4));
-x31=((x4)*(x8));
-x32=((x4)*(x6));
-x33=((x6)*(x7));
-x34=((x0)*(x3));
-x35=((x3)*(x4));
-x36=((IkReal(-1.00000000000000))*(x12));
-x37=((x14)*(x6));
-x38=((x15)*(x35));
-x39=((x14)*(x4)*(x9));
-x40=((x14)*(x31));
-x41=((((IkReal(-1.00000000000000))*(x37)))+(((x2)*(x34))));
-x42=((((x2)*(x27)))+(x29));
-x43=((((x2)*(x29)))+(x27));
-x44=((((IkReal(-1.00000000000000))*(x34)))+(((x2)*(x33))));
-x45=((((IkReal(-1.00000000000000))*(x38)))+(((x2)*(x5))));
-x46=((((x1)*(x2)))+(((x35)*(x5))));
-x47=((((IkReal(-1.00000000000000))*(x19)*(x34)))+(x37));
-x48=((((IkReal(-1.00000000000000))*(x19)*(x5)))+(x38));
-x49=((((IkReal(-1.00000000000000))*(x0)*(x14)))+(((IkReal(-1.00000000000000))*(x19)*(x29))));
-x50=((x42)*(x8));
-x51=((x1)*(x41));
-x52=((x44)*(x8));
-x53=((x49)*(x5));
-x54=((((x30)*(x5)))+(x51));
-x55=((((x32)*(x5)))+(((x1)*(x43))));
-x56=((((x47)*(x5)))+(((x1)*(x30))));
-x57=((((IkReal(-1.00000000000000))*(x15)*(x43)))+(((IkReal(-1.00000000000000))*(x24)*(x32))));
-x58=((x53)+(((x1)*(x32))));
-x59=((x54)*(x9));
-x60=((x59)+(x50));
-x61=((x52)+(((x55)*(x9))));
-x62=((((x21)*(((((IkReal(-1.00000000000000))*(x45)*(x9)))+(x40)))))+(((IkReal(-1.00000000000000))*(x26)*(x46))));
-x63=((x13)*(x60));
-eerot[0]=((((x10)*(((((x36)*(x56)))+(((x28)*(x60)))))))+(((IkReal(-1.00000000000000))*(x11)*(((((x18)*(x42)))+(((x22)*(((((IkReal(-1.00000000000000))*(x15)*(x41)))+(((IkReal(-1.00000000000000))*(x24)*(x30))))))))))));
-eerot[1]=((((x10)*(((((x42)*(x9)))+(((x8)*(((((IkReal(-1.00000000000000))*(x51)))+(((IkReal(-1.00000000000000))*(x30)*(x5)))))))))))+(((x11)*(((((IkReal(-1.00000000000000))*(x26)*(x56)))+(((IkReal(-1.00000000000000))*(x21)*(x60))))))));
-eerot[2]=((((x12)*(((((IkReal(-1.00000000000000))*(x18)*(x54)))+(((IkReal(-1.00000000000000))*(x22)*(x42)))))))+(((x13)*(x56))));
-eetrans[0]=((((x12)*(((((IkReal(-0.180000000000000))*(x50)))+(((IkReal(-1.00000000000000))*(x16)*(x54)))))))+(((IkReal(0.490000000000000))*(x30)))+(((x25)*(x30)))+(((x5)*(((((IkReal(0.420000000000000))*(x33)))+(((IkReal(-1.00000000000000))*(x17)*(x34)))))))+(((x13)*(((((x20)*(x30)))+(((x23)*(x47))))))));
-eerot[3]=((((x11)*(((((IkReal(-1.00000000000000))*(x18)*(x44)))+(((IkReal(-1.00000000000000))*(x22)*(x57)))))))+(((x10)*(((((x36)*(x58)))+(((x28)*(x61))))))));
-eerot[4]=((((x10)*(((((x57)*(x8)))+(((x44)*(x9)))))))+(((x11)*(((((IkReal(-1.00000000000000))*(x26)*(x58)))+(((IkReal(-1.00000000000000))*(x21)*(x61))))))));
-eerot[5]=((((x13)*(x58)))+(((x12)*(((((IkReal(-1.00000000000000))*(x18)*(x55)))+(((IkReal(-1.00000000000000))*(x22)*(x44))))))));
-eetrans[1]=((((x5)*(((((IkReal(-1.00000000000000))*(x17)*(x29)))+(((IkReal(-0.420000000000000))*(x27)))))))+(((x12)*(((((IkReal(-0.180000000000000))*(x52)))+(((IkReal(-1.00000000000000))*(x16)*(x55)))))))+(((IkReal(0.490000000000000))*(x32)))+(((x25)*(x32)))+(((x13)*(((((x20)*(x32)))+(((x23)*(x49))))))));
-eerot[6]=((((x11)*(((((IkReal(-1.00000000000000))*(x22)*(x48)))+(x39)))))+(((x10)*(x62))));
-eerot[7]=((((x11)*(x62)))+(((x10)*(((((IkReal(-1.00000000000000))*(x39)))+(((x48)*(x8))))))));
-eerot[8]=((((x12)*(((((IkReal(-1.00000000000000))*(x18)*(x45)))+(x40)))))+(((x13)*(x46))));
-eetrans[2]=((IkReal(0.410000000000000))+(((x1)*(x17)))+(((x13)*(((((x23)*(x35)))+(((x2)*(x20)))))))+(((x12)*(((((IkReal(0.180000000000000))*(x31)*(x7)))+(((IkReal(-1.00000000000000))*(x16)*(x45)))))))+(((IkReal(0.420000000000000))*(x35)*(x5)))+(((IkReal(0.490000000000000))*(x2))));
+IKFAST_API void ComputeFk(const IkReal* j, IkReal* eetrans, IkReal* eerot)
+{
+  IkReal x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23,
+      x24, x25, x26, x27, x28, x29, x30, x31, x32, x33, x34, x35, x36, x37, x38, x39, x40, x41, x42, x43, x44, x45, x46,
+      x47, x48, x49, x50, x51, x52, x53, x54, x55, x56, x57, x58, x59, x60, x61, x62, x63;
+  x0 = IKcos(j[0]);
+  x1 = IKcos(j[3]);
+  x2 = IKcos(j[1]);
+  x3 = IKcos(j[2]);
+  x4 = IKsin(j[1]);
+  x5 = IKsin(j[3]);
+  x6 = IKsin(j[0]);
+  x7 = IKsin(j[2]);
+  x8 = IKsin(j[4]);
+  x9 = IKcos(j[4]);
+  x10 = IKcos(j[6]);
+  x11 = IKsin(j[6]);
+  x12 = IKsin(j[5]);
+  x13 = IKcos(j[5]);
+  x14 = ((IkReal(1.00000000000000)) * (x7));
+  x15 = ((IkReal(1.00000000000000)) * (x1));
+  x16 = ((IkReal(0.180000000000000)) * (x9));
+  x17 = ((IkReal(0.420000000000000)) * (x2));
+  x18 = ((IkReal(1.00000000000000)) * (x9));
+  x19 = ((IkReal(1.00000000000000)) * (x2));
+  x20 = ((IkReal(0.180000000000000)) * (x1));
+  x21 = ((IkReal(1.00000000000000)) * (x13));
+  x22 = ((IkReal(1.00000000000000)) * (x8));
+  x23 = ((IkReal(0.180000000000000)) * (x5));
+  x24 = ((IkReal(1.00000000000000)) * (x5));
+  x25 = ((IkReal(0.420000000000000)) * (x1));
+  x26 = ((IkReal(1.00000000000000)) * (x12));
+  x27 = ((x0) * (x7));
+  x28 = ((IkReal(-1.00000000000000)) * (x13));
+  x29 = ((x3) * (x6));
+  x30 = ((x0) * (x4));
+  x31 = ((x4) * (x8));
+  x32 = ((x4) * (x6));
+  x33 = ((x6) * (x7));
+  x34 = ((x0) * (x3));
+  x35 = ((x3) * (x4));
+  x36 = ((IkReal(-1.00000000000000)) * (x12));
+  x37 = ((x14) * (x6));
+  x38 = ((x15) * (x35));
+  x39 = ((x14) * (x4) * (x9));
+  x40 = ((x14) * (x31));
+  x41 = ((((IkReal(-1.00000000000000)) * (x37))) + (((x2) * (x34))));
+  x42 = ((((x2) * (x27))) + (x29));
+  x43 = ((((x2) * (x29))) + (x27));
+  x44 = ((((IkReal(-1.00000000000000)) * (x34))) + (((x2) * (x33))));
+  x45 = ((((IkReal(-1.00000000000000)) * (x38))) + (((x2) * (x5))));
+  x46 = ((((x1) * (x2))) + (((x35) * (x5))));
+  x47 = ((((IkReal(-1.00000000000000)) * (x19) * (x34))) + (x37));
+  x48 = ((((IkReal(-1.00000000000000)) * (x19) * (x5))) + (x38));
+  x49 = ((((IkReal(-1.00000000000000)) * (x0) * (x14))) + (((IkReal(-1.00000000000000)) * (x19) * (x29))));
+  x50 = ((x42) * (x8));
+  x51 = ((x1) * (x41));
+  x52 = ((x44) * (x8));
+  x53 = ((x49) * (x5));
+  x54 = ((((x30) * (x5))) + (x51));
+  x55 = ((((x32) * (x5))) + (((x1) * (x43))));
+  x56 = ((((x47) * (x5))) + (((x1) * (x30))));
+  x57 = ((((IkReal(-1.00000000000000)) * (x15) * (x43))) + (((IkReal(-1.00000000000000)) * (x24) * (x32))));
+  x58 = ((x53) + (((x1) * (x32))));
+  x59 = ((x54) * (x9));
+  x60 = ((x59) + (x50));
+  x61 = ((x52) + (((x55) * (x9))));
+  x62 = ((((x21) * (((((IkReal(-1.00000000000000)) * (x45) * (x9))) + (x40))))) +
+         (((IkReal(-1.00000000000000)) * (x26) * (x46))));
+  x63 = ((x13) * (x60));
+  eerot[0] = ((((x10) * (((((x36) * (x56))) + (((x28) * (x60))))))) +
+              (((IkReal(-1.00000000000000)) * (x11) *
+                (((((x18) * (x42))) + (((x22) * (((((IkReal(-1.00000000000000)) * (x15) * (x41))) +
+                                                  (((IkReal(-1.00000000000000)) * (x24) * (x30))))))))))));
+  eerot[1] =
+      ((((x10) * (((((x42) * (x9))) + (((x8) * (((((IkReal(-1.00000000000000)) * (x51))) +
+                                                 (((IkReal(-1.00000000000000)) * (x30) * (x5))))))))))) +
+       (((x11) *
+         (((((IkReal(-1.00000000000000)) * (x26) * (x56))) + (((IkReal(-1.00000000000000)) * (x21) * (x60))))))));
+  eerot[2] =
+      ((((x12) *
+         (((((IkReal(-1.00000000000000)) * (x18) * (x54))) + (((IkReal(-1.00000000000000)) * (x22) * (x42))))))) +
+       (((x13) * (x56))));
+  eetrans[0] =
+      ((((x12) * (((((IkReal(-0.180000000000000)) * (x50))) + (((IkReal(-1.00000000000000)) * (x16) * (x54))))))) +
+       (((IkReal(0.490000000000000)) * (x30))) + (((x25) * (x30))) +
+       (((x5) * (((((IkReal(0.420000000000000)) * (x33))) + (((IkReal(-1.00000000000000)) * (x17) * (x34))))))) +
+       (((x13) * (((((x20) * (x30))) + (((x23) * (x47))))))));
+  eerot[3] =
+      ((((x11) *
+         (((((IkReal(-1.00000000000000)) * (x18) * (x44))) + (((IkReal(-1.00000000000000)) * (x22) * (x57))))))) +
+       (((x10) * (((((x36) * (x58))) + (((x28) * (x61))))))));
+  eerot[4] =
+      ((((x10) * (((((x57) * (x8))) + (((x44) * (x9))))))) +
+       (((x11) *
+         (((((IkReal(-1.00000000000000)) * (x26) * (x58))) + (((IkReal(-1.00000000000000)) * (x21) * (x61))))))));
+  eerot[5] = ((((x13) * (x58))) + (((x12) * (((((IkReal(-1.00000000000000)) * (x18) * (x55))) +
+                                              (((IkReal(-1.00000000000000)) * (x22) * (x44))))))));
+  eetrans[1] =
+      ((((x5) * (((((IkReal(-1.00000000000000)) * (x17) * (x29))) + (((IkReal(-0.420000000000000)) * (x27))))))) +
+       (((x12) * (((((IkReal(-0.180000000000000)) * (x52))) + (((IkReal(-1.00000000000000)) * (x16) * (x55))))))) +
+       (((IkReal(0.490000000000000)) * (x32))) + (((x25) * (x32))) +
+       (((x13) * (((((x20) * (x32))) + (((x23) * (x49))))))));
+  eerot[6] = ((((x11) * (((((IkReal(-1.00000000000000)) * (x22) * (x48))) + (x39))))) + (((x10) * (x62))));
+  eerot[7] = ((((x11) * (x62))) + (((x10) * (((((IkReal(-1.00000000000000)) * (x39))) + (((x48) * (x8))))))));
+  eerot[8] = ((((x12) * (((((IkReal(-1.00000000000000)) * (x18) * (x45))) + (x40))))) + (((x13) * (x46))));
+  eetrans[2] =
+      ((IkReal(0.410000000000000)) + (((x1) * (x17))) + (((x13) * (((((x23) * (x35))) + (((x2) * (x20))))))) +
+       (((x12) *
+         (((((IkReal(0.180000000000000)) * (x31) * (x7))) + (((IkReal(-1.00000000000000)) * (x16) * (x45))))))) +
+       (((IkReal(0.420000000000000)) * (x35) * (x5))) + (((IkReal(0.490000000000000)) * (x2))));
 }
 
-IKFAST_API int GetNumFreeParameters() { return 1; }
-IKFAST_API int* GetFreeParameters() { static int freeparams[] = {4}; return freeparams; }
-IKFAST_API int GetNumJoints() { return 7; }
+IKFAST_API int GetNumFreeParameters()
+{
+  return 1;
+}
+IKFAST_API int* GetFreeParameters()
+{
+  static int freeparams[] = { 4 };
+  return freeparams;
+}
+IKFAST_API int GetNumJoints()
+{
+  return 7;
+}
 
-IKFAST_API int GetIkRealSize() { return sizeof(IkReal); }
+IKFAST_API int GetIkRealSize()
+{
+  return sizeof(IkReal);
+}
 
-IKFAST_API int GetIkType() { return 0x67000001; }
+IKFAST_API int GetIkType()
+{
+  return 0x67000001;
+}
 
-class IKSolver {
+class IKSolver
+{
 public:
-IkReal j0,cj0,sj0,htj0,j1,cj1,sj1,htj1,j2,cj2,sj2,htj2,j3,cj3,sj3,htj3,j5,cj5,sj5,htj5,j6,cj6,sj6,htj6,j4,cj4,sj4,htj4,new_r00,r00,rxp0_0,new_r01,r01,rxp0_1,new_r02,r02,rxp0_2,new_r10,r10,rxp1_0,new_r11,r11,rxp1_1,new_r12,r12,rxp1_2,new_r20,r20,rxp2_0,new_r21,r21,rxp2_1,new_r22,r22,rxp2_2,new_px,px,npx,new_py,py,npy,new_pz,pz,npz,pp;
-unsigned char _ij0[2], _nj0,_ij1[2], _nj1,_ij2[2], _nj2,_ij3[2], _nj3,_ij5[2], _nj5,_ij6[2], _nj6,_ij4[2], _nj4;
-
-bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions) {
-j0=numeric_limits<IkReal>::quiet_NaN(); _ij0[0] = -1; _ij0[1] = -1; _nj0 = -1; j1=numeric_limits<IkReal>::quiet_NaN(); _ij1[0] = -1; _ij1[1] = -1; _nj1 = -1; j2=numeric_limits<IkReal>::quiet_NaN(); _ij2[0] = -1; _ij2[1] = -1; _nj2 = -1; j3=numeric_limits<IkReal>::quiet_NaN(); _ij3[0] = -1; _ij3[1] = -1; _nj3 = -1; j5=numeric_limits<IkReal>::quiet_NaN(); _ij5[0] = -1; _ij5[1] = -1; _nj5 = -1; j6=numeric_limits<IkReal>::quiet_NaN(); _ij6[0] = -1; _ij6[1] = -1; _nj6 = -1;  _ij4[0] = -1; _ij4[1] = -1; _nj4 = 0; 
-for(int dummyiter = 0; dummyiter < 1; ++dummyiter) {
-    solutions.Clear();
-j4=pfree[0]; cj4=cos(pfree[0]); sj4=sin(pfree[0]);
-r00 = eerot[0*3+0];
-r01 = eerot[0*3+1];
-r02 = eerot[0*3+2];
-r10 = eerot[1*3+0];
-r11 = eerot[1*3+1];
-r12 = eerot[1*3+2];
-r20 = eerot[2*3+0];
-r21 = eerot[2*3+1];
-r22 = eerot[2*3+2];
-px = eetrans[0]; py = eetrans[1]; pz = eetrans[2];
-
-new_r00=((IkReal(-1.00000000000000))*(r00));
-new_r01=r01;
-new_r02=((IkReal(-1.00000000000000))*(r02));
-new_px=((((IkReal(-0.180000000000000))*(r02)))+(px));
-new_r10=((IkReal(-1.00000000000000))*(r10));
-new_r11=r11;
-new_r12=((IkReal(-1.00000000000000))*(r12));
-new_py=((((IkReal(-0.180000000000000))*(r12)))+(py));
-new_r20=((IkReal(-1.00000000000000))*(r20));
-new_r21=r21;
-new_r22=((IkReal(-1.00000000000000))*(r22));
-new_pz=((IkReal(-0.410000000000000))+(pz)+(((IkReal(-0.180000000000000))*(r22))));
-r00 = new_r00; r01 = new_r01; r02 = new_r02; r10 = new_r10; r11 = new_r11; r12 = new_r12; r20 = new_r20; r21 = new_r21; r22 = new_r22; px = new_px; py = new_py; pz = new_pz;
-pp=(((px)*(px))+((py)*(py))+((pz)*(pz)));
-npx=((((px)*(r00)))+(((py)*(r10)))+(((pz)*(r20))));
-npy=((((px)*(r01)))+(((py)*(r11)))+(((pz)*(r21))));
-npz=((((px)*(r02)))+(((py)*(r12)))+(((pz)*(r22))));
-rxp0_0=((((IkReal(-1.00000000000000))*(py)*(r20)))+(((pz)*(r10))));
-rxp0_1=((((px)*(r20)))+(((IkReal(-1.00000000000000))*(pz)*(r00))));
-rxp0_2=((((IkReal(-1.00000000000000))*(px)*(r10)))+(((py)*(r00))));
-rxp1_0=((((IkReal(-1.00000000000000))*(py)*(r21)))+(((pz)*(r11))));
-rxp1_1=((((px)*(r21)))+(((IkReal(-1.00000000000000))*(pz)*(r01))));
-rxp1_2=((((IkReal(-1.00000000000000))*(px)*(r11)))+(((py)*(r01))));
-rxp2_0=((((IkReal(-1.00000000000000))*(py)*(r22)))+(((pz)*(r12))));
-rxp2_1=((((px)*(r22)))+(((IkReal(-1.00000000000000))*(pz)*(r02))));
-rxp2_2=((((IkReal(-1.00000000000000))*(px)*(r12)))+(((py)*(r02))));
-{
-IkReal j3array[2], cj3array[2], sj3array[2];
-bool j3valid[2]={false};
-_nj3 = 2;
-cj3array[0]=((IkReal(-1.01190476190476))+(((IkReal(2.42954324586978))*(pp))));
-if( cj3array[0] >= -1-IKFAST_SINCOS_THRESH && cj3array[0] <= 1+IKFAST_SINCOS_THRESH )
-{
-    j3valid[0] = j3valid[1] = true;
-    j3array[0] = IKacos(cj3array[0]);
-    sj3array[0] = IKsin(j3array[0]);
-    cj3array[1] = cj3array[0];
-    j3array[1] = -j3array[0];
-    sj3array[1] = -sj3array[0];
-}
-else if( isnan(cj3array[0]) )
-{
-    // probably any value will work
-    j3valid[0] = true;
-    cj3array[0] = 1; sj3array[0] = 0; j3array[0] = 0;
-}
-for(int ij3 = 0; ij3 < 2; ++ij3)
-{
-if( !j3valid[ij3] )
-{
-    continue;
-}
-_ij3[0] = ij3; _ij3[1] = -1;
-for(int iij3 = ij3+1; iij3 < 2; ++iij3)
-{
-if( j3valid[iij3] && IKabs(cj3array[ij3]-cj3array[iij3]) < IKFAST_SOLUTION_THRESH && IKabs(sj3array[ij3]-sj3array[iij3]) < IKFAST_SOLUTION_THRESH )
-{
-    j3valid[iij3]=false; _ij3[1] = iij3; break; 
-}
-}
-j3 = j3array[ij3]; cj3 = cj3array[ij3]; sj3 = sj3array[ij3];
-
-{
-IkReal dummyeval[1];
-dummyeval[0]=(((npx)*(npx))+((npy)*(npy)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=(((npx)*(npx))+((npy)*(npy)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=((IkReal(1.00000000000000))+(((IkReal(2.33333333333333))*(cj3)))+(((IkReal(1.36111111111111))*((cj4)*(cj4))*((sj3)*(sj3))))+(((IkReal(1.36111111111111))*((cj3)*(cj3)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j5array[2], cj5array[2], sj5array[2];
-bool j5valid[2]={false};
-_nj5 = 2;
-IkReal x64=((IkReal(-0.420000000000000))+(((IkReal(-0.490000000000000))*(cj3))));
-if( IKabs(x64) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(0.490000000000000))*(cj4)*(sj3))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x65=((IkReal(1.00000000000000))*(IKatan2(x64, ((IkReal(0.490000000000000))*(cj4)*(sj3)))));
-if( ((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3)))))) < (IkReal)-0.00001 )
-    continue;
-if( (((npz)*(((IKabs(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3)))))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3))))))))):(IkReal)1.0e30)))) < -1-IKFAST_SINCOS_THRESH || (((npz)*(((IKabs(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3)))))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3))))))))):(IkReal)1.0e30)))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x66=IKasin(((npz)*(((IKabs(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3)))))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((x64)*(x64))+(((IkReal(0.240100000000000))*((cj4)*(cj4))*((sj3)*(sj3))))))))):(IkReal)1.0e30))));
-j5array[0]=((x66)+(((IkReal(-1.00000000000000))*(x65))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-j5array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x65)))+(((IkReal(-1.00000000000000))*(x66))));
-sj5array[1]=IKsin(j5array[1]);
-cj5array[1]=IKcos(j5array[1]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-if( j5array[1] > IKPI )
-{
-    j5array[1]-=IK2PI;
-}
-else if( j5array[1] < -IKPI )
-{    j5array[1]+=IK2PI;
-}
-j5valid[1] = true;
-for(int ij5 = 0; ij5 < 2; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 2; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-
-{
-IkReal dummyeval[1];
-IkReal gconst0;
-IkReal x67=((IkReal(100.000000000000))*(sj5));
-gconst0=IKsign(((((x67)*((npx)*(npx))))+(((x67)*((npy)*(npy))))));
-dummyeval[0]=((((sj5)*((npy)*(npy))))+(((sj5)*((npx)*(npx)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst1;
-IkReal x68=((IkReal(2100.00000000000))*(sj5));
-gconst1=IKsign(((((x68)*((npx)*(npx))))+(((x68)*((npy)*(npy))))));
-dummyeval[0]=((((sj5)*((npy)*(npy))))+(((sj5)*((npx)*(npx)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[5];
-IkReal x69=((IkReal(1.00000000000000))*(pp));
-IkReal x70=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(npz)))+(((IkReal(-0.490000000000000))*(cj3))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j5)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x69)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=x70;
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(-0.840000000000000))*(npz)))+(((IkReal(-1.00000000000000))*(x69))));
-evalcond[4]=x70;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst2;
-gconst2=IKsign(((((IkReal(-100.000000000000))*((npy)*(npy))))+(((IkReal(-100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*((npy)*(npy))))+(((IkReal(-1.00000000000000))*((npx)*(npx)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst3;
-IkReal x71=((IkReal(100.000000000000))*(sj4));
-gconst3=IKsign(((((IkReal(-1.00000000000000))*(x71)*((npx)*(npx))))+(((IkReal(-1.00000000000000))*(x71)*((npy)*(npy))))));
-IkReal x72=((IkReal(1.00000000000000))*(sj4));
-dummyeval[0]=((((IkReal(-1.00000000000000))*(x72)*((npx)*(npx))))+(((IkReal(-1.00000000000000))*(x72)*((npy)*(npy)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[5];
-IkReal x73=((IkReal(1.00000000000000))*(pp));
-IkReal x74=x70;
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x73)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=x74;
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(-1.00000000000000))*(x73)))+(((IkReal(-0.840000000000000))*(npz))));
-evalcond[4]=x74;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst4;
-gconst4=IKsign(((((IkReal(-100.000000000000))*((npy)*(npy))))+(((IkReal(-100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*((npy)*(npy))))+(((IkReal(-1.00000000000000))*((npx)*(npx)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x75=((gconst4)*(sj3));
-if( IKabs(((IkReal(49.0000000000000))*(npy)*(x75))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-49.0000000000000))*(npx)*(x75))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((IkReal(49.0000000000000))*(npy)*(x75)), ((IkReal(-49.0000000000000))*(npx)*(x75)));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[2];
-IkReal x76=IKcos(j6);
-IkReal x77=IKsin(j6);
-evalcond[0]=((((npx)*(x77)))+(((npy)*(x76))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(npy)*(x77)))+(((npx)*(x76)))+(((IkReal(-0.490000000000000))*(sj3))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-IkReal x234=((IkReal(1.00000000000000))*(pp));
-IkReal x235=x70;
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x234)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=x235;
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(-0.840000000000000))*(npz)))+(((IkReal(-1.00000000000000))*(x234))));
-evalcond[4]=x235;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst5;
-gconst5=IKsign(((((IkReal(100.000000000000))*((npy)*(npy))))+(((IkReal(100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=(((npx)*(npx))+((npy)*(npy)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x236=((gconst5)*(sj3));
-if( IKabs(((IkReal(49.0000000000000))*(npy)*(x236))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-49.0000000000000))*(npx)*(x236))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((IkReal(49.0000000000000))*(npy)*(x236)), ((IkReal(-49.0000000000000))*(npx)*(x236)));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[2];
-IkReal x237=IKcos(j6);
-IkReal x238=IKsin(j6);
-evalcond[0]=((((npx)*(x238)))+(((npy)*(x237))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(npy)*(x238)))+(((npx)*(x237)))+(((IkReal(0.490000000000000))*(sj3))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x239=(sj4)*(sj4);
-IkReal x240=((IkReal(49.0000000000000))*(sj3)*(x239));
-IkReal x241=((IkReal(49.0000000000000))*(cj4)*(sj3)*(sj4));
-if( IKabs(((gconst3)*(((((npy)*(x241)))+(((npx)*(x240))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst3)*(((((IkReal(-1.00000000000000))*(npx)*(x241)))+(((npy)*(x240))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst3)*(((((npy)*(x241)))+(((npx)*(x240)))))), ((gconst3)*(((((IkReal(-1.00000000000000))*(npx)*(x241)))+(((npy)*(x240)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[4];
-IkReal x242=IKcos(j6);
-IkReal x243=IKsin(j6);
-IkReal x244=((cj4)*(npy));
-IkReal x245=((IkReal(0.490000000000000))*(sj3));
-IkReal x246=((npy)*(sj4));
-IkReal x247=((IkReal(1.00000000000000))*(x243));
-IkReal x248=((npx)*(x243));
-IkReal x249=((npx)*(x242));
-evalcond[0]=((x248)+(((npy)*(x242)))+(((sj4)*(x245))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(npy)*(x247)))+(((IkReal(-1.00000000000000))*(cj4)*(x245)))+(x249));
-evalcond[2]=((((cj4)*(x248)))+(((x242)*(x244)))+(((sj4)*(x249)))+(((IkReal(-1.00000000000000))*(x246)*(x247))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(npx)*(sj4)*(x247)))+(((cj4)*(x249)))+(((IkReal(-1.00000000000000))*(x245)))+(((IkReal(-1.00000000000000))*(x244)*(x247)))+(((IkReal(-1.00000000000000))*(x242)*(x246))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x250=((IkReal(49.0000000000000))*(cj4)*(sj3));
-IkReal x251=((IkReal(49.0000000000000))*(sj3)*(sj4));
-if( IKabs(((gconst2)*(((((npy)*(x250)))+(((npx)*(x251))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst2)*(((((npy)*(x251)))+(((IkReal(-1.00000000000000))*(npx)*(x250))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst2)*(((((npy)*(x250)))+(((npx)*(x251)))))), ((gconst2)*(((((npy)*(x251)))+(((IkReal(-1.00000000000000))*(npx)*(x250)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[4];
-IkReal x252=IKcos(j6);
-IkReal x253=IKsin(j6);
-IkReal x254=((cj4)*(npy));
-IkReal x255=((IkReal(0.490000000000000))*(sj3));
-IkReal x256=((npy)*(sj4));
-IkReal x257=((IkReal(1.00000000000000))*(x253));
-IkReal x258=((npx)*(x253));
-IkReal x259=((npx)*(x252));
-evalcond[0]=((((sj4)*(x255)))+(((npy)*(x252)))+(x258));
-evalcond[1]=((((IkReal(-1.00000000000000))*(npy)*(x257)))+(((IkReal(-1.00000000000000))*(cj4)*(x255)))+(x259));
-evalcond[2]=((((sj4)*(x259)))+(((IkReal(-1.00000000000000))*(x256)*(x257)))+(((x252)*(x254)))+(((cj4)*(x258))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x252)*(x256)))+(((IkReal(-1.00000000000000))*(npx)*(sj4)*(x257)))+(((IkReal(-1.00000000000000))*(x254)*(x257)))+(((cj4)*(x259)))+(((IkReal(-1.00000000000000))*(x255))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-IkReal x260=((IkReal(1.00000000000000))*(pp));
-IkReal x261=((IkReal(0.490000000000000))*(cj3));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j5)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x260)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=((IkReal(0.420000000000000))+(((IkReal(-1.00000000000000))*(npz)))+(x261));
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(npz)))+(((IkReal(-1.00000000000000))*(x260))));
-evalcond[4]=((IkReal(-0.420000000000000))+(npz)+(((IkReal(-1.00000000000000))*(x261))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst6;
-gconst6=IKsign(((((IkReal(100.000000000000))*((npy)*(npy))))+(((IkReal(100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=(((npx)*(npx))+((npy)*(npy)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst7;
-IkReal x262=((IkReal(100.000000000000))*(sj4));
-gconst7=IKsign(((((x262)*((npy)*(npy))))+(((x262)*((npx)*(npx))))));
-dummyeval[0]=((((sj4)*((npx)*(npx))))+(((sj4)*((npy)*(npy)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[5];
-IkReal x263=((IkReal(1.00000000000000))*(pp));
-IkReal x264=((IkReal(0.490000000000000))*(cj3));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x263)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=((IkReal(0.420000000000000))+(((IkReal(-1.00000000000000))*(npz)))+(x264));
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(npz)))+(((IkReal(-1.00000000000000))*(x263))));
-evalcond[4]=((IkReal(-0.420000000000000))+(npz)+(((IkReal(-1.00000000000000))*(x264))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst8;
-gconst8=IKsign(((((IkReal(100.000000000000))*((npy)*(npy))))+(((IkReal(100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=(((npx)*(npx))+((npy)*(npy)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x265=((gconst8)*(sj3));
-if( IKabs(((IkReal(49.0000000000000))*(npy)*(x265))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-49.0000000000000))*(npx)*(x265))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((IkReal(49.0000000000000))*(npy)*(x265)), ((IkReal(-49.0000000000000))*(npx)*(x265)));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[2];
-IkReal x266=IKcos(j6);
-IkReal x267=IKsin(j6);
-evalcond[0]=((((npx)*(x267)))+(((npy)*(x266))));
-evalcond[1]=((((npx)*(x266)))+(((IkReal(-1.00000000000000))*(npy)*(x267)))+(((IkReal(0.490000000000000))*(sj3))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-IkReal x268=((IkReal(1.00000000000000))*(pp));
-IkReal x269=((IkReal(0.490000000000000))*(cj3));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j4)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(0.416500000000000))+(((IkReal(-1.00000000000000))*(x268)))+(((IkReal(0.411600000000000))*(cj3))));
-evalcond[2]=((IkReal(0.420000000000000))+(((IkReal(-1.00000000000000))*(npz)))+(x269));
-evalcond[3]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(npz)))+(((IkReal(-1.00000000000000))*(x268))));
-evalcond[4]=((IkReal(-0.420000000000000))+(npz)+(((IkReal(-1.00000000000000))*(x269))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst9;
-gconst9=IKsign(((((IkReal(-100.000000000000))*((npy)*(npy))))+(((IkReal(-100.000000000000))*((npx)*(npx))))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*((npy)*(npy))))+(((IkReal(-1.00000000000000))*((npx)*(npx)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x270=((gconst9)*(sj3));
-if( IKabs(((IkReal(49.0000000000000))*(npy)*(x270))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-49.0000000000000))*(npx)*(x270))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((IkReal(49.0000000000000))*(npy)*(x270)), ((IkReal(-49.0000000000000))*(npx)*(x270)));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[2];
-IkReal x271=IKcos(j6);
-IkReal x272=IKsin(j6);
-evalcond[0]=((((npy)*(x271)))+(((npx)*(x272))));
-evalcond[1]=((((IkReal(-0.490000000000000))*(sj3)))+(((IkReal(-1.00000000000000))*(npy)*(x272)))+(((npx)*(x271))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x273=(sj4)*(sj4);
-IkReal x274=((cj4)*(sj4));
-IkReal x275=((IkReal(49.0000000000000))*(npx)*(sj3));
-IkReal x276=((IkReal(49.0000000000000))*(npy)*(sj3));
-if( IKabs(((gconst7)*(((((IkReal(-1.00000000000000))*(x273)*(x275)))+(((x274)*(x276))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst7)*(((((IkReal(-1.00000000000000))*(x273)*(x276)))+(((IkReal(-1.00000000000000))*(x274)*(x275))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst7)*(((((IkReal(-1.00000000000000))*(x273)*(x275)))+(((x274)*(x276)))))), ((gconst7)*(((((IkReal(-1.00000000000000))*(x273)*(x276)))+(((IkReal(-1.00000000000000))*(x274)*(x275)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[4];
-IkReal x277=IKcos(j6);
-IkReal x278=IKsin(j6);
-IkReal x279=((IkReal(1.00000000000000))*(sj4));
-IkReal x280=((IkReal(0.490000000000000))*(sj3));
-IkReal x281=((npy)*(x277));
-IkReal x282=((npx)*(x277));
-IkReal x283=((npx)*(x278));
-IkReal x284=((npy)*(x278));
-evalcond[0]=((x283)+(x281)+(((sj4)*(x280))));
-evalcond[1]=((x282)+(((IkReal(-1.00000000000000))*(x284)))+(((cj4)*(x280))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x279)*(x282)))+(((cj4)*(x283)))+(((cj4)*(x281)))+(((sj4)*(x284))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(cj4)*(x282)))+(((IkReal(-1.00000000000000))*(x280)))+(((IkReal(-1.00000000000000))*(x279)*(x281)))+(((IkReal(-1.00000000000000))*(x279)*(x283)))+(((cj4)*(x284))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x285=((IkReal(49.0000000000000))*(cj4)*(sj3));
-IkReal x286=((IkReal(49.0000000000000))*(sj3)*(sj4));
-if( IKabs(((gconst6)*(((((IkReal(-1.00000000000000))*(npx)*(x286)))+(((npy)*(x285))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst6)*(((((IkReal(-1.00000000000000))*(npy)*(x286)))+(((IkReal(-1.00000000000000))*(npx)*(x285))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst6)*(((((IkReal(-1.00000000000000))*(npx)*(x286)))+(((npy)*(x285)))))), ((gconst6)*(((((IkReal(-1.00000000000000))*(npy)*(x286)))+(((IkReal(-1.00000000000000))*(npx)*(x285)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[4];
-IkReal x287=IKcos(j6);
-IkReal x288=IKsin(j6);
-IkReal x289=((IkReal(1.00000000000000))*(sj4));
-IkReal x290=((IkReal(0.490000000000000))*(sj3));
-IkReal x291=((npy)*(x287));
-IkReal x292=((npx)*(x287));
-IkReal x293=((npx)*(x288));
-IkReal x294=((npy)*(x288));
-evalcond[0]=((((sj4)*(x290)))+(x291)+(x293));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x294)))+(((cj4)*(x290)))+(x292));
-evalcond[2]=((((IkReal(-1.00000000000000))*(x289)*(x292)))+(((cj4)*(x291)))+(((cj4)*(x293)))+(((sj4)*(x294))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(cj4)*(x292)))+(((IkReal(-1.00000000000000))*(x289)*(x293)))+(((IkReal(-1.00000000000000))*(x289)*(x291)))+(((IkReal(-1.00000000000000))*(x290)))+(((cj4)*(x294))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x295=((IkReal(2500.00000000000))*(pp));
-IkReal x296=((IkReal(2100.00000000000))*(cj5)*(npz));
-IkReal x297=((IkReal(1029.00000000000))*(sj3)*(sj4)*(sj5));
-if( IKabs(((gconst1)*(((((IkReal(-1.00000000000000))*(npy)*(x295)))+(((IkReal(-1.00000000000000))*(npy)*(x296)))+(((IkReal(-1.00000000000000))*(npx)*(x297)))+(((IkReal(159.250000000000))*(npy))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst1)*(((((IkReal(-1.00000000000000))*(npy)*(x297)))+(((npx)*(x295)))+(((npx)*(x296)))+(((IkReal(-159.250000000000))*(npx))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst1)*(((((IkReal(-1.00000000000000))*(npy)*(x295)))+(((IkReal(-1.00000000000000))*(npy)*(x296)))+(((IkReal(-1.00000000000000))*(npx)*(x297)))+(((IkReal(159.250000000000))*(npy)))))), ((gconst1)*(((((IkReal(-1.00000000000000))*(npy)*(x297)))+(((npx)*(x295)))+(((npx)*(x296)))+(((IkReal(-159.250000000000))*(npx)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[6];
-IkReal x298=IKcos(j6);
-IkReal x299=IKsin(j6);
-IkReal x300=((IkReal(1.00000000000000))*(sj4));
-IkReal x301=((cj5)*(npz));
-IkReal x302=((cj4)*(cj5));
-IkReal x303=((IkReal(0.490000000000000))*(sj3));
-IkReal x304=((IkReal(0.490000000000000))*(cj3));
-IkReal x305=((IkReal(0.840000000000000))*(sj5));
-IkReal x306=((npz)*(sj5));
-IkReal x307=((npy)*(x298));
-IkReal x308=((npx)*(x298));
-IkReal x309=((npy)*(x299));
-IkReal x310=((npx)*(x299));
-evalcond[0]=((x307)+(x310)+(((sj4)*(x303))));
-evalcond[1]=((IkReal(0.0637000000000000))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-1.00000000000000))*(x305)*(x309)))+(((x305)*(x308)))+(((IkReal(-0.840000000000000))*(x301))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((sj5)*(x308)))+(((IkReal(-1.00000000000000))*(x301)))+(((IkReal(-1.00000000000000))*(sj5)*(x309)))+(((IkReal(-1.00000000000000))*(x304))));
-evalcond[3]=((((IkReal(-0.420000000000000))*(sj5)))+(((IkReal(-1.00000000000000))*(x302)*(x303)))+(((IkReal(-1.00000000000000))*(x309)))+(x308)+(((IkReal(-1.00000000000000))*(sj5)*(x304))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(cj5)*(x300)*(x309)))+(((cj5)*(sj4)*(x308)))+(((cj4)*(x310)))+(((sj4)*(x306)))+(((cj4)*(x307))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x302)*(x309)))+(((IkReal(-1.00000000000000))*(x300)*(x310)))+(((x302)*(x308)))+(((IkReal(-1.00000000000000))*(x300)*(x307)))+(((cj4)*(x306)))+(((IkReal(-1.00000000000000))*(x303))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j6array[1], cj6array[1], sj6array[1];
-bool j6valid[1]={false};
-_nj6 = 1;
-IkReal x311=((IkReal(49.0000000000000))*(npx));
-IkReal x312=((IkReal(49.0000000000000))*(npy));
-IkReal x313=((sj3)*(sj4)*(sj5));
-IkReal x314=((IkReal(100.000000000000))*(cj5)*(npz));
-if( IKabs(((gconst0)*(((((IkReal(-1.00000000000000))*(npy)*(x314)))+(((IkReal(-1.00000000000000))*(x311)*(x313)))+(((IkReal(-1.00000000000000))*(cj3)*(x312)))+(((IkReal(-42.0000000000000))*(npy))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst0)*(((((IkReal(-1.00000000000000))*(x312)*(x313)))+(((npx)*(x314)))+(((cj3)*(x311)))+(((IkReal(42.0000000000000))*(npx))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j6array[0]=IKatan2(((gconst0)*(((((IkReal(-1.00000000000000))*(npy)*(x314)))+(((IkReal(-1.00000000000000))*(x311)*(x313)))+(((IkReal(-1.00000000000000))*(cj3)*(x312)))+(((IkReal(-42.0000000000000))*(npy)))))), ((gconst0)*(((((IkReal(-1.00000000000000))*(x312)*(x313)))+(((npx)*(x314)))+(((cj3)*(x311)))+(((IkReal(42.0000000000000))*(npx)))))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-for(int ij6 = 0; ij6 < 1; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 1; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[6];
-IkReal x315=IKcos(j6);
-IkReal x316=IKsin(j6);
-IkReal x317=((IkReal(1.00000000000000))*(sj4));
-IkReal x318=((cj5)*(npz));
-IkReal x319=((cj4)*(cj5));
-IkReal x320=((IkReal(0.490000000000000))*(sj3));
-IkReal x321=((IkReal(0.490000000000000))*(cj3));
-IkReal x322=((IkReal(0.840000000000000))*(sj5));
-IkReal x323=((npz)*(sj5));
-IkReal x324=((npy)*(x315));
-IkReal x325=((npx)*(x315));
-IkReal x326=((npy)*(x316));
-IkReal x327=((npx)*(x316));
-evalcond[0]=((((sj4)*(x320)))+(x324)+(x327));
-evalcond[1]=((IkReal(0.0637000000000000))+(((x322)*(x325)))+(((IkReal(-0.840000000000000))*(x318)))+(((IkReal(-1.00000000000000))*(x322)*(x326)))+(((IkReal(-1.00000000000000))*(pp))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(x321)))+(((sj5)*(x325)))+(((IkReal(-1.00000000000000))*(sj5)*(x326)))+(((IkReal(-1.00000000000000))*(x318))));
-evalcond[3]=((((IkReal(-0.420000000000000))*(sj5)))+(((IkReal(-1.00000000000000))*(x326)))+(x325)+(((IkReal(-1.00000000000000))*(x319)*(x320)))+(((IkReal(-1.00000000000000))*(sj5)*(x321))));
-evalcond[4]=((((cj5)*(sj4)*(x325)))+(((sj4)*(x323)))+(((IkReal(-1.00000000000000))*(cj5)*(x317)*(x326)))+(((cj4)*(x324)))+(((cj4)*(x327))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x317)*(x327)))+(((IkReal(-1.00000000000000))*(x317)*(x324)))+(((IkReal(-1.00000000000000))*(x320)))+(((cj4)*(x323)))+(((IkReal(-1.00000000000000))*(x319)*(x326)))+(((x319)*(x325))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j6array[2], cj6array[2], sj6array[2];
-bool j6valid[2]={false};
-_nj6 = 2;
-if( IKabs(npy) < IKFAST_ATAN2_MAGTHRESH && IKabs(npx) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x328=((IkReal(1.00000000000000))*(IKatan2(npy, npx)));
-if( ((((npx)*(npx))+((npy)*(npy)))) < (IkReal)-0.00001 )
-    continue;
-if( (((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30)))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30)))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x329=IKasin(((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30))));
-j6array[0]=((((IkReal(-1.00000000000000))*(x328)))+(((IkReal(-1.00000000000000))*(x329))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-j6array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x328)))+(x329));
-sj6array[1]=IKsin(j6array[1]);
-cj6array[1]=IKcos(j6array[1]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-if( j6array[1] > IKPI )
-{
-    j6array[1]-=IK2PI;
-}
-else if( j6array[1] < -IKPI )
-{    j6array[1]+=IK2PI;
-}
-j6valid[1] = true;
-for(int ij6 = 0; ij6 < 2; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 2; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-{
-IkReal evalcond[2];
-IkReal x330=(npx)*(npx);
-IkReal x331=(cj4)*(cj4);
-IkReal x332=(sj4)*(sj4);
-IkReal x333=IKcos(j6);
-IkReal x334=(npy)*(npy);
-IkReal x335=IKsin(j6);
-IkReal x336=((npx)*(npy));
-IkReal x337=((IkReal(0.490000000000000))*(sj3)*(sj4));
-IkReal x338=((IkReal(1.00000000000000))*(x334));
-evalcond[0]=((((x333)*(((((x331)*(x336)))+(((x332)*(x336)))))))+(((x335)*(((((x330)*(x331)))+(((x330)*(x332)))))))+(((npx)*(x337))));
-evalcond[1]=((((x335)*(((((IkReal(-1.00000000000000))*(x332)*(x336)))+(((IkReal(-1.00000000000000))*(x331)*(x336)))))))+(((x333)*(((((IkReal(-1.00000000000000))*(x331)*(x338)))+(((IkReal(-1.00000000000000))*(x332)*(x338)))))))+(((IkReal(-1.00000000000000))*(npy)*(x337))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst10;
-IkReal x339=((cj6)*(npx));
-IkReal x340=((IkReal(49.0000000000000))*(cj3));
-IkReal x341=((npy)*(sj6));
-gconst10=IKsign(((((IkReal(-42.0000000000000))*(x339)))+(((IkReal(49.0000000000000))*(cj4)*(npz)*(sj3)))+(((x340)*(x341)))+(((IkReal(42.0000000000000))*(x341)))+(((IkReal(-1.00000000000000))*(x339)*(x340)))));
-IkReal x342=((npy)*(sj6));
-IkReal x343=((cj6)*(npx));
-IkReal x344=((IkReal(1.16666666666667))*(cj3));
-dummyeval[0]=((((IkReal(1.16666666666667))*(cj4)*(npz)*(sj3)))+(x342)+(((IkReal(-1.00000000000000))*(x343)*(x344)))+(((IkReal(-1.00000000000000))*(x343)))+(((x342)*(x344))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst11;
-IkReal x345=((npy)*(sj6));
-IkReal x346=((IkReal(1029.00000000000))*(cj3));
-IkReal x347=((cj6)*(npx));
-gconst11=IKsign(((((x345)*(x346)))+(((IkReal(1029.00000000000))*(cj4)*(npz)*(sj3)))+(((IkReal(-1.00000000000000))*(x346)*(x347)))+(((IkReal(-882.000000000000))*(x347)))+(((IkReal(882.000000000000))*(x345)))));
-IkReal x348=((npy)*(sj6));
-IkReal x349=((cj6)*(npx));
-IkReal x350=((IkReal(1.16666666666667))*(cj3));
-dummyeval[0]=((((IkReal(1.16666666666667))*(cj4)*(npz)*(sj3)))+(((IkReal(-1.00000000000000))*(x349)*(x350)))+(x348)+(((x348)*(x350)))+(((IkReal(-1.00000000000000))*(x349))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-IkReal x351=((cj4)*(sj3));
-IkReal x352=((IkReal(1225.00000000000))*(pp));
-IkReal x353=((IkReal(2100.00000000000))*(npz));
-if( IKabs(((gconst11)*(((IkReal(66.8850000000000))+(((IkReal(-1.00000000000000))*(cj3)*(x352)))+(((IkReal(-1050.00000000000))*(pp)))+(((IkReal(78.0325000000000))*(cj3)))+(((npz)*(x353))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst11)*(((((IkReal(78.0325000000000))*(x351)))+(((cj6)*(npx)*(x353)))+(((IkReal(-1.00000000000000))*(x351)*(x352)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x353))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst11)*(((IkReal(66.8850000000000))+(((IkReal(-1.00000000000000))*(cj3)*(x352)))+(((IkReal(-1050.00000000000))*(pp)))+(((IkReal(78.0325000000000))*(cj3)))+(((npz)*(x353)))))), ((gconst11)*(((((IkReal(78.0325000000000))*(x351)))+(((cj6)*(npx)*(x353)))+(((IkReal(-1.00000000000000))*(x351)*(x352)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x353)))))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[6];
-IkReal x354=IKcos(j5);
-IkReal x355=IKsin(j5);
-IkReal x356=((IkReal(1.00000000000000))*(npy));
-IkReal x357=((cj6)*(sj4));
-IkReal x358=((IkReal(0.490000000000000))*(sj3));
-IkReal x359=((sj4)*(sj6));
-IkReal x360=((IkReal(1.00000000000000))*(npz));
-IkReal x361=((cj6)*(npx));
-IkReal x362=((IkReal(0.490000000000000))*(cj3));
-IkReal x363=((npz)*(x355));
-IkReal x364=((cj4)*(x354));
-IkReal x365=((sj6)*(x355));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x354)*(x362)))+(((IkReal(-0.420000000000000))*(x354)))+(((IkReal(-1.00000000000000))*(x360)))+(((cj4)*(x355)*(x358))));
-evalcond[1]=((IkReal(0.0637000000000000))+(((IkReal(-0.840000000000000))*(npz)*(x354)))+(((IkReal(0.840000000000000))*(x355)*(x361)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-0.840000000000000))*(npy)*(x365))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(x354)*(x360)))+(((IkReal(-1.00000000000000))*(x362)))+(((x355)*(x361)))+(((IkReal(-1.00000000000000))*(x356)*(x365))));
-evalcond[3]=((((IkReal(-0.420000000000000))*(x355)))+(((IkReal(-1.00000000000000))*(x358)*(x364)))+(((IkReal(-1.00000000000000))*(x355)*(x362)))+(x361)+(((IkReal(-1.00000000000000))*(sj6)*(x356))));
-evalcond[4]=((((sj4)*(x363)))+(((npx)*(x354)*(x357)))+(((cj4)*(npx)*(sj6)))+(((cj4)*(cj6)*(npy)))+(((IkReal(-1.00000000000000))*(x354)*(x356)*(x359))));
-evalcond[5]=((((x361)*(x364)))+(((IkReal(-1.00000000000000))*(x358)))+(((IkReal(-1.00000000000000))*(x356)*(x357)))+(((cj4)*(x363)))+(((IkReal(-1.00000000000000))*(npx)*(x359)))+(((IkReal(-1.00000000000000))*(sj6)*(x356)*(x364))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-IkReal x366=((cj4)*(sj3));
-IkReal x367=((IkReal(100.000000000000))*(npz));
-if( IKabs(((gconst10)*(((IkReal(-17.6400000000000))+(((IkReal(-41.1600000000000))*(cj3)))+(((npz)*(x367)))+(((IkReal(-24.0100000000000))*((cj3)*(cj3)))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst10)*(((((IkReal(-20.5800000000000))*(x366)))+(((cj6)*(npx)*(x367)))+(((IkReal(-24.0100000000000))*(cj3)*(x366)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x367))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst10)*(((IkReal(-17.6400000000000))+(((IkReal(-41.1600000000000))*(cj3)))+(((npz)*(x367)))+(((IkReal(-24.0100000000000))*((cj3)*(cj3))))))), ((gconst10)*(((((IkReal(-20.5800000000000))*(x366)))+(((cj6)*(npx)*(x367)))+(((IkReal(-24.0100000000000))*(cj3)*(x366)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x367)))))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[6];
-IkReal x368=IKcos(j5);
-IkReal x369=IKsin(j5);
-IkReal x370=((IkReal(1.00000000000000))*(npy));
-IkReal x371=((cj6)*(sj4));
-IkReal x372=((IkReal(0.490000000000000))*(sj3));
-IkReal x373=((sj4)*(sj6));
-IkReal x374=((IkReal(1.00000000000000))*(npz));
-IkReal x375=((cj6)*(npx));
-IkReal x376=((IkReal(0.490000000000000))*(cj3));
-IkReal x377=((npz)*(x369));
-IkReal x378=((cj4)*(x368));
-IkReal x379=((sj6)*(x369));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x368)*(x376)))+(((cj4)*(x369)*(x372)))+(((IkReal(-1.00000000000000))*(x374)))+(((IkReal(-0.420000000000000))*(x368))));
-evalcond[1]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(x369)*(x375)))+(((IkReal(-0.840000000000000))*(npz)*(x368)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-0.840000000000000))*(npy)*(x379))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(x368)*(x374)))+(((IkReal(-1.00000000000000))*(x370)*(x379)))+(((x369)*(x375)))+(((IkReal(-1.00000000000000))*(x376))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x372)*(x378)))+(x375)+(((IkReal(-0.420000000000000))*(x369)))+(((IkReal(-1.00000000000000))*(sj6)*(x370)))+(((IkReal(-1.00000000000000))*(x369)*(x376))));
-evalcond[4]=((((sj4)*(x377)))+(((IkReal(-1.00000000000000))*(x368)*(x370)*(x373)))+(((cj4)*(npx)*(sj6)))+(((cj4)*(cj6)*(npy)))+(((npx)*(x368)*(x371))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(npx)*(x373)))+(((x375)*(x378)))+(((IkReal(-1.00000000000000))*(x370)*(x371)))+(((IkReal(-1.00000000000000))*(x372)))+(((cj4)*(x377)))+(((IkReal(-1.00000000000000))*(sj6)*(x370)*(x378))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j6array[2], cj6array[2], sj6array[2];
-bool j6valid[2]={false};
-_nj6 = 2;
-if( IKabs(npy) < IKFAST_ATAN2_MAGTHRESH && IKabs(npx) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x380=((IkReal(1.00000000000000))*(IKatan2(npy, npx)));
-if( ((((npx)*(npx))+((npy)*(npy)))) < (IkReal)-0.00001 )
-    continue;
-if( (((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30)))) < -1-IKFAST_SINCOS_THRESH || (((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30)))) > 1+IKFAST_SINCOS_THRESH )
-    continue;
-IkReal x381=IKasin(((IkReal(0.490000000000000))*(sj3)*(sj4)*(((IKabs(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy)))))) != 0)?((IkReal)1/(IKabs(IKsqrt((((npx)*(npx))+((npy)*(npy))))))):(IkReal)1.0e30))));
-j6array[0]=((((IkReal(-1.00000000000000))*(x381)))+(((IkReal(-1.00000000000000))*(x380))));
-sj6array[0]=IKsin(j6array[0]);
-cj6array[0]=IKcos(j6array[0]);
-j6array[1]=((IkReal(3.14159265358979))+(x381)+(((IkReal(-1.00000000000000))*(x380))));
-sj6array[1]=IKsin(j6array[1]);
-cj6array[1]=IKcos(j6array[1]);
-if( j6array[0] > IKPI )
-{
-    j6array[0]-=IK2PI;
-}
-else if( j6array[0] < -IKPI )
-{    j6array[0]+=IK2PI;
-}
-j6valid[0] = true;
-if( j6array[1] > IKPI )
-{
-    j6array[1]-=IK2PI;
-}
-else if( j6array[1] < -IKPI )
-{    j6array[1]+=IK2PI;
-}
-j6valid[1] = true;
-for(int ij6 = 0; ij6 < 2; ++ij6)
-{
-if( !j6valid[ij6] )
-{
-    continue;
-}
-_ij6[0] = ij6; _ij6[1] = -1;
-for(int iij6 = ij6+1; iij6 < 2; ++iij6)
-{
-if( j6valid[iij6] && IKabs(cj6array[ij6]-cj6array[iij6]) < IKFAST_SOLUTION_THRESH && IKabs(sj6array[ij6]-sj6array[iij6]) < IKFAST_SOLUTION_THRESH )
-{
-    j6valid[iij6]=false; _ij6[1] = iij6; break; 
-}
-}
-j6 = j6array[ij6]; cj6 = cj6array[ij6]; sj6 = sj6array[ij6];
-
-{
-IkReal dummyeval[1];
-IkReal gconst10;
-IkReal x382=((cj6)*(npx));
-IkReal x383=((IkReal(49.0000000000000))*(cj3));
-IkReal x384=((npy)*(sj6));
-gconst10=IKsign(((((IkReal(-42.0000000000000))*(x382)))+(((IkReal(42.0000000000000))*(x384)))+(((x383)*(x384)))+(((IkReal(49.0000000000000))*(cj4)*(npz)*(sj3)))+(((IkReal(-1.00000000000000))*(x382)*(x383)))));
-IkReal x385=((npy)*(sj6));
-IkReal x386=((cj6)*(npx));
-IkReal x387=((IkReal(1.16666666666667))*(cj3));
-dummyeval[0]=((((IkReal(1.16666666666667))*(cj4)*(npz)*(sj3)))+(x385)+(((IkReal(-1.00000000000000))*(x386)))+(((IkReal(-1.00000000000000))*(x386)*(x387)))+(((x385)*(x387))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst11;
-IkReal x388=((npy)*(sj6));
-IkReal x389=((IkReal(1029.00000000000))*(cj3));
-IkReal x390=((cj6)*(npx));
-gconst11=IKsign(((((IkReal(-1.00000000000000))*(x389)*(x390)))+(((IkReal(-882.000000000000))*(x390)))+(((x388)*(x389)))+(((IkReal(1029.00000000000))*(cj4)*(npz)*(sj3)))+(((IkReal(882.000000000000))*(x388)))));
-IkReal x391=((npy)*(sj6));
-IkReal x392=((cj6)*(npx));
-IkReal x393=((IkReal(1.16666666666667))*(cj3));
-dummyeval[0]=((((IkReal(1.16666666666667))*(cj4)*(npz)*(sj3)))+(((IkReal(-1.00000000000000))*(x392)))+(x391)+(((x391)*(x393)))+(((IkReal(-1.00000000000000))*(x392)*(x393))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-IkReal x394=((cj4)*(sj3));
-IkReal x395=((IkReal(1225.00000000000))*(pp));
-IkReal x396=((IkReal(2100.00000000000))*(npz));
-if( IKabs(((gconst11)*(((IkReal(66.8850000000000))+(((npz)*(x396)))+(((IkReal(-1050.00000000000))*(pp)))+(((IkReal(-1.00000000000000))*(cj3)*(x395)))+(((IkReal(78.0325000000000))*(cj3))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst11)*(((((cj6)*(npx)*(x396)))+(((IkReal(-1.00000000000000))*(x394)*(x395)))+(((IkReal(78.0325000000000))*(x394)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x396))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst11)*(((IkReal(66.8850000000000))+(((npz)*(x396)))+(((IkReal(-1050.00000000000))*(pp)))+(((IkReal(-1.00000000000000))*(cj3)*(x395)))+(((IkReal(78.0325000000000))*(cj3)))))), ((gconst11)*(((((cj6)*(npx)*(x396)))+(((IkReal(-1.00000000000000))*(x394)*(x395)))+(((IkReal(78.0325000000000))*(x394)))+(((IkReal(-1.00000000000000))*(npy)*(sj6)*(x396)))))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[6];
-IkReal x397=IKcos(j5);
-IkReal x398=IKsin(j5);
-IkReal x399=((IkReal(1.00000000000000))*(npy));
-IkReal x400=((cj6)*(sj4));
-IkReal x401=((IkReal(0.490000000000000))*(sj3));
-IkReal x402=((sj4)*(sj6));
-IkReal x403=((IkReal(1.00000000000000))*(npz));
-IkReal x404=((cj6)*(npx));
-IkReal x405=((IkReal(0.490000000000000))*(cj3));
-IkReal x406=((npz)*(x398));
-IkReal x407=((cj4)*(x397));
-IkReal x408=((sj6)*(x398));
-evalcond[0]=((((cj4)*(x398)*(x401)))+(((IkReal(-1.00000000000000))*(x397)*(x405)))+(((IkReal(-0.420000000000000))*(x397)))+(((IkReal(-1.00000000000000))*(x403))));
-evalcond[1]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(x398)*(x404)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-0.840000000000000))*(npy)*(x408)))+(((IkReal(-0.840000000000000))*(npz)*(x397))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(x399)*(x408)))+(((IkReal(-1.00000000000000))*(x397)*(x403)))+(((x398)*(x404)))+(((IkReal(-1.00000000000000))*(x405))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x401)*(x407)))+(((IkReal(-1.00000000000000))*(sj6)*(x399)))+(x404)+(((IkReal(-1.00000000000000))*(x398)*(x405)))+(((IkReal(-0.420000000000000))*(x398))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x397)*(x399)*(x402)))+(((npx)*(x397)*(x400)))+(((cj4)*(npx)*(sj6)))+(((cj4)*(cj6)*(npy)))+(((sj4)*(x406))));
-evalcond[5]=((((x404)*(x407)))+(((IkReal(-1.00000000000000))*(sj6)*(x399)*(x407)))+(((cj4)*(x406)))+(((IkReal(-1.00000000000000))*(x399)*(x400)))+(((IkReal(-1.00000000000000))*(npx)*(x402)))+(((IkReal(-1.00000000000000))*(x401))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j5array[1], cj5array[1], sj5array[1];
-bool j5valid[1]={false};
-_nj5 = 1;
-IkReal x409=((cj4)*(sj3));
-IkReal x410=((IkReal(100.000000000000))*(npz));
-if( IKabs(((gconst10)*(((IkReal(-17.6400000000000))+(((IkReal(-41.1600000000000))*(cj3)))+(((npz)*(x410)))+(((IkReal(-24.0100000000000))*((cj3)*(cj3)))))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst10)*(((((IkReal(-1.00000000000000))*(npy)*(sj6)*(x410)))+(((cj6)*(npx)*(x410)))+(((IkReal(-24.0100000000000))*(cj3)*(x409)))+(((IkReal(-20.5800000000000))*(x409))))))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j5array[0]=IKatan2(((gconst10)*(((IkReal(-17.6400000000000))+(((IkReal(-41.1600000000000))*(cj3)))+(((npz)*(x410)))+(((IkReal(-24.0100000000000))*((cj3)*(cj3))))))), ((gconst10)*(((((IkReal(-1.00000000000000))*(npy)*(sj6)*(x410)))+(((cj6)*(npx)*(x410)))+(((IkReal(-24.0100000000000))*(cj3)*(x409)))+(((IkReal(-20.5800000000000))*(x409)))))));
-sj5array[0]=IKsin(j5array[0]);
-cj5array[0]=IKcos(j5array[0]);
-if( j5array[0] > IKPI )
-{
-    j5array[0]-=IK2PI;
-}
-else if( j5array[0] < -IKPI )
-{    j5array[0]+=IK2PI;
-}
-j5valid[0] = true;
-for(int ij5 = 0; ij5 < 1; ++ij5)
-{
-if( !j5valid[ij5] )
-{
-    continue;
-}
-_ij5[0] = ij5; _ij5[1] = -1;
-for(int iij5 = ij5+1; iij5 < 1; ++iij5)
-{
-if( j5valid[iij5] && IKabs(cj5array[ij5]-cj5array[iij5]) < IKFAST_SOLUTION_THRESH && IKabs(sj5array[ij5]-sj5array[iij5]) < IKFAST_SOLUTION_THRESH )
-{
-    j5valid[iij5]=false; _ij5[1] = iij5; break; 
-}
-}
-j5 = j5array[ij5]; cj5 = cj5array[ij5]; sj5 = sj5array[ij5];
-{
-IkReal evalcond[6];
-IkReal x411=IKcos(j5);
-IkReal x412=IKsin(j5);
-IkReal x413=((IkReal(1.00000000000000))*(npy));
-IkReal x414=((cj6)*(sj4));
-IkReal x415=((IkReal(0.490000000000000))*(sj3));
-IkReal x416=((sj4)*(sj6));
-IkReal x417=((IkReal(1.00000000000000))*(npz));
-IkReal x418=((cj6)*(npx));
-IkReal x419=((IkReal(0.490000000000000))*(cj3));
-IkReal x420=((npz)*(x412));
-IkReal x421=((cj4)*(x411));
-IkReal x422=((sj6)*(x412));
-evalcond[0]=((((cj4)*(x412)*(x415)))+(((IkReal(-0.420000000000000))*(x411)))+(((IkReal(-1.00000000000000))*(x411)*(x419)))+(((IkReal(-1.00000000000000))*(x417))));
-evalcond[1]=((IkReal(0.0637000000000000))+(((IkReal(0.840000000000000))*(x412)*(x418)))+(((IkReal(-1.00000000000000))*(pp)))+(((IkReal(-0.840000000000000))*(npy)*(x422)))+(((IkReal(-0.840000000000000))*(npz)*(x411))));
-evalcond[2]=((IkReal(-0.420000000000000))+(((IkReal(-1.00000000000000))*(x411)*(x417)))+(((x412)*(x418)))+(((IkReal(-1.00000000000000))*(x413)*(x422)))+(((IkReal(-1.00000000000000))*(x419))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(sj6)*(x413)))+(((IkReal(-1.00000000000000))*(x412)*(x419)))+(((IkReal(-0.420000000000000))*(x412)))+(x418)+(((IkReal(-1.00000000000000))*(x415)*(x421))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x411)*(x413)*(x416)))+(((npx)*(x411)*(x414)))+(((sj4)*(x420)))+(((cj4)*(npx)*(sj6)))+(((cj4)*(cj6)*(npy))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(sj6)*(x413)*(x421)))+(((x418)*(x421)))+(((cj4)*(x420)))+(((IkReal(-1.00000000000000))*(x413)*(x414)))+(((IkReal(-1.00000000000000))*(npx)*(x416)))+(((IkReal(-1.00000000000000))*(x415))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-rotationfunction0(solutions);
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-}
-}
-}
-return solutions.GetNumSolutions()>0;
-}
-inline void rotationfunction0(IkSolutionListBase<IkReal>& solutions) {
-for(int rotationiter = 0; rotationiter < 1; ++rotationiter) {
-IkReal x78=((cj6)*(sj4));
-IkReal x79=((IkReal(1.00000000000000))*(sj5));
-IkReal x80=((cj4)*(cj5));
-IkReal x81=((IkReal(1.00000000000000))*(sj3));
-IkReal x82=((cj3)*(sj5));
-IkReal x83=((IkReal(1.00000000000000))*(sj6));
-IkReal x84=((sj4)*(sj6));
-IkReal x85=((IkReal(1.00000000000000))*(cj3));
-IkReal x86=((IkReal(-1.00000000000000))*(cj3));
-IkReal x87=((((cj3)*(x80)))+(((IkReal(-1.00000000000000))*(sj3)*(x79))));
-IkReal x88=((((cj5)*(sj3)))+(((cj4)*(x82))));
-IkReal x89=((((cj5)*(x84)))+(((IkReal(-1.00000000000000))*(cj4)*(cj6))));
-IkReal x90=((x82)+(((sj3)*(x80))));
-IkReal x91=((((cj4)*(sj3)*(sj5)))+(((IkReal(-1.00000000000000))*(cj5)*(x85))));
-IkReal x92=((cj6)*(x87));
-IkReal x93=((((IkReal(-1.00000000000000))*(cj4)*(x83)))+(((IkReal(-1.00000000000000))*(cj5)*(x78))));
-IkReal x94=((((IkReal(-1.00000000000000))*(cj3)*(sj4)*(x83)))+(x92));
-IkReal x95=((((IkReal(-1.00000000000000))*(x81)*(x84)))+(((cj6)*(x90))));
-IkReal x96=((((IkReal(-1.00000000000000))*(x83)*(x90)))+(((IkReal(-1.00000000000000))*(x78)*(x81))));
-IkReal x97=((((x78)*(x86)))+(((IkReal(-1.00000000000000))*(sj6)*(x87))));
-new_r00=((((r00)*(((((x84)*(x86)))+(x92)))))+(((r01)*(((((IkReal(-1.00000000000000))*(x83)*(x87)))+(((IkReal(-1.00000000000000))*(x78)*(x85)))))))+(((r02)*(x88))));
-new_r01=((((r12)*(x88)))+(((r11)*(x97)))+(((r10)*(x94))));
-new_r02=((((r21)*(x97)))+(((r20)*(x94)))+(((r22)*(x88))));
-new_r10=((((r00)*(x93)))+(((r01)*(x89)))+(((IkReal(-1.00000000000000))*(r02)*(sj4)*(x79))));
-new_r11=((((r11)*(x89)))+(((r10)*(x93)))+(((IkReal(-1.00000000000000))*(r12)*(sj4)*(x79))));
-new_r12=((((r21)*(x89)))+(((IkReal(-1.00000000000000))*(r22)*(sj4)*(x79)))+(((r20)*(x93))));
-new_r20=((((r01)*(x96)))+(((r00)*(x95)))+(((r02)*(x91))));
-new_r21=((((r12)*(x91)))+(((r11)*(x96)))+(((r10)*(x95))));
-new_r22=((((r21)*(x96)))+(((r20)*(x95)))+(((r22)*(x91))));
-{
-IkReal j1array[2], cj1array[2], sj1array[2];
-bool j1valid[2]={false};
-_nj1 = 2;
-cj1array[0]=new_r22;
-if( cj1array[0] >= -1-IKFAST_SINCOS_THRESH && cj1array[0] <= 1+IKFAST_SINCOS_THRESH )
-{
-    j1valid[0] = j1valid[1] = true;
-    j1array[0] = IKacos(cj1array[0]);
-    sj1array[0] = IKsin(j1array[0]);
-    cj1array[1] = cj1array[0];
-    j1array[1] = -j1array[0];
-    sj1array[1] = -sj1array[0];
-}
-else if( isnan(cj1array[0]) )
-{
-    // probably any value will work
-    j1valid[0] = true;
-    cj1array[0] = 1; sj1array[0] = 0; j1array[0] = 0;
-}
-for(int ij1 = 0; ij1 < 2; ++ij1)
-{
-if( !j1valid[ij1] )
-{
-    continue;
-}
-_ij1[0] = ij1; _ij1[1] = -1;
-for(int iij1 = ij1+1; iij1 < 2; ++iij1)
-{
-if( j1valid[iij1] && IKabs(cj1array[ij1]-cj1array[iij1]) < IKFAST_SOLUTION_THRESH && IKabs(sj1array[ij1]-sj1array[iij1]) < IKFAST_SOLUTION_THRESH )
-{
-    j1valid[iij1]=false; _ij1[1] = iij1; break; 
-}
-}
-j1 = j1array[ij1]; cj1 = cj1array[ij1]; sj1 = sj1array[ij1];
-
-{
-IkReal dummyeval[1];
-IkReal gconst12;
-gconst12=IKsign(sj1);
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst13;
-gconst13=IKsign((((new_r12)*(new_r12))+((new_r02)*(new_r02))));
-dummyeval[0]=(((new_r12)*(new_r12))+((new_r02)*(new_r02)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst14;
-gconst14=IKsign(((((cj1)*((new_r12)*(new_r12))))+(((cj1)*((new_r02)*(new_r02))))));
-dummyeval[0]=((((cj1)*((new_r12)*(new_r12))))+(((cj1)*((new_r02)*(new_r02)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[7];
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.57079632679490))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=new_r22;
-evalcond[2]=new_r22;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(new_r21) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r20) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(new_r21)+IKsqr(new_r20)-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(new_r21, new_r20);
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[2];
-evalcond[0]=((((IkReal(-1.00000000000000))*(IKcos(j0))))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(IKsin(j0))))+(new_r21));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst21;
-gconst21=IKsign((((new_r12)*(new_r12))+((new_r02)*(new_r02))));
-dummyeval[0]=(((new_r12)*(new_r12))+((new_r02)*(new_r02)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst20;
-gconst20=IKsign(((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10)))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x98=((gconst20)*(sj0));
-if( IKabs(((new_r12)*(x98))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x98))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x98)), ((IkReal(-1.00000000000000))*(new_r02)*(x98)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x99=IKsin(j2);
-IkReal x100=IKcos(j2);
-IkReal x101=((IkReal(1.00000000000000))*(x99));
-evalcond[0]=((((new_r02)*(x99)))+(((new_r12)*(x100))));
-evalcond[1]=((((new_r10)*(x100)))+(sj0)+(((new_r00)*(x99))));
-evalcond[2]=((IkReal(1.00000000000000))+(((new_r02)*(x100)))+(((IkReal(-1.00000000000000))*(new_r12)*(x101))));
-evalcond[3]=((((new_r01)*(x99)))+(((IkReal(-1.00000000000000))*(cj0)))+(((new_r11)*(x100))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(new_r10)*(x101)))+(((new_r00)*(x100))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r11)*(x101)))+(((new_r01)*(x100))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-if( IKabs(((gconst21)*(new_r12))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(gconst21)*(new_r02))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((gconst21)*(new_r12)), ((IkReal(-1.00000000000000))*(gconst21)*(new_r02)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x102=IKsin(j2);
-IkReal x103=IKcos(j2);
-IkReal x104=((IkReal(1.00000000000000))*(x102));
-evalcond[0]=((((new_r02)*(x102)))+(((new_r12)*(x103))));
-evalcond[1]=((((new_r10)*(x103)))+(sj0)+(((new_r00)*(x102))));
-evalcond[2]=((IkReal(1.00000000000000))+(((new_r02)*(x103)))+(((IkReal(-1.00000000000000))*(new_r12)*(x104))));
-evalcond[3]=((((new_r01)*(x102)))+(((IkReal(-1.00000000000000))*(cj0)))+(((new_r11)*(x103))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(new_r10)*(x104)))+(((new_r00)*(x103))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r11)*(x104)))+(((new_r01)*(x103))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-} else
-{
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(4.71238898038469))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=new_r22;
-evalcond[2]=((IkReal(-1.00000000000000))*(new_r22));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((IkReal(-1.00000000000000))*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r20))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((IkReal(-1.00000000000000))*(new_r21)))+IKsqr(((IkReal(-1.00000000000000))*(new_r20)))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((IkReal(-1.00000000000000))*(new_r21)), ((IkReal(-1.00000000000000))*(new_r20)));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[2];
-evalcond[0]=((IKcos(j0))+(new_r20));
-evalcond[1]=((IKsin(j0))+(new_r21));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst24;
-gconst24=IKsign(((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10)))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst25;
-gconst25=IKsign(((((IkReal(-1.00000000000000))*((new_r02)*(new_r02))))+(((IkReal(-1.00000000000000))*((new_r12)*(new_r12))))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*((new_r02)*(new_r02))))+(((IkReal(-1.00000000000000))*((new_r12)*(new_r12)))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-if( IKabs(((gconst25)*(new_r12))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(gconst25)*(new_r02))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((gconst25)*(new_r12)), ((IkReal(-1.00000000000000))*(gconst25)*(new_r02)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x105=IKsin(j2);
-IkReal x106=IKcos(j2);
-IkReal x107=((IkReal(1.00000000000000))*(x105));
-evalcond[0]=((((new_r02)*(x105)))+(((new_r12)*(x106))));
-evalcond[1]=((((new_r10)*(x106)))+(sj0)+(((new_r00)*(x105))));
-evalcond[2]=((IkReal(-1.00000000000000))+(((new_r02)*(x106)))+(((IkReal(-1.00000000000000))*(new_r12)*(x107))));
-evalcond[3]=((((new_r01)*(x105)))+(((IkReal(-1.00000000000000))*(cj0)))+(((new_r11)*(x106))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(new_r10)*(x107)))+(((new_r00)*(x106))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r11)*(x107)))+(((new_r01)*(x106))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x108=((gconst24)*(sj0));
-if( IKabs(((new_r12)*(x108))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x108))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x108)), ((IkReal(-1.00000000000000))*(new_r02)*(x108)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x109=IKsin(j2);
-IkReal x110=IKcos(j2);
-IkReal x111=((IkReal(1.00000000000000))*(x109));
-evalcond[0]=((((new_r02)*(x109)))+(((new_r12)*(x110))));
-evalcond[1]=((((new_r10)*(x110)))+(sj0)+(((new_r00)*(x109))));
-evalcond[2]=((IkReal(-1.00000000000000))+(((new_r02)*(x110)))+(((IkReal(-1.00000000000000))*(new_r12)*(x111))));
-evalcond[3]=((((new_r11)*(x110)))+(((new_r01)*(x109)))+(((IkReal(-1.00000000000000))*(cj0))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(new_r10)*(x111)))+(((new_r00)*(x110))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r11)*(x111)))+(((new_r01)*(x110))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-} else
-{
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(-1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[5]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[6]=((IkReal(1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  )
-{
-{
-IkReal j2array[2], cj2array[2], sj2array[2];
-bool j2valid[2]={false};
-_nj2 = 2;
-if( IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x112=IKatan2(new_r12, new_r02);
-j2array[0]=((IkReal(-1.00000000000000))*(x112));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-j2array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x112))));
-sj2array[1]=IKsin(j2array[1]);
-cj2array[1]=IKcos(j2array[1]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-if( j2array[1] > IKPI )
-{
-    j2array[1]-=IK2PI;
-}
-else if( j2array[1] < -IKPI )
-{    j2array[1]+=IK2PI;
-}
-j2valid[1] = true;
-for(int ij2 = 0; ij2 < 2; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 2; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[1];
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r12)*(IKsin(j2))))+(((new_r02)*(IKcos(j2)))));
-if( IKabs(evalcond[0]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x113=IKsin(j0);
-IkReal x114=((IkReal(1.00000000000000))*(sj2));
-IkReal x115=((IkReal(1.00000000000000))*(IKcos(j0)));
-evalcond[0]=((((new_r00)*(sj2)))+(x113)+(((cj2)*(new_r10))));
-evalcond[1]=((((new_r01)*(sj2)))+(((IkReal(-1.00000000000000))*(x115)))+(((cj2)*(new_r11))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r10)*(x114)))+(((IkReal(-1.00000000000000))*(x115)))+(((cj2)*(new_r00))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r11)*(x114)))+(((cj2)*(new_r01)))+(((IkReal(-1.00000000000000))*(x113))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-}
-}
-
-} else
-{
-IkReal x116=((IkReal(1.00000000000000))+(new_r22));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=x116;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=new_r20;
-evalcond[5]=new_r21;
-evalcond[6]=x116;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  )
-{
-{
-IkReal j2array[2], cj2array[2], sj2array[2];
-bool j2valid[2]={false};
-_nj2 = 2;
-if( IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-IkReal x117=IKatan2(new_r12, new_r02);
-j2array[0]=((IkReal(-1.00000000000000))*(x117));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-j2array[1]=((IkReal(3.14159265358979))+(((IkReal(-1.00000000000000))*(x117))));
-sj2array[1]=IKsin(j2array[1]);
-cj2array[1]=IKcos(j2array[1]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-if( j2array[1] > IKPI )
-{
-    j2array[1]-=IK2PI;
-}
-else if( j2array[1] < -IKPI )
-{    j2array[1]+=IK2PI;
-}
-j2valid[1] = true;
-for(int ij2 = 0; ij2 < 2; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 2; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[1];
-evalcond[0]=((((IkReal(-1.00000000000000))*(new_r12)*(IKsin(j2))))+(((new_r02)*(IKcos(j2)))));
-if( IKabs(evalcond[0]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x118=IKcos(j0);
-IkReal x119=IKsin(j0);
-IkReal x120=((IkReal(1.00000000000000))*(sj2));
-evalcond[0]=((((new_r00)*(sj2)))+(x119)+(((cj2)*(new_r10))));
-evalcond[1]=((((new_r01)*(sj2)))+(((cj2)*(new_r11)))+(((IkReal(-1.00000000000000))*(x118))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r10)*(x120)))+(x118)+(((cj2)*(new_r00))));
-evalcond[3]=((x119)+(((cj2)*(new_r01)))+(((IkReal(-1.00000000000000))*(new_r11)*(x120))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x121=((gconst14)*(new_r22)*(sj1));
-if( IKabs(((new_r12)*(x121))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x121))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x121)), ((IkReal(-1.00000000000000))*(new_r02)*(x121)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x122=IKcos(j2);
-IkReal x123=IKsin(j2);
-IkReal x124=((IkReal(1.00000000000000))*(cj1));
-IkReal x125=((sj1)*(x122));
-IkReal x126=((new_r12)*(x123));
-IkReal x127=((new_r02)*(x122));
-IkReal x128=((IkReal(1.00000000000000))*(sj1)*(x123));
-evalcond[0]=((((new_r02)*(x123)))+(((new_r12)*(x122))));
-evalcond[1]=((sj1)+(x127)+(((IkReal(-1.00000000000000))*(x126))));
-evalcond[2]=((((cj1)*(x127)))+(((IkReal(-1.00000000000000))*(x124)*(x126)))+(((new_r22)*(sj1))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r10)*(x128)))+(((new_r00)*(x125)))+(((IkReal(-1.00000000000000))*(new_r20)*(x124))));
-evalcond[4]=((((new_r01)*(x125)))+(((IkReal(-1.00000000000000))*(new_r21)*(x124)))+(((IkReal(-1.00000000000000))*(new_r11)*(x128))));
-evalcond[5]=((IkReal(1.00000000000000))+(((IkReal(-1.00000000000000))*(sj1)*(x126)))+(((new_r02)*(x125)))+(((IkReal(-1.00000000000000))*(new_r22)*(x124))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst15;
-gconst15=IKsign(sj1);
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[11];
-IkReal x129=((((new_r02)*(sj2)))+(((cj2)*(new_r12))));
-IkReal x130=((((cj2)*(new_r02)))+(((IkReal(-1.00000000000000))*(new_r12)*(sj2))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(-1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x129;
-evalcond[5]=x129;
-evalcond[6]=x130;
-evalcond[7]=x130;
-evalcond[8]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[9]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[10]=((IkReal(1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x131=IKsin(j0);
-IkReal x132=((IkReal(1.00000000000000))*(sj2));
-IkReal x133=((IkReal(1.00000000000000))*(IKcos(j0)));
-evalcond[0]=((((new_r00)*(sj2)))+(x131)+(((cj2)*(new_r10))));
-evalcond[1]=((((new_r01)*(sj2)))+(((IkReal(-1.00000000000000))*(x133)))+(((cj2)*(new_r11))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r10)*(x132)))+(((IkReal(-1.00000000000000))*(x133)))+(((cj2)*(new_r00))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r11)*(x132)))+(((cj2)*(new_r01)))+(((IkReal(-1.00000000000000))*(x131))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-IkReal x134=((IkReal(1.00000000000000))+(new_r22));
-IkReal x135=((new_r12)*(sj2));
-IkReal x136=((cj2)*(new_r02));
-IkReal x137=((((new_r02)*(sj2)))+(((cj2)*(new_r12))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=x134;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x137;
-evalcond[5]=x137;
-evalcond[6]=((x136)+(((IkReal(-1.00000000000000))*(x135))));
-evalcond[7]=((x135)+(((IkReal(-1.00000000000000))*(x136))));
-evalcond[8]=new_r20;
-evalcond[9]=new_r21;
-evalcond[10]=x134;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x138=IKcos(j0);
-IkReal x139=IKsin(j0);
-IkReal x140=((IkReal(1.00000000000000))*(sj2));
-evalcond[0]=((((new_r00)*(sj2)))+(x139)+(((cj2)*(new_r10))));
-evalcond[1]=((((new_r01)*(sj2)))+(((cj2)*(new_r11)))+(((IkReal(-1.00000000000000))*(x138))));
-evalcond[2]=((x138)+(((IkReal(-1.00000000000000))*(new_r10)*(x140)))+(((cj2)*(new_r00))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(new_r11)*(x140)))+(x139)+(((cj2)*(new_r01))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x141=IKsin(j0);
-IkReal x142=IKcos(j0);
-IkReal x143=((cj2)*(new_r01));
-IkReal x144=((IkReal(1.00000000000000))*(cj1));
-IkReal x145=((IkReal(1.00000000000000))*(sj1));
-IkReal x146=((new_r10)*(sj2));
-IkReal x147=((new_r11)*(sj2));
-IkReal x148=((cj2)*(new_r00));
-IkReal x149=((IkReal(1.00000000000000))*(x142));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x142)*(x145)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x141)*(x145)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x141)+(((cj2)*(new_r10))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x149)))+(((new_r01)*(sj2)))+(((cj2)*(new_r11))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x142)*(x144)))+(x148)+(((IkReal(-1.00000000000000))*(x146))));
-evalcond[5]=((x143)+(((IkReal(-1.00000000000000))*(x147)))+(((IkReal(-1.00000000000000))*(x141)*(x144))));
-evalcond[6]=((((IkReal(-1.00000000000000))*(x149)))+(((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(x144)*(x146)))+(((cj1)*(x148))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x144)*(x147)))+(((IkReal(-1.00000000000000))*(x141)))+(((new_r21)*(sj1)))+(((cj1)*(x143))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x150=IKsin(j0);
-IkReal x151=IKcos(j0);
-IkReal x152=((cj2)*(new_r01));
-IkReal x153=((IkReal(1.00000000000000))*(cj1));
-IkReal x154=((IkReal(1.00000000000000))*(sj1));
-IkReal x155=((new_r10)*(sj2));
-IkReal x156=((new_r11)*(sj2));
-IkReal x157=((cj2)*(new_r00));
-IkReal x158=((IkReal(1.00000000000000))*(x151));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x151)*(x154)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x150)*(x154)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x150)+(((cj2)*(new_r10))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x158)))+(((new_r01)*(sj2)))+(((cj2)*(new_r11))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x151)*(x153)))+(x157)+(((IkReal(-1.00000000000000))*(x155))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x150)*(x153)))+(x152)+(((IkReal(-1.00000000000000))*(x156))));
-evalcond[6]=((((IkReal(-1.00000000000000))*(x158)))+(((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(x153)*(x155)))+(((cj1)*(x157))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x153)*(x156)))+(((IkReal(-1.00000000000000))*(x150)))+(((new_r21)*(sj1)))+(((cj1)*(x152))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((gconst15)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst15)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j0array[0]=IKatan2(((gconst15)*(new_r21)), ((gconst15)*(new_r20)));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x159=IKsin(j0);
-IkReal x160=IKcos(j0);
-IkReal x161=((cj2)*(new_r01));
-IkReal x162=((IkReal(1.00000000000000))*(cj1));
-IkReal x163=((IkReal(1.00000000000000))*(sj1));
-IkReal x164=((new_r10)*(sj2));
-IkReal x165=((new_r11)*(sj2));
-IkReal x166=((cj2)*(new_r00));
-IkReal x167=((IkReal(1.00000000000000))*(x160));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x160)*(x163)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x159)*(x163)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x159)+(((cj2)*(new_r10))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x167)))+(((new_r01)*(sj2)))+(((cj2)*(new_r11))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x160)*(x162)))+(x166)+(((IkReal(-1.00000000000000))*(x164))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x159)*(x162)))+(x161)+(((IkReal(-1.00000000000000))*(x165))));
-evalcond[6]=((((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(x167)))+(((IkReal(-1.00000000000000))*(x162)*(x164)))+(((cj1)*(x166))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x162)*(x165)))+(((IkReal(-1.00000000000000))*(x159)))+(((cj1)*(x161)))+(((new_r21)*(sj1))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x168=((gconst13)*(sj1));
-if( IKabs(((new_r12)*(x168))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x168))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x168)), ((IkReal(-1.00000000000000))*(new_r02)*(x168)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[6];
-IkReal x169=IKcos(j2);
-IkReal x170=IKsin(j2);
-IkReal x171=((IkReal(1.00000000000000))*(cj1));
-IkReal x172=((sj1)*(x169));
-IkReal x173=((new_r12)*(x170));
-IkReal x174=((new_r02)*(x169));
-IkReal x175=((IkReal(1.00000000000000))*(sj1)*(x170));
-evalcond[0]=((((new_r02)*(x170)))+(((new_r12)*(x169))));
-evalcond[1]=((sj1)+(((IkReal(-1.00000000000000))*(x173)))+(x174));
-evalcond[2]=((((new_r22)*(sj1)))+(((IkReal(-1.00000000000000))*(x171)*(x173)))+(((cj1)*(x174))));
-evalcond[3]=((((new_r00)*(x172)))+(((IkReal(-1.00000000000000))*(new_r20)*(x171)))+(((IkReal(-1.00000000000000))*(new_r10)*(x175))));
-evalcond[4]=((((new_r01)*(x172)))+(((IkReal(-1.00000000000000))*(new_r21)*(x171)))+(((IkReal(-1.00000000000000))*(new_r11)*(x175))));
-evalcond[5]=((IkReal(1.00000000000000))+(((new_r02)*(x172)))+(((IkReal(-1.00000000000000))*(sj1)*(x173)))+(((IkReal(-1.00000000000000))*(new_r22)*(x171))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst15;
-gconst15=IKsign(sj1);
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-dummyeval[0]=sj1;
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal evalcond[11];
-IkReal x176=((((new_r02)*(sj2)))+(((cj2)*(new_r12))));
-IkReal x177=((((cj2)*(new_r02)))+(((IkReal(-1.00000000000000))*(new_r12)*(sj2))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(3.14159265358979))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=((IkReal(-1.00000000000000))+(new_r22));
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x176;
-evalcond[5]=x176;
-evalcond[6]=x177;
-evalcond[7]=x177;
-evalcond[8]=((IkReal(-1.00000000000000))*(new_r20));
-evalcond[9]=((IkReal(-1.00000000000000))*(new_r21));
-evalcond[10]=((IkReal(1.00000000000000))+(((IkReal(-1.00000000000000))*(new_r22))));
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x178=IKsin(j0);
-IkReal x179=((IkReal(1.00000000000000))*(sj2));
-IkReal x180=((IkReal(1.00000000000000))*(IKcos(j0)));
-evalcond[0]=((((new_r00)*(sj2)))+(x178)+(((cj2)*(new_r10))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x180)))+(((new_r01)*(sj2)))+(((cj2)*(new_r11))));
-evalcond[2]=((((IkReal(-1.00000000000000))*(new_r10)*(x179)))+(((IkReal(-1.00000000000000))*(x180)))+(((cj2)*(new_r00))));
-evalcond[3]=((((IkReal(-1.00000000000000))*(x178)))+(((IkReal(-1.00000000000000))*(new_r11)*(x179)))+(((cj2)*(new_r01))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-IkReal x181=((IkReal(1.00000000000000))+(new_r22));
-IkReal x182=((new_r12)*(sj2));
-IkReal x183=((cj2)*(new_r02));
-IkReal x184=((((new_r02)*(sj2)))+(((cj2)*(new_r12))));
-evalcond[0]=((IkReal(-3.14159265358979))+(IKfmod(((IkReal(1.11022302462516e-16))+(j1)), IkReal(6.28318530717959))));
-evalcond[1]=x181;
-evalcond[2]=new_r20;
-evalcond[3]=new_r21;
-evalcond[4]=x184;
-evalcond[5]=x184;
-evalcond[6]=((((IkReal(-1.00000000000000))*(x182)))+(x183));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x183)))+(x182));
-evalcond[8]=new_r20;
-evalcond[9]=new_r21;
-evalcond[10]=x181;
-if( IKabs(evalcond[0]) < 0.0000010000000000  && IKabs(evalcond[1]) < 0.0000010000000000  && IKabs(evalcond[2]) < 0.0000010000000000  && IKabs(evalcond[3]) < 0.0000010000000000  && IKabs(evalcond[4]) < 0.0000010000000000  && IKabs(evalcond[5]) < 0.0000010000000000  && IKabs(evalcond[6]) < 0.0000010000000000  && IKabs(evalcond[7]) < 0.0000010000000000  && IKabs(evalcond[8]) < 0.0000010000000000  && IKabs(evalcond[9]) < 0.0000010000000000  && IKabs(evalcond[10]) < 0.0000010000000000  )
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[4];
-IkReal x185=IKcos(j0);
-IkReal x186=IKsin(j0);
-IkReal x187=((IkReal(1.00000000000000))*(sj2));
-evalcond[0]=((((new_r00)*(sj2)))+(x186)+(((cj2)*(new_r10))));
-evalcond[1]=((((new_r01)*(sj2)))+(((IkReal(-1.00000000000000))*(x185)))+(((cj2)*(new_r11))));
-evalcond[2]=((x185)+(((IkReal(-1.00000000000000))*(new_r10)*(x187)))+(((cj2)*(new_r00))));
-evalcond[3]=((x186)+(((IkReal(-1.00000000000000))*(new_r11)*(x187)))+(((cj2)*(new_r01))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-} else
-{
-if( 1 )
-{
-continue;
-
-} else
-{
-}
-}
-}
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))))+IKsqr(((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((((IkReal(-1.00000000000000))*(cj2)*(new_r10)))+(((IkReal(-1.00000000000000))*(new_r00)*(sj2)))), ((new_r20)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x188=IKsin(j0);
-IkReal x189=IKcos(j0);
-IkReal x190=((cj2)*(new_r01));
-IkReal x191=((IkReal(1.00000000000000))*(cj1));
-IkReal x192=((IkReal(1.00000000000000))*(sj1));
-IkReal x193=((new_r10)*(sj2));
-IkReal x194=((new_r11)*(sj2));
-IkReal x195=((cj2)*(new_r00));
-IkReal x196=((IkReal(1.00000000000000))*(x189));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x189)*(x192)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x188)*(x192)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x188)+(((cj2)*(new_r10))));
-evalcond[3]=((((new_r01)*(sj2)))+(((IkReal(-1.00000000000000))*(x196)))+(((cj2)*(new_r11))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x189)*(x191)))+(((IkReal(-1.00000000000000))*(x193)))+(x195));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x188)*(x191)))+(((IkReal(-1.00000000000000))*(x194)))+(x190));
-evalcond[6]=((((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(x191)*(x193)))+(((IkReal(-1.00000000000000))*(x196)))+(((cj1)*(x195))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x191)*(x194)))+(((IkReal(-1.00000000000000))*(x188)))+(((cj1)*(x190)))+(((new_r21)*(sj1))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30)))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((((new_r01)*(sj2)))+(((cj2)*(new_r11))))) < IKFAST_ATAN2_MAGTHRESH && IKabs(IKsqr(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))))+IKsqr(((((new_r01)*(sj2)))+(((cj2)*(new_r11)))))-1) <= IKFAST_SINCOS_THRESH )
-    continue;
-j0array[0]=IKatan2(((new_r21)*(((IKabs(sj1) != 0)?((IkReal)1/(sj1)):(IkReal)1.0e30))), ((((new_r01)*(sj2)))+(((cj2)*(new_r11)))));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x197=IKsin(j0);
-IkReal x198=IKcos(j0);
-IkReal x199=((cj2)*(new_r01));
-IkReal x200=((IkReal(1.00000000000000))*(cj1));
-IkReal x201=((IkReal(1.00000000000000))*(sj1));
-IkReal x202=((new_r10)*(sj2));
-IkReal x203=((new_r11)*(sj2));
-IkReal x204=((cj2)*(new_r00));
-IkReal x205=((IkReal(1.00000000000000))*(x198));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x198)*(x201)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x197)*(x201)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x197)+(((cj2)*(new_r10))));
-evalcond[3]=((((new_r01)*(sj2)))+(((IkReal(-1.00000000000000))*(x205)))+(((cj2)*(new_r11))));
-evalcond[4]=((x204)+(((IkReal(-1.00000000000000))*(x198)*(x200)))+(((IkReal(-1.00000000000000))*(x202))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x197)*(x200)))+(x199)+(((IkReal(-1.00000000000000))*(x203))));
-evalcond[6]=((((IkReal(-1.00000000000000))*(x200)*(x202)))+(((cj1)*(x204)))+(((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(x205))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(x200)*(x203)))+(((IkReal(-1.00000000000000))*(x197)))+(((cj1)*(x199)))+(((new_r21)*(sj1))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((gconst15)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst15)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j0array[0]=IKatan2(((gconst15)*(new_r21)), ((gconst15)*(new_r20)));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[8];
-IkReal x206=IKsin(j0);
-IkReal x207=IKcos(j0);
-IkReal x208=((cj2)*(new_r01));
-IkReal x209=((IkReal(1.00000000000000))*(cj1));
-IkReal x210=((IkReal(1.00000000000000))*(sj1));
-IkReal x211=((new_r10)*(sj2));
-IkReal x212=((new_r11)*(sj2));
-IkReal x213=((cj2)*(new_r00));
-IkReal x214=((IkReal(1.00000000000000))*(x207));
-evalcond[0]=((((IkReal(-1.00000000000000))*(x207)*(x210)))+(new_r20));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x206)*(x210)))+(new_r21));
-evalcond[2]=((((new_r00)*(sj2)))+(x206)+(((cj2)*(new_r10))));
-evalcond[3]=((((new_r01)*(sj2)))+(((cj2)*(new_r11)))+(((IkReal(-1.00000000000000))*(x214))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(x207)*(x209)))+(x213)+(((IkReal(-1.00000000000000))*(x211))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(x206)*(x209)))+(x208)+(((IkReal(-1.00000000000000))*(x212))));
-evalcond[6]=((((new_r20)*(sj1)))+(((cj1)*(x213)))+(((IkReal(-1.00000000000000))*(x214)))+(((IkReal(-1.00000000000000))*(x209)*(x211))));
-evalcond[7]=((((cj1)*(x208)))+(((new_r21)*(sj1)))+(((IkReal(-1.00000000000000))*(x206)))+(((IkReal(-1.00000000000000))*(x209)*(x212))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j0array[1], cj0array[1], sj0array[1];
-bool j0valid[1]={false};
-_nj0 = 1;
-if( IKabs(((gconst12)*(new_r21))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((gconst12)*(new_r20))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j0array[0]=IKatan2(((gconst12)*(new_r21)), ((gconst12)*(new_r20)));
-sj0array[0]=IKsin(j0array[0]);
-cj0array[0]=IKcos(j0array[0]);
-if( j0array[0] > IKPI )
-{
-    j0array[0]-=IK2PI;
-}
-else if( j0array[0] < -IKPI )
-{    j0array[0]+=IK2PI;
-}
-j0valid[0] = true;
-for(int ij0 = 0; ij0 < 1; ++ij0)
-{
-if( !j0valid[ij0] )
-{
-    continue;
-}
-_ij0[0] = ij0; _ij0[1] = -1;
-for(int iij0 = ij0+1; iij0 < 1; ++iij0)
-{
-if( j0valid[iij0] && IKabs(cj0array[ij0]-cj0array[iij0]) < IKFAST_SOLUTION_THRESH && IKabs(sj0array[ij0]-sj0array[iij0]) < IKFAST_SOLUTION_THRESH )
-{
-    j0valid[iij0]=false; _ij0[1] = iij0; break; 
-}
-}
-j0 = j0array[ij0]; cj0 = cj0array[ij0]; sj0 = sj0array[ij0];
-{
-IkReal evalcond[2];
-IkReal x215=((IkReal(1.00000000000000))*(sj1));
-evalcond[0]=((new_r20)+(((IkReal(-1.00000000000000))*(x215)*(IKcos(j0)))));
-evalcond[1]=((((IkReal(-1.00000000000000))*(x215)*(IKsin(j0))))+(new_r21));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-IkReal dummyeval[1];
-IkReal gconst17;
-gconst17=IKsign((((new_r12)*(new_r12))+((new_r02)*(new_r02))));
-dummyeval[0]=(((new_r12)*(new_r12))+((new_r02)*(new_r02)));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-{
-IkReal dummyeval[1];
-IkReal gconst16;
-gconst16=IKsign(((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10)))));
-dummyeval[0]=((((IkReal(-1.00000000000000))*(new_r00)*(new_r12)))+(((new_r02)*(new_r10))));
-if( IKabs(dummyeval[0]) < 0.0000010000000000  )
-{
-continue;
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x216=((gconst16)*(sj0));
-if( IKabs(((new_r12)*(x216))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x216))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x216)), ((IkReal(-1.00000000000000))*(new_r02)*(x216)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[12];
-IkReal x217=IKsin(j2);
-IkReal x218=IKcos(j2);
-IkReal x219=((IkReal(1.00000000000000))*(cj0));
-IkReal x220=((IkReal(1.00000000000000))*(cj1));
-IkReal x221=((IkReal(1.00000000000000))*(x217));
-IkReal x222=((new_r01)*(x218));
-IkReal x223=((new_r00)*(x218));
-IkReal x224=((new_r02)*(x218));
-evalcond[0]=((((new_r02)*(x217)))+(((new_r12)*(x218))));
-evalcond[1]=((sj0)+(((new_r00)*(x217)))+(((new_r10)*(x218))));
-evalcond[2]=((sj1)+(x224)+(((IkReal(-1.00000000000000))*(new_r12)*(x221))));
-evalcond[3]=((((new_r01)*(x217)))+(((IkReal(-1.00000000000000))*(x219)))+(((new_r11)*(x218))));
-evalcond[4]=((((IkReal(-1.00000000000000))*(cj1)*(x219)))+(((IkReal(-1.00000000000000))*(new_r10)*(x221)))+(x223));
-evalcond[5]=((((IkReal(-1.00000000000000))*(new_r11)*(x221)))+(((IkReal(-1.00000000000000))*(sj0)*(x220)))+(x222));
-evalcond[6]=((((IkReal(-1.00000000000000))*(new_r12)*(x217)*(x220)))+(((cj1)*(x224)))+(((new_r22)*(sj1))));
-evalcond[7]=((((IkReal(-1.00000000000000))*(new_r10)*(sj1)*(x221)))+(((sj1)*(x223)))+(((IkReal(-1.00000000000000))*(new_r20)*(x220))));
-evalcond[8]=((((sj1)*(x222)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj1)*(x221)))+(((IkReal(-1.00000000000000))*(new_r21)*(x220))));
-evalcond[9]=((IkReal(1.00000000000000))+(((sj1)*(x224)))+(((IkReal(-1.00000000000000))*(new_r22)*(x220)))+(((IkReal(-1.00000000000000))*(new_r12)*(sj1)*(x221))));
-evalcond[10]=((((new_r20)*(sj1)))+(((cj1)*(x223)))+(((IkReal(-1.00000000000000))*(new_r10)*(x217)*(x220)))+(((IkReal(-1.00000000000000))*(x219))));
-evalcond[11]=((((IkReal(-1.00000000000000))*(sj0)))+(((cj1)*(x222)))+(((IkReal(-1.00000000000000))*(new_r11)*(x217)*(x220)))+(((new_r21)*(sj1))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  || IKabs(evalcond[8]) > 0.000001  || IKabs(evalcond[9]) > 0.000001  || IKabs(evalcond[10]) > 0.000001  || IKabs(evalcond[11]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-
-} else
-{
-{
-IkReal j2array[1], cj2array[1], sj2array[1];
-bool j2valid[1]={false};
-_nj2 = 1;
-IkReal x225=((gconst17)*(sj1));
-if( IKabs(((new_r12)*(x225))) < IKFAST_ATAN2_MAGTHRESH && IKabs(((IkReal(-1.00000000000000))*(new_r02)*(x225))) < IKFAST_ATAN2_MAGTHRESH )
-    continue;
-j2array[0]=IKatan2(((new_r12)*(x225)), ((IkReal(-1.00000000000000))*(new_r02)*(x225)));
-sj2array[0]=IKsin(j2array[0]);
-cj2array[0]=IKcos(j2array[0]);
-if( j2array[0] > IKPI )
-{
-    j2array[0]-=IK2PI;
-}
-else if( j2array[0] < -IKPI )
-{    j2array[0]+=IK2PI;
-}
-j2valid[0] = true;
-for(int ij2 = 0; ij2 < 1; ++ij2)
-{
-if( !j2valid[ij2] )
-{
-    continue;
-}
-_ij2[0] = ij2; _ij2[1] = -1;
-for(int iij2 = ij2+1; iij2 < 1; ++iij2)
-{
-if( j2valid[iij2] && IKabs(cj2array[ij2]-cj2array[iij2]) < IKFAST_SOLUTION_THRESH && IKabs(sj2array[ij2]-sj2array[iij2]) < IKFAST_SOLUTION_THRESH )
-{
-    j2valid[iij2]=false; _ij2[1] = iij2; break; 
-}
-}
-j2 = j2array[ij2]; cj2 = cj2array[ij2]; sj2 = sj2array[ij2];
-{
-IkReal evalcond[12];
-IkReal x226=IKsin(j2);
-IkReal x227=IKcos(j2);
-IkReal x228=((IkReal(1.00000000000000))*(cj0));
-IkReal x229=((IkReal(1.00000000000000))*(cj1));
-IkReal x230=((IkReal(1.00000000000000))*(x226));
-IkReal x231=((new_r01)*(x227));
-IkReal x232=((new_r00)*(x227));
-IkReal x233=((new_r02)*(x227));
-evalcond[0]=((((new_r02)*(x226)))+(((new_r12)*(x227))));
-evalcond[1]=((((new_r00)*(x226)))+(sj0)+(((new_r10)*(x227))));
-evalcond[2]=((sj1)+(((IkReal(-1.00000000000000))*(new_r12)*(x230)))+(x233));
-evalcond[3]=((((new_r01)*(x226)))+(((new_r11)*(x227)))+(((IkReal(-1.00000000000000))*(x228))));
-evalcond[4]=((x232)+(((IkReal(-1.00000000000000))*(cj1)*(x228)))+(((IkReal(-1.00000000000000))*(new_r10)*(x230))));
-evalcond[5]=((((IkReal(-1.00000000000000))*(sj0)*(x229)))+(x231)+(((IkReal(-1.00000000000000))*(new_r11)*(x230))));
-evalcond[6]=((((IkReal(-1.00000000000000))*(new_r12)*(x226)*(x229)))+(((cj1)*(x233)))+(((new_r22)*(sj1))));
-evalcond[7]=((((sj1)*(x232)))+(((IkReal(-1.00000000000000))*(new_r20)*(x229)))+(((IkReal(-1.00000000000000))*(new_r10)*(sj1)*(x230))));
-evalcond[8]=((((sj1)*(x231)))+(((IkReal(-1.00000000000000))*(new_r11)*(sj1)*(x230)))+(((IkReal(-1.00000000000000))*(new_r21)*(x229))));
-evalcond[9]=((IkReal(1.00000000000000))+(((sj1)*(x233)))+(((IkReal(-1.00000000000000))*(new_r22)*(x229)))+(((IkReal(-1.00000000000000))*(new_r12)*(sj1)*(x230))));
-evalcond[10]=((((cj1)*(x232)))+(((new_r20)*(sj1)))+(((IkReal(-1.00000000000000))*(new_r10)*(x226)*(x229)))+(((IkReal(-1.00000000000000))*(x228))));
-evalcond[11]=((((cj1)*(x231)))+(((IkReal(-1.00000000000000))*(sj0)))+(((IkReal(-1.00000000000000))*(new_r11)*(x226)*(x229)))+(((new_r21)*(sj1))));
-if( IKabs(evalcond[0]) > 0.000001  || IKabs(evalcond[1]) > 0.000001  || IKabs(evalcond[2]) > 0.000001  || IKabs(evalcond[3]) > 0.000001  || IKabs(evalcond[4]) > 0.000001  || IKabs(evalcond[5]) > 0.000001  || IKabs(evalcond[6]) > 0.000001  || IKabs(evalcond[7]) > 0.000001  || IKabs(evalcond[8]) > 0.000001  || IKabs(evalcond[9]) > 0.000001  || IKabs(evalcond[10]) > 0.000001  || IKabs(evalcond[11]) > 0.000001  )
-{
-continue;
-}
-}
-
-{
-std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
-vinfos[0].jointtype = 1;
-vinfos[0].foffset = j0;
-vinfos[0].indices[0] = _ij0[0];
-vinfos[0].indices[1] = _ij0[1];
-vinfos[0].maxsolutions = _nj0;
-vinfos[1].jointtype = 1;
-vinfos[1].foffset = j1;
-vinfos[1].indices[0] = _ij1[0];
-vinfos[1].indices[1] = _ij1[1];
-vinfos[1].maxsolutions = _nj1;
-vinfos[2].jointtype = 1;
-vinfos[2].foffset = j2;
-vinfos[2].indices[0] = _ij2[0];
-vinfos[2].indices[1] = _ij2[1];
-vinfos[2].maxsolutions = _nj2;
-vinfos[3].jointtype = 1;
-vinfos[3].foffset = j3;
-vinfos[3].indices[0] = _ij3[0];
-vinfos[3].indices[1] = _ij3[1];
-vinfos[3].maxsolutions = _nj3;
-vinfos[4].jointtype = 1;
-vinfos[4].foffset = j4;
-vinfos[4].indices[0] = _ij4[0];
-vinfos[4].indices[1] = _ij4[1];
-vinfos[4].maxsolutions = _nj4;
-vinfos[5].jointtype = 1;
-vinfos[5].foffset = j5;
-vinfos[5].indices[0] = _ij5[0];
-vinfos[5].indices[1] = _ij5[1];
-vinfos[5].maxsolutions = _nj5;
-vinfos[6].jointtype = 1;
-vinfos[6].foffset = j6;
-vinfos[6].indices[0] = _ij6[0];
-vinfos[6].indices[1] = _ij6[1];
-vinfos[6].maxsolutions = _nj6;
-std::vector<int> vfree(0);
-solutions.AddSolution(vinfos,vfree);
-}
-}
-}
-
-}
-
-}
-}
-}
-
-}
-
-}
-}
-}
-}
-}};
-
+  IkReal j0, cj0, sj0, htj0, j1, cj1, sj1, htj1, j2, cj2, sj2, htj2, j3, cj3, sj3, htj3, j5, cj5, sj5, htj5, j6, cj6,
+      sj6, htj6, j4, cj4, sj4, htj4, new_r00, r00, rxp0_0, new_r01, r01, rxp0_1, new_r02, r02, rxp0_2, new_r10, r10,
+      rxp1_0, new_r11, r11, rxp1_1, new_r12, r12, rxp1_2, new_r20, r20, rxp2_0, new_r21, r21, rxp2_1, new_r22, r22,
+      rxp2_2, new_px, px, npx, new_py, py, npy, new_pz, pz, npz, pp;
+  unsigned char _ij0[2], _nj0, _ij1[2], _nj1, _ij2[2], _nj2, _ij3[2], _nj3, _ij5[2], _nj5, _ij6[2], _nj6, _ij4[2], _nj4;
+
+  bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions)
+  {
+    j0 = numeric_limits<IkReal>::quiet_NaN();
+    _ij0[0] = -1;
+    _ij0[1] = -1;
+    _nj0 = -1;
+    j1 = numeric_limits<IkReal>::quiet_NaN();
+    _ij1[0] = -1;
+    _ij1[1] = -1;
+    _nj1 = -1;
+    j2 = numeric_limits<IkReal>::quiet_NaN();
+    _ij2[0] = -1;
+    _ij2[1] = -1;
+    _nj2 = -1;
+    j3 = numeric_limits<IkReal>::quiet_NaN();
+    _ij3[0] = -1;
+    _ij3[1] = -1;
+    _nj3 = -1;
+    j5 = numeric_limits<IkReal>::quiet_NaN();
+    _ij5[0] = -1;
+    _ij5[1] = -1;
+    _nj5 = -1;
+    j6 = numeric_limits<IkReal>::quiet_NaN();
+    _ij6[0] = -1;
+    _ij6[1] = -1;
+    _nj6 = -1;
+    _ij4[0] = -1;
+    _ij4[1] = -1;
+    _nj4 = 0;
+    for (int dummyiter = 0; dummyiter < 1; ++dummyiter)
+    {
+      solutions.Clear();
+      j4 = pfree[0];
+      cj4 = cos(pfree[0]);
+      sj4 = sin(pfree[0]);
+      r00 = eerot[0 * 3 + 0];
+      r01 = eerot[0 * 3 + 1];
+      r02 = eerot[0 * 3 + 2];
+      r10 = eerot[1 * 3 + 0];
+      r11 = eerot[1 * 3 + 1];
+      r12 = eerot[1 * 3 + 2];
+      r20 = eerot[2 * 3 + 0];
+      r21 = eerot[2 * 3 + 1];
+      r22 = eerot[2 * 3 + 2];
+      px = eetrans[0];
+      py = eetrans[1];
+      pz = eetrans[2];
+
+      new_r00 = ((IkReal(-1.00000000000000)) * (r00));
+      new_r01 = r01;
+      new_r02 = ((IkReal(-1.00000000000000)) * (r02));
+      new_px = ((((IkReal(-0.180000000000000)) * (r02))) + (px));
+      new_r10 = ((IkReal(-1.00000000000000)) * (r10));
+      new_r11 = r11;
+      new_r12 = ((IkReal(-1.00000000000000)) * (r12));
+      new_py = ((((IkReal(-0.180000000000000)) * (r12))) + (py));
+      new_r20 = ((IkReal(-1.00000000000000)) * (r20));
+      new_r21 = r21;
+      new_r22 = ((IkReal(-1.00000000000000)) * (r22));
+      new_pz = ((IkReal(-0.410000000000000)) + (pz) + (((IkReal(-0.180000000000000)) * (r22))));
+      r00 = new_r00;
+      r01 = new_r01;
+      r02 = new_r02;
+      r10 = new_r10;
+      r11 = new_r11;
+      r12 = new_r12;
+      r20 = new_r20;
+      r21 = new_r21;
+      r22 = new_r22;
+      px = new_px;
+      py = new_py;
+      pz = new_pz;
+      pp = (((px) * (px)) + ((py) * (py)) + ((pz) * (pz)));
+      npx = ((((px) * (r00))) + (((py) * (r10))) + (((pz) * (r20))));
+      npy = ((((px) * (r01))) + (((py) * (r11))) + (((pz) * (r21))));
+      npz = ((((px) * (r02))) + (((py) * (r12))) + (((pz) * (r22))));
+      rxp0_0 = ((((IkReal(-1.00000000000000)) * (py) * (r20))) + (((pz) * (r10))));
+      rxp0_1 = ((((px) * (r20))) + (((IkReal(-1.00000000000000)) * (pz) * (r00))));
+      rxp0_2 = ((((IkReal(-1.00000000000000)) * (px) * (r10))) + (((py) * (r00))));
+      rxp1_0 = ((((IkReal(-1.00000000000000)) * (py) * (r21))) + (((pz) * (r11))));
+      rxp1_1 = ((((px) * (r21))) + (((IkReal(-1.00000000000000)) * (pz) * (r01))));
+      rxp1_2 = ((((IkReal(-1.00000000000000)) * (px) * (r11))) + (((py) * (r01))));
+      rxp2_0 = ((((IkReal(-1.00000000000000)) * (py) * (r22))) + (((pz) * (r12))));
+      rxp2_1 = ((((px) * (r22))) + (((IkReal(-1.00000000000000)) * (pz) * (r02))));
+      rxp2_2 = ((((IkReal(-1.00000000000000)) * (px) * (r12))) + (((py) * (r02))));
+      {
+        IkReal j3array[2], cj3array[2], sj3array[2];
+        bool j3valid[2] = { false };
+        _nj3 = 2;
+        cj3array[0] = ((IkReal(-1.01190476190476)) + (((IkReal(2.42954324586978)) * (pp))));
+        if (cj3array[0] >= -1 - IKFAST_SINCOS_THRESH && cj3array[0] <= 1 + IKFAST_SINCOS_THRESH)
+        {
+          j3valid[0] = j3valid[1] = true;
+          j3array[0] = IKacos(cj3array[0]);
+          sj3array[0] = IKsin(j3array[0]);
+          cj3array[1] = cj3array[0];
+          j3array[1] = -j3array[0];
+          sj3array[1] = -sj3array[0];
+        }
+        else if (isnan(cj3array[0]))
+        {
+          // probably any value will work
+          j3valid[0] = true;
+          cj3array[0] = 1;
+          sj3array[0] = 0;
+          j3array[0] = 0;
+        }
+        for (int ij3 = 0; ij3 < 2; ++ij3)
+        {
+          if (!j3valid[ij3])
+          {
+            continue;
+          }
+          _ij3[0] = ij3;
+          _ij3[1] = -1;
+          for (int iij3 = ij3 + 1; iij3 < 2; ++iij3)
+          {
+            if (j3valid[iij3] && IKabs(cj3array[ij3] - cj3array[iij3]) < IKFAST_SOLUTION_THRESH &&
+                IKabs(sj3array[ij3] - sj3array[iij3]) < IKFAST_SOLUTION_THRESH)
+            {
+              j3valid[iij3] = false;
+              _ij3[1] = iij3;
+              break;
+            }
+          }
+          j3 = j3array[ij3];
+          cj3 = cj3array[ij3];
+          sj3 = sj3array[ij3];
+
+          {
+            IkReal dummyeval[1];
+            dummyeval[0] = (((npx) * (npx)) + ((npy) * (npy)));
+            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+            {
+              {
+                IkReal dummyeval[1];
+                dummyeval[0] = (((npx) * (npx)) + ((npy) * (npy)));
+                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                {
+                  {
+                    IkReal dummyeval[1];
+                    dummyeval[0] = ((IkReal(1.00000000000000)) + (((IkReal(2.33333333333333)) * (cj3))) +
+                                    (((IkReal(1.36111111111111)) * ((cj4) * (cj4)) * ((sj3) * (sj3)))) +
+                                    (((IkReal(1.36111111111111)) * ((cj3) * (cj3)))));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      continue;
+                    }
+                    else
+                    {
+                      {
+                        IkReal j5array[2], cj5array[2], sj5array[2];
+                        bool j5valid[2] = { false };
+                        _nj5 = 2;
+                        IkReal x64 = ((IkReal(-0.420000000000000)) + (((IkReal(-0.490000000000000)) * (cj3))));
+                        if (IKabs(x64) < IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((IkReal(0.490000000000000)) * (cj4) * (sj3))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        IkReal x65 = ((IkReal(1.00000000000000)) *
+                                      (IKatan2(x64, ((IkReal(0.490000000000000)) * (cj4) * (sj3)))));
+                        if (((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) * ((sj3) * (sj3)))))) <
+                            (IkReal)-0.00001)
+                          continue;
+                        if ((((npz) *
+                              (((IKabs(IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                         ((sj3) * (sj3)))))))) != 0) ?
+                                    ((IkReal)1 /
+                                     (IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                        ((sj3) * (sj3))))))))) :
+                                    (IkReal)1.0e30)))) < -1 - IKFAST_SINCOS_THRESH ||
+                            (((npz) *
+                              (((IKabs(IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                         ((sj3) * (sj3)))))))) != 0) ?
+                                    ((IkReal)1 /
+                                     (IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                        ((sj3) * (sj3))))))))) :
+                                    (IkReal)1.0e30)))) > 1 + IKFAST_SINCOS_THRESH)
+                          continue;
+                        IkReal x66 = IKasin(
+                            ((npz) *
+                             (((IKabs(IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                        ((sj3) * (sj3)))))))) != 0) ?
+                                   ((IkReal)1 /
+                                    (IKabs(IKsqrt((((x64) * (x64)) + (((IkReal(0.240100000000000)) * ((cj4) * (cj4)) *
+                                                                       ((sj3) * (sj3))))))))) :
+                                   (IkReal)1.0e30))));
+                        j5array[0] = ((x66) + (((IkReal(-1.00000000000000)) * (x65))));
+                        sj5array[0] = IKsin(j5array[0]);
+                        cj5array[0] = IKcos(j5array[0]);
+                        j5array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x65))) +
+                                      (((IkReal(-1.00000000000000)) * (x66))));
+                        sj5array[1] = IKsin(j5array[1]);
+                        cj5array[1] = IKcos(j5array[1]);
+                        if (j5array[0] > IKPI)
+                        {
+                          j5array[0] -= IK2PI;
+                        }
+                        else if (j5array[0] < -IKPI)
+                        {
+                          j5array[0] += IK2PI;
+                        }
+                        j5valid[0] = true;
+                        if (j5array[1] > IKPI)
+                        {
+                          j5array[1] -= IK2PI;
+                        }
+                        else if (j5array[1] < -IKPI)
+                        {
+                          j5array[1] += IK2PI;
+                        }
+                        j5valid[1] = true;
+                        for (int ij5 = 0; ij5 < 2; ++ij5)
+                        {
+                          if (!j5valid[ij5])
+                          {
+                            continue;
+                          }
+                          _ij5[0] = ij5;
+                          _ij5[1] = -1;
+                          for (int iij5 = ij5 + 1; iij5 < 2; ++iij5)
+                          {
+                            if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j5valid[iij5] = false;
+                              _ij5[1] = iij5;
+                              break;
+                            }
+                          }
+                          j5 = j5array[ij5];
+                          cj5 = cj5array[ij5];
+                          sj5 = sj5array[ij5];
+
+                          {
+                            IkReal dummyeval[1];
+                            IkReal gconst0;
+                            IkReal x67 = ((IkReal(100.000000000000)) * (sj5));
+                            gconst0 = IKsign(((((x67) * ((npx) * (npx)))) + (((x67) * ((npy) * (npy))))));
+                            dummyeval[0] = ((((sj5) * ((npy) * (npy)))) + (((sj5) * ((npx) * (npx)))));
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal dummyeval[1];
+                                IkReal gconst1;
+                                IkReal x68 = ((IkReal(2100.00000000000)) * (sj5));
+                                gconst1 = IKsign(((((x68) * ((npx) * (npx)))) + (((x68) * ((npy) * (npy))))));
+                                dummyeval[0] = ((((sj5) * ((npy) * (npy)))) + (((sj5) * ((npx) * (npx)))));
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal evalcond[5];
+                                    IkReal x69 = ((IkReal(1.00000000000000)) * (pp));
+                                    IkReal x70 =
+                                        ((IkReal(-0.420000000000000)) + (((IkReal(-1.00000000000000)) * (npz))) +
+                                         (((IkReal(-0.490000000000000)) * (cj3))));
+                                    evalcond[0] =
+                                        ((IkReal(-3.14159265358979)) +
+                                         (IKfmod(((IkReal(3.14159265358979)) + (j5)), IkReal(6.28318530717959))));
+                                    evalcond[1] =
+                                        ((IkReal(0.416500000000000)) + (((IkReal(-1.00000000000000)) * (x69))) +
+                                         (((IkReal(0.411600000000000)) * (cj3))));
+                                    evalcond[2] = x70;
+                                    evalcond[3] =
+                                        ((IkReal(0.0637000000000000)) + (((IkReal(-0.840000000000000)) * (npz))) +
+                                         (((IkReal(-1.00000000000000)) * (x69))));
+                                    evalcond[4] = x70;
+                                    if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[4]) < 0.0000010000000000)
+                                    {
+                                      {
+                                        IkReal dummyeval[1];
+                                        IkReal gconst2;
+                                        gconst2 = IKsign(((((IkReal(-100.000000000000)) * ((npy) * (npy)))) +
+                                                          (((IkReal(-100.000000000000)) * ((npx) * (npx))))));
+                                        dummyeval[0] = ((((IkReal(-1.00000000000000)) * ((npy) * (npy)))) +
+                                                        (((IkReal(-1.00000000000000)) * ((npx) * (npx)))));
+                                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                        {
+                                          {
+                                            IkReal dummyeval[1];
+                                            IkReal gconst3;
+                                            IkReal x71 = ((IkReal(100.000000000000)) * (sj4));
+                                            gconst3 =
+                                                IKsign(((((IkReal(-1.00000000000000)) * (x71) * ((npx) * (npx)))) +
+                                                        (((IkReal(-1.00000000000000)) * (x71) * ((npy) * (npy))))));
+                                            IkReal x72 = ((IkReal(1.00000000000000)) * (sj4));
+                                            dummyeval[0] = ((((IkReal(-1.00000000000000)) * (x72) * ((npx) * (npx)))) +
+                                                            (((IkReal(-1.00000000000000)) * (x72) * ((npy) * (npy)))));
+                                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                            {
+                                              {
+                                                IkReal evalcond[5];
+                                                IkReal x73 = ((IkReal(1.00000000000000)) * (pp));
+                                                IkReal x74 = x70;
+                                                evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                               (IKfmod(((IkReal(3.14159265358979)) + (j4)),
+                                                                       IkReal(6.28318530717959))));
+                                                evalcond[1] = ((IkReal(0.416500000000000)) +
+                                                               (((IkReal(-1.00000000000000)) * (x73))) +
+                                                               (((IkReal(0.411600000000000)) * (cj3))));
+                                                evalcond[2] = x74;
+                                                evalcond[3] = ((IkReal(0.0637000000000000)) +
+                                                               (((IkReal(-1.00000000000000)) * (x73))) +
+                                                               (((IkReal(-0.840000000000000)) * (npz))));
+                                                evalcond[4] = x74;
+                                                if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                                    IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                                    IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                                    IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                                    IKabs(evalcond[4]) < 0.0000010000000000)
+                                                {
+                                                  {
+                                                    IkReal dummyeval[1];
+                                                    IkReal gconst4;
+                                                    gconst4 =
+                                                        IKsign(((((IkReal(-100.000000000000)) * ((npy) * (npy)))) +
+                                                                (((IkReal(-100.000000000000)) * ((npx) * (npx))))));
+                                                    dummyeval[0] = ((((IkReal(-1.00000000000000)) * ((npy) * (npy)))) +
+                                                                    (((IkReal(-1.00000000000000)) * ((npx) * (npx)))));
+                                                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                                    {
+                                                      continue;
+                                                    }
+                                                    else
+                                                    {
+                                                      {
+                                                        IkReal j6array[1], cj6array[1], sj6array[1];
+                                                        bool j6valid[1] = { false };
+                                                        _nj6 = 1;
+                                                        IkReal x75 = ((gconst4) * (sj3));
+                                                        if (IKabs(((IkReal(49.0000000000000)) * (npy) * (x75))) <
+                                                                IKFAST_ATAN2_MAGTHRESH &&
+                                                            IKabs(((IkReal(-49.0000000000000)) * (npx) * (x75))) <
+                                                                IKFAST_ATAN2_MAGTHRESH)
+                                                          continue;
+                                                        j6array[0] =
+                                                            IKatan2(((IkReal(49.0000000000000)) * (npy) * (x75)),
+                                                                    ((IkReal(-49.0000000000000)) * (npx) * (x75)));
+                                                        sj6array[0] = IKsin(j6array[0]);
+                                                        cj6array[0] = IKcos(j6array[0]);
+                                                        if (j6array[0] > IKPI)
+                                                        {
+                                                          j6array[0] -= IK2PI;
+                                                        }
+                                                        else if (j6array[0] < -IKPI)
+                                                        {
+                                                          j6array[0] += IK2PI;
+                                                        }
+                                                        j6valid[0] = true;
+                                                        for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                        {
+                                                          if (!j6valid[ij6])
+                                                          {
+                                                            continue;
+                                                          }
+                                                          _ij6[0] = ij6;
+                                                          _ij6[1] = -1;
+                                                          for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                          {
+                                                            if (j6valid[iij6] &&
+                                                                IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                                    IKFAST_SOLUTION_THRESH &&
+                                                                IKabs(sj6array[ij6] - sj6array[iij6]) <
+                                                                    IKFAST_SOLUTION_THRESH)
+                                                            {
+                                                              j6valid[iij6] = false;
+                                                              _ij6[1] = iij6;
+                                                              break;
+                                                            }
+                                                          }
+                                                          j6 = j6array[ij6];
+                                                          cj6 = cj6array[ij6];
+                                                          sj6 = sj6array[ij6];
+                                                          {
+                                                            IkReal evalcond[2];
+                                                            IkReal x76 = IKcos(j6);
+                                                            IkReal x77 = IKsin(j6);
+                                                            evalcond[0] = ((((npx) * (x77))) + (((npy) * (x76))));
+                                                            evalcond[1] =
+                                                                ((((IkReal(-1.00000000000000)) * (npy) * (x77))) +
+                                                                 (((npx) * (x76))) +
+                                                                 (((IkReal(-0.490000000000000)) * (sj3))));
+                                                            if (IKabs(evalcond[0]) > 0.000001 ||
+                                                                IKabs(evalcond[1]) > 0.000001)
+                                                            {
+                                                              continue;
+                                                            }
+                                                          }
+
+                                                          rotationfunction0(solutions);
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                                else
+                                                {
+                                                  IkReal x234 = ((IkReal(1.00000000000000)) * (pp));
+                                                  IkReal x235 = x70;
+                                                  evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                                 (IKfmod(((IkReal(1.11022302462516e-16)) + (j4)),
+                                                                         IkReal(6.28318530717959))));
+                                                  evalcond[1] = ((IkReal(0.416500000000000)) +
+                                                                 (((IkReal(-1.00000000000000)) * (x234))) +
+                                                                 (((IkReal(0.411600000000000)) * (cj3))));
+                                                  evalcond[2] = x235;
+                                                  evalcond[3] = ((IkReal(0.0637000000000000)) +
+                                                                 (((IkReal(-0.840000000000000)) * (npz))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x234))));
+                                                  evalcond[4] = x235;
+                                                  if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[4]) < 0.0000010000000000)
+                                                  {
+                                                    {
+                                                      IkReal dummyeval[1];
+                                                      IkReal gconst5;
+                                                      gconst5 =
+                                                          IKsign(((((IkReal(100.000000000000)) * ((npy) * (npy)))) +
+                                                                  (((IkReal(100.000000000000)) * ((npx) * (npx))))));
+                                                      dummyeval[0] = (((npx) * (npx)) + ((npy) * (npy)));
+                                                      if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                                      {
+                                                        continue;
+                                                      }
+                                                      else
+                                                      {
+                                                        {
+                                                          IkReal j6array[1], cj6array[1], sj6array[1];
+                                                          bool j6valid[1] = { false };
+                                                          _nj6 = 1;
+                                                          IkReal x236 = ((gconst5) * (sj3));
+                                                          if (IKabs(((IkReal(49.0000000000000)) * (npy) * (x236))) <
+                                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                                              IKabs(((IkReal(-49.0000000000000)) * (npx) * (x236))) <
+                                                                  IKFAST_ATAN2_MAGTHRESH)
+                                                            continue;
+                                                          j6array[0] =
+                                                              IKatan2(((IkReal(49.0000000000000)) * (npy) * (x236)),
+                                                                      ((IkReal(-49.0000000000000)) * (npx) * (x236)));
+                                                          sj6array[0] = IKsin(j6array[0]);
+                                                          cj6array[0] = IKcos(j6array[0]);
+                                                          if (j6array[0] > IKPI)
+                                                          {
+                                                            j6array[0] -= IK2PI;
+                                                          }
+                                                          else if (j6array[0] < -IKPI)
+                                                          {
+                                                            j6array[0] += IK2PI;
+                                                          }
+                                                          j6valid[0] = true;
+                                                          for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                          {
+                                                            if (!j6valid[ij6])
+                                                            {
+                                                              continue;
+                                                            }
+                                                            _ij6[0] = ij6;
+                                                            _ij6[1] = -1;
+                                                            for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                            {
+                                                              if (j6valid[iij6] &&
+                                                                  IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                                      IKFAST_SOLUTION_THRESH &&
+                                                                  IKabs(sj6array[ij6] - sj6array[iij6]) <
+                                                                      IKFAST_SOLUTION_THRESH)
+                                                              {
+                                                                j6valid[iij6] = false;
+                                                                _ij6[1] = iij6;
+                                                                break;
+                                                              }
+                                                            }
+                                                            j6 = j6array[ij6];
+                                                            cj6 = cj6array[ij6];
+                                                            sj6 = sj6array[ij6];
+                                                            {
+                                                              IkReal evalcond[2];
+                                                              IkReal x237 = IKcos(j6);
+                                                              IkReal x238 = IKsin(j6);
+                                                              evalcond[0] = ((((npx) * (x238))) + (((npy) * (x237))));
+                                                              evalcond[1] =
+                                                                  ((((IkReal(-1.00000000000000)) * (npy) * (x238))) +
+                                                                   (((npx) * (x237))) +
+                                                                   (((IkReal(0.490000000000000)) * (sj3))));
+                                                              if (IKabs(evalcond[0]) > 0.000001 ||
+                                                                  IKabs(evalcond[1]) > 0.000001)
+                                                              {
+                                                                continue;
+                                                              }
+                                                            }
+
+                                                            rotationfunction0(solutions);
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                  else
+                                                  {
+                                                    if (1)
+                                                    {
+                                                      continue;
+                                                    }
+                                                    else
+                                                    {
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                            else
+                                            {
+                                              {
+                                                IkReal j6array[1], cj6array[1], sj6array[1];
+                                                bool j6valid[1] = { false };
+                                                _nj6 = 1;
+                                                IkReal x239 = (sj4) * (sj4);
+                                                IkReal x240 = ((IkReal(49.0000000000000)) * (sj3) * (x239));
+                                                IkReal x241 = ((IkReal(49.0000000000000)) * (cj4) * (sj3) * (sj4));
+                                                if (IKabs(((gconst3) * (((((npy) * (x241))) + (((npx) * (x240))))))) <
+                                                        IKFAST_ATAN2_MAGTHRESH &&
+                                                    IKabs(((gconst3) *
+                                                           (((((IkReal(-1.00000000000000)) * (npx) * (x241))) +
+                                                             (((npy) * (x240))))))) < IKFAST_ATAN2_MAGTHRESH)
+                                                  continue;
+                                                j6array[0] = IKatan2(
+                                                    ((gconst3) * (((((npy) * (x241))) + (((npx) * (x240)))))),
+                                                    ((gconst3) * (((((IkReal(-1.00000000000000)) * (npx) * (x241))) +
+                                                                   (((npy) * (x240)))))));
+                                                sj6array[0] = IKsin(j6array[0]);
+                                                cj6array[0] = IKcos(j6array[0]);
+                                                if (j6array[0] > IKPI)
+                                                {
+                                                  j6array[0] -= IK2PI;
+                                                }
+                                                else if (j6array[0] < -IKPI)
+                                                {
+                                                  j6array[0] += IK2PI;
+                                                }
+                                                j6valid[0] = true;
+                                                for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                {
+                                                  if (!j6valid[ij6])
+                                                  {
+                                                    continue;
+                                                  }
+                                                  _ij6[0] = ij6;
+                                                  _ij6[1] = -1;
+                                                  for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                  {
+                                                    if (j6valid[iij6] &&
+                                                        IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                            IKFAST_SOLUTION_THRESH &&
+                                                        IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                                                    {
+                                                      j6valid[iij6] = false;
+                                                      _ij6[1] = iij6;
+                                                      break;
+                                                    }
+                                                  }
+                                                  j6 = j6array[ij6];
+                                                  cj6 = cj6array[ij6];
+                                                  sj6 = sj6array[ij6];
+                                                  {
+                                                    IkReal evalcond[4];
+                                                    IkReal x242 = IKcos(j6);
+                                                    IkReal x243 = IKsin(j6);
+                                                    IkReal x244 = ((cj4) * (npy));
+                                                    IkReal x245 = ((IkReal(0.490000000000000)) * (sj3));
+                                                    IkReal x246 = ((npy) * (sj4));
+                                                    IkReal x247 = ((IkReal(1.00000000000000)) * (x243));
+                                                    IkReal x248 = ((npx) * (x243));
+                                                    IkReal x249 = ((npx) * (x242));
+                                                    evalcond[0] = ((x248) + (((npy) * (x242))) + (((sj4) * (x245))));
+                                                    evalcond[1] =
+                                                        ((((IkReal(-1.00000000000000)) * (npy) * (x247))) +
+                                                         (((IkReal(-1.00000000000000)) * (cj4) * (x245))) + (x249));
+                                                    evalcond[2] =
+                                                        ((((cj4) * (x248))) + (((x242) * (x244))) + (((sj4) * (x249))) +
+                                                         (((IkReal(-1.00000000000000)) * (x246) * (x247))));
+                                                    evalcond[3] =
+                                                        ((((IkReal(-1.00000000000000)) * (npx) * (sj4) * (x247))) +
+                                                         (((cj4) * (x249))) + (((IkReal(-1.00000000000000)) * (x245))) +
+                                                         (((IkReal(-1.00000000000000)) * (x244) * (x247))) +
+                                                         (((IkReal(-1.00000000000000)) * (x242) * (x246))));
+                                                    if (IKabs(evalcond[0]) > 0.000001 ||
+                                                        IKabs(evalcond[1]) > 0.000001 ||
+                                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                    {
+                                                      continue;
+                                                    }
+                                                  }
+
+                                                  rotationfunction0(solutions);
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                        else
+                                        {
+                                          {
+                                            IkReal j6array[1], cj6array[1], sj6array[1];
+                                            bool j6valid[1] = { false };
+                                            _nj6 = 1;
+                                            IkReal x250 = ((IkReal(49.0000000000000)) * (cj4) * (sj3));
+                                            IkReal x251 = ((IkReal(49.0000000000000)) * (sj3) * (sj4));
+                                            if (IKabs(((gconst2) * (((((npy) * (x250))) + (((npx) * (x251))))))) <
+                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                IKabs(((gconst2) *
+                                                       (((((npy) * (x251))) + (((IkReal(-1.00000000000000)) * (npx) *
+                                                                                (x250))))))) < IKFAST_ATAN2_MAGTHRESH)
+                                              continue;
+                                            j6array[0] = IKatan2(
+                                                ((gconst2) * (((((npy) * (x250))) + (((npx) * (x251)))))),
+                                                ((gconst2) * (((((npy) * (x251))) +
+                                                               (((IkReal(-1.00000000000000)) * (npx) * (x250)))))));
+                                            sj6array[0] = IKsin(j6array[0]);
+                                            cj6array[0] = IKcos(j6array[0]);
+                                            if (j6array[0] > IKPI)
+                                            {
+                                              j6array[0] -= IK2PI;
+                                            }
+                                            else if (j6array[0] < -IKPI)
+                                            {
+                                              j6array[0] += IK2PI;
+                                            }
+                                            j6valid[0] = true;
+                                            for (int ij6 = 0; ij6 < 1; ++ij6)
+                                            {
+                                              if (!j6valid[ij6])
+                                              {
+                                                continue;
+                                              }
+                                              _ij6[0] = ij6;
+                                              _ij6[1] = -1;
+                                              for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                              {
+                                                if (j6valid[iij6] &&
+                                                    IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                                                    IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                                                {
+                                                  j6valid[iij6] = false;
+                                                  _ij6[1] = iij6;
+                                                  break;
+                                                }
+                                              }
+                                              j6 = j6array[ij6];
+                                              cj6 = cj6array[ij6];
+                                              sj6 = sj6array[ij6];
+                                              {
+                                                IkReal evalcond[4];
+                                                IkReal x252 = IKcos(j6);
+                                                IkReal x253 = IKsin(j6);
+                                                IkReal x254 = ((cj4) * (npy));
+                                                IkReal x255 = ((IkReal(0.490000000000000)) * (sj3));
+                                                IkReal x256 = ((npy) * (sj4));
+                                                IkReal x257 = ((IkReal(1.00000000000000)) * (x253));
+                                                IkReal x258 = ((npx) * (x253));
+                                                IkReal x259 = ((npx) * (x252));
+                                                evalcond[0] = ((((sj4) * (x255))) + (((npy) * (x252))) + (x258));
+                                                evalcond[1] =
+                                                    ((((IkReal(-1.00000000000000)) * (npy) * (x257))) +
+                                                     (((IkReal(-1.00000000000000)) * (cj4) * (x255))) + (x259));
+                                                evalcond[2] = ((((sj4) * (x259))) +
+                                                               (((IkReal(-1.00000000000000)) * (x256) * (x257))) +
+                                                               (((x252) * (x254))) + (((cj4) * (x258))));
+                                                evalcond[3] =
+                                                    ((((IkReal(-1.00000000000000)) * (x252) * (x256))) +
+                                                     (((IkReal(-1.00000000000000)) * (npx) * (sj4) * (x257))) +
+                                                     (((IkReal(-1.00000000000000)) * (x254) * (x257))) +
+                                                     (((cj4) * (x259))) + (((IkReal(-1.00000000000000)) * (x255))));
+                                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                {
+                                                  continue;
+                                                }
+                                              }
+
+                                              rotationfunction0(solutions);
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                    else
+                                    {
+                                      IkReal x260 = ((IkReal(1.00000000000000)) * (pp));
+                                      IkReal x261 = ((IkReal(0.490000000000000)) * (cj3));
+                                      evalcond[0] =
+                                          ((IkReal(-3.14159265358979)) +
+                                           (IKfmod(((IkReal(1.11022302462516e-16)) + (j5)), IkReal(6.28318530717959))));
+                                      evalcond[1] =
+                                          ((IkReal(0.416500000000000)) + (((IkReal(-1.00000000000000)) * (x260))) +
+                                           (((IkReal(0.411600000000000)) * (cj3))));
+                                      evalcond[2] = ((IkReal(0.420000000000000)) +
+                                                     (((IkReal(-1.00000000000000)) * (npz))) + (x261));
+                                      evalcond[3] =
+                                          ((IkReal(0.0637000000000000)) + (((IkReal(0.840000000000000)) * (npz))) +
+                                           (((IkReal(-1.00000000000000)) * (x260))));
+                                      evalcond[4] = ((IkReal(-0.420000000000000)) + (npz) +
+                                                     (((IkReal(-1.00000000000000)) * (x261))));
+                                      if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[4]) < 0.0000010000000000)
+                                      {
+                                        {
+                                          IkReal dummyeval[1];
+                                          IkReal gconst6;
+                                          gconst6 = IKsign(((((IkReal(100.000000000000)) * ((npy) * (npy)))) +
+                                                            (((IkReal(100.000000000000)) * ((npx) * (npx))))));
+                                          dummyeval[0] = (((npx) * (npx)) + ((npy) * (npy)));
+                                          if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                          {
+                                            {
+                                              IkReal dummyeval[1];
+                                              IkReal gconst7;
+                                              IkReal x262 = ((IkReal(100.000000000000)) * (sj4));
+                                              gconst7 =
+                                                  IKsign(((((x262) * ((npy) * (npy)))) + (((x262) * ((npx) * (npx))))));
+                                              dummyeval[0] =
+                                                  ((((sj4) * ((npx) * (npx)))) + (((sj4) * ((npy) * (npy)))));
+                                              if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                              {
+                                                {
+                                                  IkReal evalcond[5];
+                                                  IkReal x263 = ((IkReal(1.00000000000000)) * (pp));
+                                                  IkReal x264 = ((IkReal(0.490000000000000)) * (cj3));
+                                                  evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                                 (IKfmod(((IkReal(3.14159265358979)) + (j4)),
+                                                                         IkReal(6.28318530717959))));
+                                                  evalcond[1] = ((IkReal(0.416500000000000)) +
+                                                                 (((IkReal(-1.00000000000000)) * (x263))) +
+                                                                 (((IkReal(0.411600000000000)) * (cj3))));
+                                                  evalcond[2] = ((IkReal(0.420000000000000)) +
+                                                                 (((IkReal(-1.00000000000000)) * (npz))) + (x264));
+                                                  evalcond[3] = ((IkReal(0.0637000000000000)) +
+                                                                 (((IkReal(0.840000000000000)) * (npz))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x263))));
+                                                  evalcond[4] = ((IkReal(-0.420000000000000)) + (npz) +
+                                                                 (((IkReal(-1.00000000000000)) * (x264))));
+                                                  if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                                      IKabs(evalcond[4]) < 0.0000010000000000)
+                                                  {
+                                                    {
+                                                      IkReal dummyeval[1];
+                                                      IkReal gconst8;
+                                                      gconst8 =
+                                                          IKsign(((((IkReal(100.000000000000)) * ((npy) * (npy)))) +
+                                                                  (((IkReal(100.000000000000)) * ((npx) * (npx))))));
+                                                      dummyeval[0] = (((npx) * (npx)) + ((npy) * (npy)));
+                                                      if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                                      {
+                                                        continue;
+                                                      }
+                                                      else
+                                                      {
+                                                        {
+                                                          IkReal j6array[1], cj6array[1], sj6array[1];
+                                                          bool j6valid[1] = { false };
+                                                          _nj6 = 1;
+                                                          IkReal x265 = ((gconst8) * (sj3));
+                                                          if (IKabs(((IkReal(49.0000000000000)) * (npy) * (x265))) <
+                                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                                              IKabs(((IkReal(-49.0000000000000)) * (npx) * (x265))) <
+                                                                  IKFAST_ATAN2_MAGTHRESH)
+                                                            continue;
+                                                          j6array[0] =
+                                                              IKatan2(((IkReal(49.0000000000000)) * (npy) * (x265)),
+                                                                      ((IkReal(-49.0000000000000)) * (npx) * (x265)));
+                                                          sj6array[0] = IKsin(j6array[0]);
+                                                          cj6array[0] = IKcos(j6array[0]);
+                                                          if (j6array[0] > IKPI)
+                                                          {
+                                                            j6array[0] -= IK2PI;
+                                                          }
+                                                          else if (j6array[0] < -IKPI)
+                                                          {
+                                                            j6array[0] += IK2PI;
+                                                          }
+                                                          j6valid[0] = true;
+                                                          for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                          {
+                                                            if (!j6valid[ij6])
+                                                            {
+                                                              continue;
+                                                            }
+                                                            _ij6[0] = ij6;
+                                                            _ij6[1] = -1;
+                                                            for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                            {
+                                                              if (j6valid[iij6] &&
+                                                                  IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                                      IKFAST_SOLUTION_THRESH &&
+                                                                  IKabs(sj6array[ij6] - sj6array[iij6]) <
+                                                                      IKFAST_SOLUTION_THRESH)
+                                                              {
+                                                                j6valid[iij6] = false;
+                                                                _ij6[1] = iij6;
+                                                                break;
+                                                              }
+                                                            }
+                                                            j6 = j6array[ij6];
+                                                            cj6 = cj6array[ij6];
+                                                            sj6 = sj6array[ij6];
+                                                            {
+                                                              IkReal evalcond[2];
+                                                              IkReal x266 = IKcos(j6);
+                                                              IkReal x267 = IKsin(j6);
+                                                              evalcond[0] = ((((npx) * (x267))) + (((npy) * (x266))));
+                                                              evalcond[1] =
+                                                                  ((((npx) * (x266))) +
+                                                                   (((IkReal(-1.00000000000000)) * (npy) * (x267))) +
+                                                                   (((IkReal(0.490000000000000)) * (sj3))));
+                                                              if (IKabs(evalcond[0]) > 0.000001 ||
+                                                                  IKabs(evalcond[1]) > 0.000001)
+                                                              {
+                                                                continue;
+                                                              }
+                                                            }
+
+                                                            rotationfunction0(solutions);
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                  else
+                                                  {
+                                                    IkReal x268 = ((IkReal(1.00000000000000)) * (pp));
+                                                    IkReal x269 = ((IkReal(0.490000000000000)) * (cj3));
+                                                    evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                                   (IKfmod(((IkReal(1.11022302462516e-16)) + (j4)),
+                                                                           IkReal(6.28318530717959))));
+                                                    evalcond[1] = ((IkReal(0.416500000000000)) +
+                                                                   (((IkReal(-1.00000000000000)) * (x268))) +
+                                                                   (((IkReal(0.411600000000000)) * (cj3))));
+                                                    evalcond[2] = ((IkReal(0.420000000000000)) +
+                                                                   (((IkReal(-1.00000000000000)) * (npz))) + (x269));
+                                                    evalcond[3] = ((IkReal(0.0637000000000000)) +
+                                                                   (((IkReal(0.840000000000000)) * (npz))) +
+                                                                   (((IkReal(-1.00000000000000)) * (x268))));
+                                                    evalcond[4] = ((IkReal(-0.420000000000000)) + (npz) +
+                                                                   (((IkReal(-1.00000000000000)) * (x269))));
+                                                    if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                                        IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                                        IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                                        IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                                        IKabs(evalcond[4]) < 0.0000010000000000)
+                                                    {
+                                                      {
+                                                        IkReal dummyeval[1];
+                                                        IkReal gconst9;
+                                                        gconst9 =
+                                                            IKsign(((((IkReal(-100.000000000000)) * ((npy) * (npy)))) +
+                                                                    (((IkReal(-100.000000000000)) * ((npx) * (npx))))));
+                                                        dummyeval[0] =
+                                                            ((((IkReal(-1.00000000000000)) * ((npy) * (npy)))) +
+                                                             (((IkReal(-1.00000000000000)) * ((npx) * (npx)))));
+                                                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                                        {
+                                                          continue;
+                                                        }
+                                                        else
+                                                        {
+                                                          {
+                                                            IkReal j6array[1], cj6array[1], sj6array[1];
+                                                            bool j6valid[1] = { false };
+                                                            _nj6 = 1;
+                                                            IkReal x270 = ((gconst9) * (sj3));
+                                                            if (IKabs(((IkReal(49.0000000000000)) * (npy) * (x270))) <
+                                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                                IKabs(((IkReal(-49.0000000000000)) * (npx) * (x270))) <
+                                                                    IKFAST_ATAN2_MAGTHRESH)
+                                                              continue;
+                                                            j6array[0] =
+                                                                IKatan2(((IkReal(49.0000000000000)) * (npy) * (x270)),
+                                                                        ((IkReal(-49.0000000000000)) * (npx) * (x270)));
+                                                            sj6array[0] = IKsin(j6array[0]);
+                                                            cj6array[0] = IKcos(j6array[0]);
+                                                            if (j6array[0] > IKPI)
+                                                            {
+                                                              j6array[0] -= IK2PI;
+                                                            }
+                                                            else if (j6array[0] < -IKPI)
+                                                            {
+                                                              j6array[0] += IK2PI;
+                                                            }
+                                                            j6valid[0] = true;
+                                                            for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                            {
+                                                              if (!j6valid[ij6])
+                                                              {
+                                                                continue;
+                                                              }
+                                                              _ij6[0] = ij6;
+                                                              _ij6[1] = -1;
+                                                              for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                              {
+                                                                if (j6valid[iij6] &&
+                                                                    IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                                        IKFAST_SOLUTION_THRESH &&
+                                                                    IKabs(sj6array[ij6] - sj6array[iij6]) <
+                                                                        IKFAST_SOLUTION_THRESH)
+                                                                {
+                                                                  j6valid[iij6] = false;
+                                                                  _ij6[1] = iij6;
+                                                                  break;
+                                                                }
+                                                              }
+                                                              j6 = j6array[ij6];
+                                                              cj6 = cj6array[ij6];
+                                                              sj6 = sj6array[ij6];
+                                                              {
+                                                                IkReal evalcond[2];
+                                                                IkReal x271 = IKcos(j6);
+                                                                IkReal x272 = IKsin(j6);
+                                                                evalcond[0] = ((((npy) * (x271))) + (((npx) * (x272))));
+                                                                evalcond[1] =
+                                                                    ((((IkReal(-0.490000000000000)) * (sj3))) +
+                                                                     (((IkReal(-1.00000000000000)) * (npy) * (x272))) +
+                                                                     (((npx) * (x271))));
+                                                                if (IKabs(evalcond[0]) > 0.000001 ||
+                                                                    IKabs(evalcond[1]) > 0.000001)
+                                                                {
+                                                                  continue;
+                                                                }
+                                                              }
+
+                                                              rotationfunction0(solutions);
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                    else
+                                                    {
+                                                      if (1)
+                                                      {
+                                                        continue;
+                                                      }
+                                                      else
+                                                      {
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                              else
+                                              {
+                                                {
+                                                  IkReal j6array[1], cj6array[1], sj6array[1];
+                                                  bool j6valid[1] = { false };
+                                                  _nj6 = 1;
+                                                  IkReal x273 = (sj4) * (sj4);
+                                                  IkReal x274 = ((cj4) * (sj4));
+                                                  IkReal x275 = ((IkReal(49.0000000000000)) * (npx) * (sj3));
+                                                  IkReal x276 = ((IkReal(49.0000000000000)) * (npy) * (sj3));
+                                                  if (IKabs(((gconst7) *
+                                                             (((((IkReal(-1.00000000000000)) * (x273) * (x275))) +
+                                                               (((x274) * (x276))))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                                      IKabs(((gconst7) *
+                                                             (((((IkReal(-1.00000000000000)) * (x273) * (x276))) +
+                                                               (((IkReal(-1.00000000000000)) * (x274) * (x275))))))) <
+                                                          IKFAST_ATAN2_MAGTHRESH)
+                                                    continue;
+                                                  j6array[0] = IKatan2(
+                                                      ((gconst7) * (((((IkReal(-1.00000000000000)) * (x273) * (x275))) +
+                                                                     (((x274) * (x276)))))),
+                                                      ((gconst7) *
+                                                       (((((IkReal(-1.00000000000000)) * (x273) * (x276))) +
+                                                         (((IkReal(-1.00000000000000)) * (x274) * (x275)))))));
+                                                  sj6array[0] = IKsin(j6array[0]);
+                                                  cj6array[0] = IKcos(j6array[0]);
+                                                  if (j6array[0] > IKPI)
+                                                  {
+                                                    j6array[0] -= IK2PI;
+                                                  }
+                                                  else if (j6array[0] < -IKPI)
+                                                  {
+                                                    j6array[0] += IK2PI;
+                                                  }
+                                                  j6valid[0] = true;
+                                                  for (int ij6 = 0; ij6 < 1; ++ij6)
+                                                  {
+                                                    if (!j6valid[ij6])
+                                                    {
+                                                      continue;
+                                                    }
+                                                    _ij6[0] = ij6;
+                                                    _ij6[1] = -1;
+                                                    for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                    {
+                                                      if (j6valid[iij6] &&
+                                                          IKabs(cj6array[ij6] - cj6array[iij6]) <
+                                                              IKFAST_SOLUTION_THRESH &&
+                                                          IKabs(sj6array[ij6] - sj6array[iij6]) <
+                                                              IKFAST_SOLUTION_THRESH)
+                                                      {
+                                                        j6valid[iij6] = false;
+                                                        _ij6[1] = iij6;
+                                                        break;
+                                                      }
+                                                    }
+                                                    j6 = j6array[ij6];
+                                                    cj6 = cj6array[ij6];
+                                                    sj6 = sj6array[ij6];
+                                                    {
+                                                      IkReal evalcond[4];
+                                                      IkReal x277 = IKcos(j6);
+                                                      IkReal x278 = IKsin(j6);
+                                                      IkReal x279 = ((IkReal(1.00000000000000)) * (sj4));
+                                                      IkReal x280 = ((IkReal(0.490000000000000)) * (sj3));
+                                                      IkReal x281 = ((npy) * (x277));
+                                                      IkReal x282 = ((npx) * (x277));
+                                                      IkReal x283 = ((npx) * (x278));
+                                                      IkReal x284 = ((npy) * (x278));
+                                                      evalcond[0] = ((x283) + (x281) + (((sj4) * (x280))));
+                                                      evalcond[1] = ((x282) + (((IkReal(-1.00000000000000)) * (x284))) +
+                                                                     (((cj4) * (x280))));
+                                                      evalcond[2] = ((((IkReal(-1.00000000000000)) * (x279) * (x282))) +
+                                                                     (((cj4) * (x283))) + (((cj4) * (x281))) +
+                                                                     (((sj4) * (x284))));
+                                                      evalcond[3] = ((((IkReal(-1.00000000000000)) * (cj4) * (x282))) +
+                                                                     (((IkReal(-1.00000000000000)) * (x280))) +
+                                                                     (((IkReal(-1.00000000000000)) * (x279) * (x281))) +
+                                                                     (((IkReal(-1.00000000000000)) * (x279) * (x283))) +
+                                                                     (((cj4) * (x284))));
+                                                      if (IKabs(evalcond[0]) > 0.000001 ||
+                                                          IKabs(evalcond[1]) > 0.000001 ||
+                                                          IKabs(evalcond[2]) > 0.000001 ||
+                                                          IKabs(evalcond[3]) > 0.000001)
+                                                      {
+                                                        continue;
+                                                      }
+                                                    }
+
+                                                    rotationfunction0(solutions);
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                          else
+                                          {
+                                            {
+                                              IkReal j6array[1], cj6array[1], sj6array[1];
+                                              bool j6valid[1] = { false };
+                                              _nj6 = 1;
+                                              IkReal x285 = ((IkReal(49.0000000000000)) * (cj4) * (sj3));
+                                              IkReal x286 = ((IkReal(49.0000000000000)) * (sj3) * (sj4));
+                                              if (IKabs(
+                                                      ((gconst6) * (((((IkReal(-1.00000000000000)) * (npx) * (x286))) +
+                                                                     (((npy) * (x285))))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                                  IKabs(((gconst6) *
+                                                         (((((IkReal(-1.00000000000000)) * (npy) * (x286))) +
+                                                           (((IkReal(-1.00000000000000)) * (npx) * (x285))))))) <
+                                                      IKFAST_ATAN2_MAGTHRESH)
+                                                continue;
+                                              j6array[0] = IKatan2(
+                                                  ((gconst6) * (((((IkReal(-1.00000000000000)) * (npx) * (x286))) +
+                                                                 (((npy) * (x285)))))),
+                                                  ((gconst6) * (((((IkReal(-1.00000000000000)) * (npy) * (x286))) +
+                                                                 (((IkReal(-1.00000000000000)) * (npx) * (x285)))))));
+                                              sj6array[0] = IKsin(j6array[0]);
+                                              cj6array[0] = IKcos(j6array[0]);
+                                              if (j6array[0] > IKPI)
+                                              {
+                                                j6array[0] -= IK2PI;
+                                              }
+                                              else if (j6array[0] < -IKPI)
+                                              {
+                                                j6array[0] += IK2PI;
+                                              }
+                                              j6valid[0] = true;
+                                              for (int ij6 = 0; ij6 < 1; ++ij6)
+                                              {
+                                                if (!j6valid[ij6])
+                                                {
+                                                  continue;
+                                                }
+                                                _ij6[0] = ij6;
+                                                _ij6[1] = -1;
+                                                for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                                {
+                                                  if (j6valid[iij6] &&
+                                                      IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                                                      IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                                                  {
+                                                    j6valid[iij6] = false;
+                                                    _ij6[1] = iij6;
+                                                    break;
+                                                  }
+                                                }
+                                                j6 = j6array[ij6];
+                                                cj6 = cj6array[ij6];
+                                                sj6 = sj6array[ij6];
+                                                {
+                                                  IkReal evalcond[4];
+                                                  IkReal x287 = IKcos(j6);
+                                                  IkReal x288 = IKsin(j6);
+                                                  IkReal x289 = ((IkReal(1.00000000000000)) * (sj4));
+                                                  IkReal x290 = ((IkReal(0.490000000000000)) * (sj3));
+                                                  IkReal x291 = ((npy) * (x287));
+                                                  IkReal x292 = ((npx) * (x287));
+                                                  IkReal x293 = ((npx) * (x288));
+                                                  IkReal x294 = ((npy) * (x288));
+                                                  evalcond[0] = ((((sj4) * (x290))) + (x291) + (x293));
+                                                  evalcond[1] = ((((IkReal(-1.00000000000000)) * (x294))) +
+                                                                 (((cj4) * (x290))) + (x292));
+                                                  evalcond[2] =
+                                                      ((((IkReal(-1.00000000000000)) * (x289) * (x292))) +
+                                                       (((cj4) * (x291))) + (((cj4) * (x293))) + (((sj4) * (x294))));
+                                                  evalcond[3] =
+                                                      ((((IkReal(-1.00000000000000)) * (cj4) * (x292))) +
+                                                       (((IkReal(-1.00000000000000)) * (x289) * (x293))) +
+                                                       (((IkReal(-1.00000000000000)) * (x289) * (x291))) +
+                                                       (((IkReal(-1.00000000000000)) * (x290))) + (((cj4) * (x294))));
+                                                  if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                      IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                  {
+                                                    continue;
+                                                  }
+                                                }
+
+                                                rotationfunction0(solutions);
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                      else
+                                      {
+                                        if (1)
+                                        {
+                                          continue;
+                                        }
+                                        else
+                                        {
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j6array[1], cj6array[1], sj6array[1];
+                                    bool j6valid[1] = { false };
+                                    _nj6 = 1;
+                                    IkReal x295 = ((IkReal(2500.00000000000)) * (pp));
+                                    IkReal x296 = ((IkReal(2100.00000000000)) * (cj5) * (npz));
+                                    IkReal x297 = ((IkReal(1029.00000000000)) * (sj3) * (sj4) * (sj5));
+                                    if (IKabs(((gconst1) * (((((IkReal(-1.00000000000000)) * (npy) * (x295))) +
+                                                             (((IkReal(-1.00000000000000)) * (npy) * (x296))) +
+                                                             (((IkReal(-1.00000000000000)) * (npx) * (x297))) +
+                                                             (((IkReal(159.250000000000)) * (npy))))))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((gconst1) *
+                                               (((((IkReal(-1.00000000000000)) * (npy) * (x297))) + (((npx) * (x295))) +
+                                                 (((npx) * (x296))) + (((IkReal(-159.250000000000)) * (npx))))))) <
+                                            IKFAST_ATAN2_MAGTHRESH)
+                                      continue;
+                                    j6array[0] =
+                                        IKatan2(((gconst1) * (((((IkReal(-1.00000000000000)) * (npy) * (x295))) +
+                                                               (((IkReal(-1.00000000000000)) * (npy) * (x296))) +
+                                                               (((IkReal(-1.00000000000000)) * (npx) * (x297))) +
+                                                               (((IkReal(159.250000000000)) * (npy)))))),
+                                                ((gconst1) * (((((IkReal(-1.00000000000000)) * (npy) * (x297))) +
+                                                               (((npx) * (x295))) + (((npx) * (x296))) +
+                                                               (((IkReal(-159.250000000000)) * (npx)))))));
+                                    sj6array[0] = IKsin(j6array[0]);
+                                    cj6array[0] = IKcos(j6array[0]);
+                                    if (j6array[0] > IKPI)
+                                    {
+                                      j6array[0] -= IK2PI;
+                                    }
+                                    else if (j6array[0] < -IKPI)
+                                    {
+                                      j6array[0] += IK2PI;
+                                    }
+                                    j6valid[0] = true;
+                                    for (int ij6 = 0; ij6 < 1; ++ij6)
+                                    {
+                                      if (!j6valid[ij6])
+                                      {
+                                        continue;
+                                      }
+                                      _ij6[0] = ij6;
+                                      _ij6[1] = -1;
+                                      for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                      {
+                                        if (j6valid[iij6] &&
+                                            IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j6valid[iij6] = false;
+                                          _ij6[1] = iij6;
+                                          break;
+                                        }
+                                      }
+                                      j6 = j6array[ij6];
+                                      cj6 = cj6array[ij6];
+                                      sj6 = sj6array[ij6];
+                                      {
+                                        IkReal evalcond[6];
+                                        IkReal x298 = IKcos(j6);
+                                        IkReal x299 = IKsin(j6);
+                                        IkReal x300 = ((IkReal(1.00000000000000)) * (sj4));
+                                        IkReal x301 = ((cj5) * (npz));
+                                        IkReal x302 = ((cj4) * (cj5));
+                                        IkReal x303 = ((IkReal(0.490000000000000)) * (sj3));
+                                        IkReal x304 = ((IkReal(0.490000000000000)) * (cj3));
+                                        IkReal x305 = ((IkReal(0.840000000000000)) * (sj5));
+                                        IkReal x306 = ((npz) * (sj5));
+                                        IkReal x307 = ((npy) * (x298));
+                                        IkReal x308 = ((npx) * (x298));
+                                        IkReal x309 = ((npy) * (x299));
+                                        IkReal x310 = ((npx) * (x299));
+                                        evalcond[0] = ((x307) + (x310) + (((sj4) * (x303))));
+                                        evalcond[1] =
+                                            ((IkReal(0.0637000000000000)) + (((IkReal(-1.00000000000000)) * (pp))) +
+                                             (((IkReal(-1.00000000000000)) * (x305) * (x309))) + (((x305) * (x308))) +
+                                             (((IkReal(-0.840000000000000)) * (x301))));
+                                        evalcond[2] = ((IkReal(-0.420000000000000)) + (((sj5) * (x308))) +
+                                                       (((IkReal(-1.00000000000000)) * (x301))) +
+                                                       (((IkReal(-1.00000000000000)) * (sj5) * (x309))) +
+                                                       (((IkReal(-1.00000000000000)) * (x304))));
+                                        evalcond[3] = ((((IkReal(-0.420000000000000)) * (sj5))) +
+                                                       (((IkReal(-1.00000000000000)) * (x302) * (x303))) +
+                                                       (((IkReal(-1.00000000000000)) * (x309))) + (x308) +
+                                                       (((IkReal(-1.00000000000000)) * (sj5) * (x304))));
+                                        evalcond[4] = ((((IkReal(-1.00000000000000)) * (cj5) * (x300) * (x309))) +
+                                                       (((cj5) * (sj4) * (x308))) + (((cj4) * (x310))) +
+                                                       (((sj4) * (x306))) + (((cj4) * (x307))));
+                                        evalcond[5] =
+                                            ((((IkReal(-1.00000000000000)) * (x302) * (x309))) +
+                                             (((IkReal(-1.00000000000000)) * (x300) * (x310))) + (((x302) * (x308))) +
+                                             (((IkReal(-1.00000000000000)) * (x300) * (x307))) + (((cj4) * (x306))) +
+                                             (((IkReal(-1.00000000000000)) * (x303))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      rotationfunction0(solutions);
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              {
+                                IkReal j6array[1], cj6array[1], sj6array[1];
+                                bool j6valid[1] = { false };
+                                _nj6 = 1;
+                                IkReal x311 = ((IkReal(49.0000000000000)) * (npx));
+                                IkReal x312 = ((IkReal(49.0000000000000)) * (npy));
+                                IkReal x313 = ((sj3) * (sj4) * (sj5));
+                                IkReal x314 = ((IkReal(100.000000000000)) * (cj5) * (npz));
+                                if (IKabs(((gconst0) * (((((IkReal(-1.00000000000000)) * (npy) * (x314))) +
+                                                         (((IkReal(-1.00000000000000)) * (x311) * (x313))) +
+                                                         (((IkReal(-1.00000000000000)) * (cj3) * (x312))) +
+                                                         (((IkReal(-42.0000000000000)) * (npy))))))) <
+                                        IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((gconst0) *
+                                           (((((IkReal(-1.00000000000000)) * (x312) * (x313))) + (((npx) * (x314))) +
+                                             (((cj3) * (x311))) + (((IkReal(42.0000000000000)) * (npx))))))) <
+                                        IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                j6array[0] = IKatan2(((gconst0) * (((((IkReal(-1.00000000000000)) * (npy) * (x314))) +
+                                                                    (((IkReal(-1.00000000000000)) * (x311) * (x313))) +
+                                                                    (((IkReal(-1.00000000000000)) * (cj3) * (x312))) +
+                                                                    (((IkReal(-42.0000000000000)) * (npy)))))),
+                                                     ((gconst0) * (((((IkReal(-1.00000000000000)) * (x312) * (x313))) +
+                                                                    (((npx) * (x314))) + (((cj3) * (x311))) +
+                                                                    (((IkReal(42.0000000000000)) * (npx)))))));
+                                sj6array[0] = IKsin(j6array[0]);
+                                cj6array[0] = IKcos(j6array[0]);
+                                if (j6array[0] > IKPI)
+                                {
+                                  j6array[0] -= IK2PI;
+                                }
+                                else if (j6array[0] < -IKPI)
+                                {
+                                  j6array[0] += IK2PI;
+                                }
+                                j6valid[0] = true;
+                                for (int ij6 = 0; ij6 < 1; ++ij6)
+                                {
+                                  if (!j6valid[ij6])
+                                  {
+                                    continue;
+                                  }
+                                  _ij6[0] = ij6;
+                                  _ij6[1] = -1;
+                                  for (int iij6 = ij6 + 1; iij6 < 1; ++iij6)
+                                  {
+                                    if (j6valid[iij6] &&
+                                        IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j6valid[iij6] = false;
+                                      _ij6[1] = iij6;
+                                      break;
+                                    }
+                                  }
+                                  j6 = j6array[ij6];
+                                  cj6 = cj6array[ij6];
+                                  sj6 = sj6array[ij6];
+                                  {
+                                    IkReal evalcond[6];
+                                    IkReal x315 = IKcos(j6);
+                                    IkReal x316 = IKsin(j6);
+                                    IkReal x317 = ((IkReal(1.00000000000000)) * (sj4));
+                                    IkReal x318 = ((cj5) * (npz));
+                                    IkReal x319 = ((cj4) * (cj5));
+                                    IkReal x320 = ((IkReal(0.490000000000000)) * (sj3));
+                                    IkReal x321 = ((IkReal(0.490000000000000)) * (cj3));
+                                    IkReal x322 = ((IkReal(0.840000000000000)) * (sj5));
+                                    IkReal x323 = ((npz) * (sj5));
+                                    IkReal x324 = ((npy) * (x315));
+                                    IkReal x325 = ((npx) * (x315));
+                                    IkReal x326 = ((npy) * (x316));
+                                    IkReal x327 = ((npx) * (x316));
+                                    evalcond[0] = ((((sj4) * (x320))) + (x324) + (x327));
+                                    evalcond[1] = ((IkReal(0.0637000000000000)) + (((x322) * (x325))) +
+                                                   (((IkReal(-0.840000000000000)) * (x318))) +
+                                                   (((IkReal(-1.00000000000000)) * (x322) * (x326))) +
+                                                   (((IkReal(-1.00000000000000)) * (pp))));
+                                    evalcond[2] =
+                                        ((IkReal(-0.420000000000000)) + (((IkReal(-1.00000000000000)) * (x321))) +
+                                         (((sj5) * (x325))) + (((IkReal(-1.00000000000000)) * (sj5) * (x326))) +
+                                         (((IkReal(-1.00000000000000)) * (x318))));
+                                    evalcond[3] = ((((IkReal(-0.420000000000000)) * (sj5))) +
+                                                   (((IkReal(-1.00000000000000)) * (x326))) + (x325) +
+                                                   (((IkReal(-1.00000000000000)) * (x319) * (x320))) +
+                                                   (((IkReal(-1.00000000000000)) * (sj5) * (x321))));
+                                    evalcond[4] = ((((cj5) * (sj4) * (x325))) + (((sj4) * (x323))) +
+                                                   (((IkReal(-1.00000000000000)) * (cj5) * (x317) * (x326))) +
+                                                   (((cj4) * (x324))) + (((cj4) * (x327))));
+                                    evalcond[5] =
+                                        ((((IkReal(-1.00000000000000)) * (x317) * (x327))) +
+                                         (((IkReal(-1.00000000000000)) * (x317) * (x324))) +
+                                         (((IkReal(-1.00000000000000)) * (x320))) + (((cj4) * (x323))) +
+                                         (((IkReal(-1.00000000000000)) * (x319) * (x326))) + (((x319) * (x325))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  rotationfunction0(solutions);
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                else
+                {
+                  {
+                    IkReal j6array[2], cj6array[2], sj6array[2];
+                    bool j6valid[2] = { false };
+                    _nj6 = 2;
+                    if (IKabs(npy) < IKFAST_ATAN2_MAGTHRESH && IKabs(npx) < IKFAST_ATAN2_MAGTHRESH)
+                      continue;
+                    IkReal x328 = ((IkReal(1.00000000000000)) * (IKatan2(npy, npx)));
+                    if (((((npx) * (npx)) + ((npy) * (npy)))) < (IkReal)-0.00001)
+                      continue;
+                    if ((((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                          (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                                ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                                (IkReal)1.0e30)))) < -1 - IKFAST_SINCOS_THRESH ||
+                        (((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                          (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                                ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                                (IkReal)1.0e30)))) > 1 + IKFAST_SINCOS_THRESH)
+                      continue;
+                    IkReal x329 = IKasin(((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                                          (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                                                ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                                                (IkReal)1.0e30))));
+                    j6array[0] = ((((IkReal(-1.00000000000000)) * (x328))) + (((IkReal(-1.00000000000000)) * (x329))));
+                    sj6array[0] = IKsin(j6array[0]);
+                    cj6array[0] = IKcos(j6array[0]);
+                    j6array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x328))) + (x329));
+                    sj6array[1] = IKsin(j6array[1]);
+                    cj6array[1] = IKcos(j6array[1]);
+                    if (j6array[0] > IKPI)
+                    {
+                      j6array[0] -= IK2PI;
+                    }
+                    else if (j6array[0] < -IKPI)
+                    {
+                      j6array[0] += IK2PI;
+                    }
+                    j6valid[0] = true;
+                    if (j6array[1] > IKPI)
+                    {
+                      j6array[1] -= IK2PI;
+                    }
+                    else if (j6array[1] < -IKPI)
+                    {
+                      j6array[1] += IK2PI;
+                    }
+                    j6valid[1] = true;
+                    for (int ij6 = 0; ij6 < 2; ++ij6)
+                    {
+                      if (!j6valid[ij6])
+                      {
+                        continue;
+                      }
+                      _ij6[0] = ij6;
+                      _ij6[1] = -1;
+                      for (int iij6 = ij6 + 1; iij6 < 2; ++iij6)
+                      {
+                        if (j6valid[iij6] && IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                            IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                        {
+                          j6valid[iij6] = false;
+                          _ij6[1] = iij6;
+                          break;
+                        }
+                      }
+                      j6 = j6array[ij6];
+                      cj6 = cj6array[ij6];
+                      sj6 = sj6array[ij6];
+                      {
+                        IkReal evalcond[2];
+                        IkReal x330 = (npx) * (npx);
+                        IkReal x331 = (cj4) * (cj4);
+                        IkReal x332 = (sj4) * (sj4);
+                        IkReal x333 = IKcos(j6);
+                        IkReal x334 = (npy) * (npy);
+                        IkReal x335 = IKsin(j6);
+                        IkReal x336 = ((npx) * (npy));
+                        IkReal x337 = ((IkReal(0.490000000000000)) * (sj3) * (sj4));
+                        IkReal x338 = ((IkReal(1.00000000000000)) * (x334));
+                        evalcond[0] = ((((x333) * (((((x331) * (x336))) + (((x332) * (x336))))))) +
+                                       (((x335) * (((((x330) * (x331))) + (((x330) * (x332))))))) + (((npx) * (x337))));
+                        evalcond[1] = ((((x335) * (((((IkReal(-1.00000000000000)) * (x332) * (x336))) +
+                                                    (((IkReal(-1.00000000000000)) * (x331) * (x336))))))) +
+                                       (((x333) * (((((IkReal(-1.00000000000000)) * (x331) * (x338))) +
+                                                    (((IkReal(-1.00000000000000)) * (x332) * (x338))))))) +
+                                       (((IkReal(-1.00000000000000)) * (npy) * (x337))));
+                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001)
+                        {
+                          continue;
+                        }
+                      }
+
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst10;
+                        IkReal x339 = ((cj6) * (npx));
+                        IkReal x340 = ((IkReal(49.0000000000000)) * (cj3));
+                        IkReal x341 = ((npy) * (sj6));
+                        gconst10 = IKsign(((((IkReal(-42.0000000000000)) * (x339))) +
+                                           (((IkReal(49.0000000000000)) * (cj4) * (npz) * (sj3))) +
+                                           (((x340) * (x341))) + (((IkReal(42.0000000000000)) * (x341))) +
+                                           (((IkReal(-1.00000000000000)) * (x339) * (x340)))));
+                        IkReal x342 = ((npy) * (sj6));
+                        IkReal x343 = ((cj6) * (npx));
+                        IkReal x344 = ((IkReal(1.16666666666667)) * (cj3));
+                        dummyeval[0] = ((((IkReal(1.16666666666667)) * (cj4) * (npz) * (sj3))) + (x342) +
+                                        (((IkReal(-1.00000000000000)) * (x343) * (x344))) +
+                                        (((IkReal(-1.00000000000000)) * (x343))) + (((x342) * (x344))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal dummyeval[1];
+                            IkReal gconst11;
+                            IkReal x345 = ((npy) * (sj6));
+                            IkReal x346 = ((IkReal(1029.00000000000)) * (cj3));
+                            IkReal x347 = ((cj6) * (npx));
+                            gconst11 = IKsign(
+                                ((((x345) * (x346))) + (((IkReal(1029.00000000000)) * (cj4) * (npz) * (sj3))) +
+                                 (((IkReal(-1.00000000000000)) * (x346) * (x347))) +
+                                 (((IkReal(-882.000000000000)) * (x347))) + (((IkReal(882.000000000000)) * (x345)))));
+                            IkReal x348 = ((npy) * (sj6));
+                            IkReal x349 = ((cj6) * (npx));
+                            IkReal x350 = ((IkReal(1.16666666666667)) * (cj3));
+                            dummyeval[0] = ((((IkReal(1.16666666666667)) * (cj4) * (npz) * (sj3))) +
+                                            (((IkReal(-1.00000000000000)) * (x349) * (x350))) + (x348) +
+                                            (((x348) * (x350))) + (((IkReal(-1.00000000000000)) * (x349))));
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              continue;
+                            }
+                            else
+                            {
+                              {
+                                IkReal j5array[1], cj5array[1], sj5array[1];
+                                bool j5valid[1] = { false };
+                                _nj5 = 1;
+                                IkReal x351 = ((cj4) * (sj3));
+                                IkReal x352 = ((IkReal(1225.00000000000)) * (pp));
+                                IkReal x353 = ((IkReal(2100.00000000000)) * (npz));
+                                if (IKabs(((gconst11) * (((IkReal(66.8850000000000)) +
+                                                          (((IkReal(-1.00000000000000)) * (cj3) * (x352))) +
+                                                          (((IkReal(-1050.00000000000)) * (pp))) +
+                                                          (((IkReal(78.0325000000000)) * (cj3))) +
+                                                          (((npz) * (x353))))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((gconst11) *
+                                           (((((IkReal(78.0325000000000)) * (x351))) + (((cj6) * (npx) * (x353))) +
+                                             (((IkReal(-1.00000000000000)) * (x351) * (x352))) +
+                                             (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x353))))))) <
+                                        IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                j5array[0] = IKatan2(
+                                    ((gconst11) *
+                                     (((IkReal(66.8850000000000)) + (((IkReal(-1.00000000000000)) * (cj3) * (x352))) +
+                                       (((IkReal(-1050.00000000000)) * (pp))) + (((IkReal(78.0325000000000)) * (cj3))) +
+                                       (((npz) * (x353)))))),
+                                    ((gconst11) *
+                                     (((((IkReal(78.0325000000000)) * (x351))) + (((cj6) * (npx) * (x353))) +
+                                       (((IkReal(-1.00000000000000)) * (x351) * (x352))) +
+                                       (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x353)))))));
+                                sj5array[0] = IKsin(j5array[0]);
+                                cj5array[0] = IKcos(j5array[0]);
+                                if (j5array[0] > IKPI)
+                                {
+                                  j5array[0] -= IK2PI;
+                                }
+                                else if (j5array[0] < -IKPI)
+                                {
+                                  j5array[0] += IK2PI;
+                                }
+                                j5valid[0] = true;
+                                for (int ij5 = 0; ij5 < 1; ++ij5)
+                                {
+                                  if (!j5valid[ij5])
+                                  {
+                                    continue;
+                                  }
+                                  _ij5[0] = ij5;
+                                  _ij5[1] = -1;
+                                  for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                                  {
+                                    if (j5valid[iij5] &&
+                                        IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j5valid[iij5] = false;
+                                      _ij5[1] = iij5;
+                                      break;
+                                    }
+                                  }
+                                  j5 = j5array[ij5];
+                                  cj5 = cj5array[ij5];
+                                  sj5 = sj5array[ij5];
+                                  {
+                                    IkReal evalcond[6];
+                                    IkReal x354 = IKcos(j5);
+                                    IkReal x355 = IKsin(j5);
+                                    IkReal x356 = ((IkReal(1.00000000000000)) * (npy));
+                                    IkReal x357 = ((cj6) * (sj4));
+                                    IkReal x358 = ((IkReal(0.490000000000000)) * (sj3));
+                                    IkReal x359 = ((sj4) * (sj6));
+                                    IkReal x360 = ((IkReal(1.00000000000000)) * (npz));
+                                    IkReal x361 = ((cj6) * (npx));
+                                    IkReal x362 = ((IkReal(0.490000000000000)) * (cj3));
+                                    IkReal x363 = ((npz) * (x355));
+                                    IkReal x364 = ((cj4) * (x354));
+                                    IkReal x365 = ((sj6) * (x355));
+                                    evalcond[0] =
+                                        ((((IkReal(-1.00000000000000)) * (x354) * (x362))) +
+                                         (((IkReal(-0.420000000000000)) * (x354))) +
+                                         (((IkReal(-1.00000000000000)) * (x360))) + (((cj4) * (x355) * (x358))));
+                                    evalcond[1] = ((IkReal(0.0637000000000000)) +
+                                                   (((IkReal(-0.840000000000000)) * (npz) * (x354))) +
+                                                   (((IkReal(0.840000000000000)) * (x355) * (x361))) +
+                                                   (((IkReal(-1.00000000000000)) * (pp))) +
+                                                   (((IkReal(-0.840000000000000)) * (npy) * (x365))));
+                                    evalcond[2] = ((IkReal(-0.420000000000000)) +
+                                                   (((IkReal(-1.00000000000000)) * (x354) * (x360))) +
+                                                   (((IkReal(-1.00000000000000)) * (x362))) + (((x355) * (x361))) +
+                                                   (((IkReal(-1.00000000000000)) * (x356) * (x365))));
+                                    evalcond[3] = ((((IkReal(-0.420000000000000)) * (x355))) +
+                                                   (((IkReal(-1.00000000000000)) * (x358) * (x364))) +
+                                                   (((IkReal(-1.00000000000000)) * (x355) * (x362))) + (x361) +
+                                                   (((IkReal(-1.00000000000000)) * (sj6) * (x356))));
+                                    evalcond[4] = ((((sj4) * (x363))) + (((npx) * (x354) * (x357))) +
+                                                   (((cj4) * (npx) * (sj6))) + (((cj4) * (cj6) * (npy))) +
+                                                   (((IkReal(-1.00000000000000)) * (x354) * (x356) * (x359))));
+                                    evalcond[5] =
+                                        ((((x361) * (x364))) + (((IkReal(-1.00000000000000)) * (x358))) +
+                                         (((IkReal(-1.00000000000000)) * (x356) * (x357))) + (((cj4) * (x363))) +
+                                         (((IkReal(-1.00000000000000)) * (npx) * (x359))) +
+                                         (((IkReal(-1.00000000000000)) * (sj6) * (x356) * (x364))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  rotationfunction0(solutions);
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          {
+                            IkReal j5array[1], cj5array[1], sj5array[1];
+                            bool j5valid[1] = { false };
+                            _nj5 = 1;
+                            IkReal x366 = ((cj4) * (sj3));
+                            IkReal x367 = ((IkReal(100.000000000000)) * (npz));
+                            if (IKabs(((gconst10) *
+                                       (((IkReal(-17.6400000000000)) + (((IkReal(-41.1600000000000)) * (cj3))) +
+                                         (((npz) * (x367))) + (((IkReal(-24.0100000000000)) * ((cj3) * (cj3)))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((gconst10) *
+                                       (((((IkReal(-20.5800000000000)) * (x366))) + (((cj6) * (npx) * (x367))) +
+                                         (((IkReal(-24.0100000000000)) * (cj3) * (x366))) +
+                                         (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x367))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j5array[0] = IKatan2(
+                                ((gconst10) *
+                                 (((IkReal(-17.6400000000000)) + (((IkReal(-41.1600000000000)) * (cj3))) +
+                                   (((npz) * (x367))) + (((IkReal(-24.0100000000000)) * ((cj3) * (cj3))))))),
+                                ((gconst10) * (((((IkReal(-20.5800000000000)) * (x366))) + (((cj6) * (npx) * (x367))) +
+                                                (((IkReal(-24.0100000000000)) * (cj3) * (x366))) +
+                                                (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x367)))))));
+                            sj5array[0] = IKsin(j5array[0]);
+                            cj5array[0] = IKcos(j5array[0]);
+                            if (j5array[0] > IKPI)
+                            {
+                              j5array[0] -= IK2PI;
+                            }
+                            else if (j5array[0] < -IKPI)
+                            {
+                              j5array[0] += IK2PI;
+                            }
+                            j5valid[0] = true;
+                            for (int ij5 = 0; ij5 < 1; ++ij5)
+                            {
+                              if (!j5valid[ij5])
+                              {
+                                continue;
+                              }
+                              _ij5[0] = ij5;
+                              _ij5[1] = -1;
+                              for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                              {
+                                if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j5valid[iij5] = false;
+                                  _ij5[1] = iij5;
+                                  break;
+                                }
+                              }
+                              j5 = j5array[ij5];
+                              cj5 = cj5array[ij5];
+                              sj5 = sj5array[ij5];
+                              {
+                                IkReal evalcond[6];
+                                IkReal x368 = IKcos(j5);
+                                IkReal x369 = IKsin(j5);
+                                IkReal x370 = ((IkReal(1.00000000000000)) * (npy));
+                                IkReal x371 = ((cj6) * (sj4));
+                                IkReal x372 = ((IkReal(0.490000000000000)) * (sj3));
+                                IkReal x373 = ((sj4) * (sj6));
+                                IkReal x374 = ((IkReal(1.00000000000000)) * (npz));
+                                IkReal x375 = ((cj6) * (npx));
+                                IkReal x376 = ((IkReal(0.490000000000000)) * (cj3));
+                                IkReal x377 = ((npz) * (x369));
+                                IkReal x378 = ((cj4) * (x368));
+                                IkReal x379 = ((sj6) * (x369));
+                                evalcond[0] = ((((IkReal(-1.00000000000000)) * (x368) * (x376))) +
+                                               (((cj4) * (x369) * (x372))) + (((IkReal(-1.00000000000000)) * (x374))) +
+                                               (((IkReal(-0.420000000000000)) * (x368))));
+                                evalcond[1] =
+                                    ((IkReal(0.0637000000000000)) + (((IkReal(0.840000000000000)) * (x369) * (x375))) +
+                                     (((IkReal(-0.840000000000000)) * (npz) * (x368))) +
+                                     (((IkReal(-1.00000000000000)) * (pp))) +
+                                     (((IkReal(-0.840000000000000)) * (npy) * (x379))));
+                                evalcond[2] =
+                                    ((IkReal(-0.420000000000000)) + (((IkReal(-1.00000000000000)) * (x368) * (x374))) +
+                                     (((IkReal(-1.00000000000000)) * (x370) * (x379))) + (((x369) * (x375))) +
+                                     (((IkReal(-1.00000000000000)) * (x376))));
+                                evalcond[3] = ((((IkReal(-1.00000000000000)) * (x372) * (x378))) + (x375) +
+                                               (((IkReal(-0.420000000000000)) * (x369))) +
+                                               (((IkReal(-1.00000000000000)) * (sj6) * (x370))) +
+                                               (((IkReal(-1.00000000000000)) * (x369) * (x376))));
+                                evalcond[4] =
+                                    ((((sj4) * (x377))) + (((IkReal(-1.00000000000000)) * (x368) * (x370) * (x373))) +
+                                     (((cj4) * (npx) * (sj6))) + (((cj4) * (cj6) * (npy))) +
+                                     (((npx) * (x368) * (x371))));
+                                evalcond[5] = ((((IkReal(-1.00000000000000)) * (npx) * (x373))) + (((x375) * (x378))) +
+                                               (((IkReal(-1.00000000000000)) * (x370) * (x371))) +
+                                               (((IkReal(-1.00000000000000)) * (x372))) + (((cj4) * (x377))) +
+                                               (((IkReal(-1.00000000000000)) * (sj6) * (x370) * (x378))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              rotationfunction0(solutions);
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            else
+            {
+              {
+                IkReal j6array[2], cj6array[2], sj6array[2];
+                bool j6valid[2] = { false };
+                _nj6 = 2;
+                if (IKabs(npy) < IKFAST_ATAN2_MAGTHRESH && IKabs(npx) < IKFAST_ATAN2_MAGTHRESH)
+                  continue;
+                IkReal x380 = ((IkReal(1.00000000000000)) * (IKatan2(npy, npx)));
+                if (((((npx) * (npx)) + ((npy) * (npy)))) < (IkReal)-0.00001)
+                  continue;
+                if ((((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                      (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                            ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                            (IkReal)1.0e30)))) < -1 - IKFAST_SINCOS_THRESH ||
+                    (((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                      (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                            ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                            (IkReal)1.0e30)))) > 1 + IKFAST_SINCOS_THRESH)
+                  continue;
+                IkReal x381 = IKasin(((IkReal(0.490000000000000)) * (sj3) * (sj4) *
+                                      (((IKabs(IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy)))))) != 0) ?
+                                            ((IkReal)1 / (IKabs(IKsqrt((((npx) * (npx)) + ((npy) * (npy))))))) :
+                                            (IkReal)1.0e30))));
+                j6array[0] = ((((IkReal(-1.00000000000000)) * (x381))) + (((IkReal(-1.00000000000000)) * (x380))));
+                sj6array[0] = IKsin(j6array[0]);
+                cj6array[0] = IKcos(j6array[0]);
+                j6array[1] = ((IkReal(3.14159265358979)) + (x381) + (((IkReal(-1.00000000000000)) * (x380))));
+                sj6array[1] = IKsin(j6array[1]);
+                cj6array[1] = IKcos(j6array[1]);
+                if (j6array[0] > IKPI)
+                {
+                  j6array[0] -= IK2PI;
+                }
+                else if (j6array[0] < -IKPI)
+                {
+                  j6array[0] += IK2PI;
+                }
+                j6valid[0] = true;
+                if (j6array[1] > IKPI)
+                {
+                  j6array[1] -= IK2PI;
+                }
+                else if (j6array[1] < -IKPI)
+                {
+                  j6array[1] += IK2PI;
+                }
+                j6valid[1] = true;
+                for (int ij6 = 0; ij6 < 2; ++ij6)
+                {
+                  if (!j6valid[ij6])
+                  {
+                    continue;
+                  }
+                  _ij6[0] = ij6;
+                  _ij6[1] = -1;
+                  for (int iij6 = ij6 + 1; iij6 < 2; ++iij6)
+                  {
+                    if (j6valid[iij6] && IKabs(cj6array[ij6] - cj6array[iij6]) < IKFAST_SOLUTION_THRESH &&
+                        IKabs(sj6array[ij6] - sj6array[iij6]) < IKFAST_SOLUTION_THRESH)
+                    {
+                      j6valid[iij6] = false;
+                      _ij6[1] = iij6;
+                      break;
+                    }
+                  }
+                  j6 = j6array[ij6];
+                  cj6 = cj6array[ij6];
+                  sj6 = sj6array[ij6];
+
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst10;
+                    IkReal x382 = ((cj6) * (npx));
+                    IkReal x383 = ((IkReal(49.0000000000000)) * (cj3));
+                    IkReal x384 = ((npy) * (sj6));
+                    gconst10 =
+                        IKsign(((((IkReal(-42.0000000000000)) * (x382))) + (((IkReal(42.0000000000000)) * (x384))) +
+                                (((x383) * (x384))) + (((IkReal(49.0000000000000)) * (cj4) * (npz) * (sj3))) +
+                                (((IkReal(-1.00000000000000)) * (x382) * (x383)))));
+                    IkReal x385 = ((npy) * (sj6));
+                    IkReal x386 = ((cj6) * (npx));
+                    IkReal x387 = ((IkReal(1.16666666666667)) * (cj3));
+                    dummyeval[0] = ((((IkReal(1.16666666666667)) * (cj4) * (npz) * (sj3))) + (x385) +
+                                    (((IkReal(-1.00000000000000)) * (x386))) +
+                                    (((IkReal(-1.00000000000000)) * (x386) * (x387))) + (((x385) * (x387))));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst11;
+                        IkReal x388 = ((npy) * (sj6));
+                        IkReal x389 = ((IkReal(1029.00000000000)) * (cj3));
+                        IkReal x390 = ((cj6) * (npx));
+                        gconst11 = IKsign(((((IkReal(-1.00000000000000)) * (x389) * (x390))) +
+                                           (((IkReal(-882.000000000000)) * (x390))) + (((x388) * (x389))) +
+                                           (((IkReal(1029.00000000000)) * (cj4) * (npz) * (sj3))) +
+                                           (((IkReal(882.000000000000)) * (x388)))));
+                        IkReal x391 = ((npy) * (sj6));
+                        IkReal x392 = ((cj6) * (npx));
+                        IkReal x393 = ((IkReal(1.16666666666667)) * (cj3));
+                        dummyeval[0] = ((((IkReal(1.16666666666667)) * (cj4) * (npz) * (sj3))) +
+                                        (((IkReal(-1.00000000000000)) * (x392))) + (x391) + (((x391) * (x393))) +
+                                        (((IkReal(-1.00000000000000)) * (x392) * (x393))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          continue;
+                        }
+                        else
+                        {
+                          {
+                            IkReal j5array[1], cj5array[1], sj5array[1];
+                            bool j5valid[1] = { false };
+                            _nj5 = 1;
+                            IkReal x394 = ((cj4) * (sj3));
+                            IkReal x395 = ((IkReal(1225.00000000000)) * (pp));
+                            IkReal x396 = ((IkReal(2100.00000000000)) * (npz));
+                            if (IKabs(((gconst11) * (((IkReal(66.8850000000000)) + (((npz) * (x396))) +
+                                                      (((IkReal(-1050.00000000000)) * (pp))) +
+                                                      (((IkReal(-1.00000000000000)) * (cj3) * (x395))) +
+                                                      (((IkReal(78.0325000000000)) * (cj3))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((gconst11) * (((((cj6) * (npx) * (x396))) +
+                                                      (((IkReal(-1.00000000000000)) * (x394) * (x395))) +
+                                                      (((IkReal(78.0325000000000)) * (x394))) +
+                                                      (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x396))))))) <
+                                    IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j5array[0] =
+                                IKatan2(((gconst11) * (((IkReal(66.8850000000000)) + (((npz) * (x396))) +
+                                                        (((IkReal(-1050.00000000000)) * (pp))) +
+                                                        (((IkReal(-1.00000000000000)) * (cj3) * (x395))) +
+                                                        (((IkReal(78.0325000000000)) * (cj3)))))),
+                                        ((gconst11) * (((((cj6) * (npx) * (x396))) +
+                                                        (((IkReal(-1.00000000000000)) * (x394) * (x395))) +
+                                                        (((IkReal(78.0325000000000)) * (x394))) +
+                                                        (((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x396)))))));
+                            sj5array[0] = IKsin(j5array[0]);
+                            cj5array[0] = IKcos(j5array[0]);
+                            if (j5array[0] > IKPI)
+                            {
+                              j5array[0] -= IK2PI;
+                            }
+                            else if (j5array[0] < -IKPI)
+                            {
+                              j5array[0] += IK2PI;
+                            }
+                            j5valid[0] = true;
+                            for (int ij5 = 0; ij5 < 1; ++ij5)
+                            {
+                              if (!j5valid[ij5])
+                              {
+                                continue;
+                              }
+                              _ij5[0] = ij5;
+                              _ij5[1] = -1;
+                              for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                              {
+                                if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j5valid[iij5] = false;
+                                  _ij5[1] = iij5;
+                                  break;
+                                }
+                              }
+                              j5 = j5array[ij5];
+                              cj5 = cj5array[ij5];
+                              sj5 = sj5array[ij5];
+                              {
+                                IkReal evalcond[6];
+                                IkReal x397 = IKcos(j5);
+                                IkReal x398 = IKsin(j5);
+                                IkReal x399 = ((IkReal(1.00000000000000)) * (npy));
+                                IkReal x400 = ((cj6) * (sj4));
+                                IkReal x401 = ((IkReal(0.490000000000000)) * (sj3));
+                                IkReal x402 = ((sj4) * (sj6));
+                                IkReal x403 = ((IkReal(1.00000000000000)) * (npz));
+                                IkReal x404 = ((cj6) * (npx));
+                                IkReal x405 = ((IkReal(0.490000000000000)) * (cj3));
+                                IkReal x406 = ((npz) * (x398));
+                                IkReal x407 = ((cj4) * (x397));
+                                IkReal x408 = ((sj6) * (x398));
+                                evalcond[0] =
+                                    ((((cj4) * (x398) * (x401))) + (((IkReal(-1.00000000000000)) * (x397) * (x405))) +
+                                     (((IkReal(-0.420000000000000)) * (x397))) +
+                                     (((IkReal(-1.00000000000000)) * (x403))));
+                                evalcond[1] =
+                                    ((IkReal(0.0637000000000000)) + (((IkReal(0.840000000000000)) * (x398) * (x404))) +
+                                     (((IkReal(-1.00000000000000)) * (pp))) +
+                                     (((IkReal(-0.840000000000000)) * (npy) * (x408))) +
+                                     (((IkReal(-0.840000000000000)) * (npz) * (x397))));
+                                evalcond[2] =
+                                    ((IkReal(-0.420000000000000)) + (((IkReal(-1.00000000000000)) * (x399) * (x408))) +
+                                     (((IkReal(-1.00000000000000)) * (x397) * (x403))) + (((x398) * (x404))) +
+                                     (((IkReal(-1.00000000000000)) * (x405))));
+                                evalcond[3] = ((((IkReal(-1.00000000000000)) * (x401) * (x407))) +
+                                               (((IkReal(-1.00000000000000)) * (sj6) * (x399))) + (x404) +
+                                               (((IkReal(-1.00000000000000)) * (x398) * (x405))) +
+                                               (((IkReal(-0.420000000000000)) * (x398))));
+                                evalcond[4] = ((((IkReal(-1.00000000000000)) * (x397) * (x399) * (x402))) +
+                                               (((npx) * (x397) * (x400))) + (((cj4) * (npx) * (sj6))) +
+                                               (((cj4) * (cj6) * (npy))) + (((sj4) * (x406))));
+                                evalcond[5] =
+                                    ((((x404) * (x407))) + (((IkReal(-1.00000000000000)) * (sj6) * (x399) * (x407))) +
+                                     (((cj4) * (x406))) + (((IkReal(-1.00000000000000)) * (x399) * (x400))) +
+                                     (((IkReal(-1.00000000000000)) * (npx) * (x402))) +
+                                     (((IkReal(-1.00000000000000)) * (x401))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              rotationfunction0(solutions);
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j5array[1], cj5array[1], sj5array[1];
+                        bool j5valid[1] = { false };
+                        _nj5 = 1;
+                        IkReal x409 = ((cj4) * (sj3));
+                        IkReal x410 = ((IkReal(100.000000000000)) * (npz));
+                        if (IKabs(((gconst10) *
+                                   (((IkReal(-17.6400000000000)) + (((IkReal(-41.1600000000000)) * (cj3))) +
+                                     (((npz) * (x410))) + (((IkReal(-24.0100000000000)) * ((cj3) * (cj3)))))))) <
+                                IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((gconst10) *
+                                   (((((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x410))) +
+                                     (((cj6) * (npx) * (x410))) + (((IkReal(-24.0100000000000)) * (cj3) * (x409))) +
+                                     (((IkReal(-20.5800000000000)) * (x409))))))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j5array[0] = IKatan2(
+                            ((gconst10) * (((IkReal(-17.6400000000000)) + (((IkReal(-41.1600000000000)) * (cj3))) +
+                                            (((npz) * (x410))) + (((IkReal(-24.0100000000000)) * ((cj3) * (cj3))))))),
+                            ((gconst10) *
+                             (((((IkReal(-1.00000000000000)) * (npy) * (sj6) * (x410))) + (((cj6) * (npx) * (x410))) +
+                               (((IkReal(-24.0100000000000)) * (cj3) * (x409))) +
+                               (((IkReal(-20.5800000000000)) * (x409)))))));
+                        sj5array[0] = IKsin(j5array[0]);
+                        cj5array[0] = IKcos(j5array[0]);
+                        if (j5array[0] > IKPI)
+                        {
+                          j5array[0] -= IK2PI;
+                        }
+                        else if (j5array[0] < -IKPI)
+                        {
+                          j5array[0] += IK2PI;
+                        }
+                        j5valid[0] = true;
+                        for (int ij5 = 0; ij5 < 1; ++ij5)
+                        {
+                          if (!j5valid[ij5])
+                          {
+                            continue;
+                          }
+                          _ij5[0] = ij5;
+                          _ij5[1] = -1;
+                          for (int iij5 = ij5 + 1; iij5 < 1; ++iij5)
+                          {
+                            if (j5valid[iij5] && IKabs(cj5array[ij5] - cj5array[iij5]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj5array[ij5] - sj5array[iij5]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j5valid[iij5] = false;
+                              _ij5[1] = iij5;
+                              break;
+                            }
+                          }
+                          j5 = j5array[ij5];
+                          cj5 = cj5array[ij5];
+                          sj5 = sj5array[ij5];
+                          {
+                            IkReal evalcond[6];
+                            IkReal x411 = IKcos(j5);
+                            IkReal x412 = IKsin(j5);
+                            IkReal x413 = ((IkReal(1.00000000000000)) * (npy));
+                            IkReal x414 = ((cj6) * (sj4));
+                            IkReal x415 = ((IkReal(0.490000000000000)) * (sj3));
+                            IkReal x416 = ((sj4) * (sj6));
+                            IkReal x417 = ((IkReal(1.00000000000000)) * (npz));
+                            IkReal x418 = ((cj6) * (npx));
+                            IkReal x419 = ((IkReal(0.490000000000000)) * (cj3));
+                            IkReal x420 = ((npz) * (x412));
+                            IkReal x421 = ((cj4) * (x411));
+                            IkReal x422 = ((sj6) * (x412));
+                            evalcond[0] = ((((cj4) * (x412) * (x415))) + (((IkReal(-0.420000000000000)) * (x411))) +
+                                           (((IkReal(-1.00000000000000)) * (x411) * (x419))) +
+                                           (((IkReal(-1.00000000000000)) * (x417))));
+                            evalcond[1] =
+                                ((IkReal(0.0637000000000000)) + (((IkReal(0.840000000000000)) * (x412) * (x418))) +
+                                 (((IkReal(-1.00000000000000)) * (pp))) +
+                                 (((IkReal(-0.840000000000000)) * (npy) * (x422))) +
+                                 (((IkReal(-0.840000000000000)) * (npz) * (x411))));
+                            evalcond[2] =
+                                ((IkReal(-0.420000000000000)) + (((IkReal(-1.00000000000000)) * (x411) * (x417))) +
+                                 (((x412) * (x418))) + (((IkReal(-1.00000000000000)) * (x413) * (x422))) +
+                                 (((IkReal(-1.00000000000000)) * (x419))));
+                            evalcond[3] = ((((IkReal(-1.00000000000000)) * (sj6) * (x413))) +
+                                           (((IkReal(-1.00000000000000)) * (x412) * (x419))) +
+                                           (((IkReal(-0.420000000000000)) * (x412))) + (x418) +
+                                           (((IkReal(-1.00000000000000)) * (x415) * (x421))));
+                            evalcond[4] = ((((IkReal(-1.00000000000000)) * (x411) * (x413) * (x416))) +
+                                           (((npx) * (x411) * (x414))) + (((sj4) * (x420))) +
+                                           (((cj4) * (npx) * (sj6))) + (((cj4) * (cj6) * (npy))));
+                            evalcond[5] =
+                                ((((IkReal(-1.00000000000000)) * (sj6) * (x413) * (x421))) + (((x418) * (x421))) +
+                                 (((cj4) * (x420))) + (((IkReal(-1.00000000000000)) * (x413) * (x414))) +
+                                 (((IkReal(-1.00000000000000)) * (npx) * (x416))) +
+                                 (((IkReal(-1.00000000000000)) * (x415))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          rotationfunction0(solutions);
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return solutions.GetNumSolutions() > 0;
+  }
+  inline void rotationfunction0(IkSolutionListBase<IkReal>& solutions)
+  {
+    for (int rotationiter = 0; rotationiter < 1; ++rotationiter)
+    {
+      IkReal x78 = ((cj6) * (sj4));
+      IkReal x79 = ((IkReal(1.00000000000000)) * (sj5));
+      IkReal x80 = ((cj4) * (cj5));
+      IkReal x81 = ((IkReal(1.00000000000000)) * (sj3));
+      IkReal x82 = ((cj3) * (sj5));
+      IkReal x83 = ((IkReal(1.00000000000000)) * (sj6));
+      IkReal x84 = ((sj4) * (sj6));
+      IkReal x85 = ((IkReal(1.00000000000000)) * (cj3));
+      IkReal x86 = ((IkReal(-1.00000000000000)) * (cj3));
+      IkReal x87 = ((((cj3) * (x80))) + (((IkReal(-1.00000000000000)) * (sj3) * (x79))));
+      IkReal x88 = ((((cj5) * (sj3))) + (((cj4) * (x82))));
+      IkReal x89 = ((((cj5) * (x84))) + (((IkReal(-1.00000000000000)) * (cj4) * (cj6))));
+      IkReal x90 = ((x82) + (((sj3) * (x80))));
+      IkReal x91 = ((((cj4) * (sj3) * (sj5))) + (((IkReal(-1.00000000000000)) * (cj5) * (x85))));
+      IkReal x92 = ((cj6) * (x87));
+      IkReal x93 = ((((IkReal(-1.00000000000000)) * (cj4) * (x83))) + (((IkReal(-1.00000000000000)) * (cj5) * (x78))));
+      IkReal x94 = ((((IkReal(-1.00000000000000)) * (cj3) * (sj4) * (x83))) + (x92));
+      IkReal x95 = ((((IkReal(-1.00000000000000)) * (x81) * (x84))) + (((cj6) * (x90))));
+      IkReal x96 = ((((IkReal(-1.00000000000000)) * (x83) * (x90))) + (((IkReal(-1.00000000000000)) * (x78) * (x81))));
+      IkReal x97 = ((((x78) * (x86))) + (((IkReal(-1.00000000000000)) * (sj6) * (x87))));
+      new_r00 =
+          ((((r00) * (((((x84) * (x86))) + (x92))))) + (((r01) * (((((IkReal(-1.00000000000000)) * (x83) * (x87))) +
+                                                                   (((IkReal(-1.00000000000000)) * (x78) * (x85))))))) +
+           (((r02) * (x88))));
+      new_r01 = ((((r12) * (x88))) + (((r11) * (x97))) + (((r10) * (x94))));
+      new_r02 = ((((r21) * (x97))) + (((r20) * (x94))) + (((r22) * (x88))));
+      new_r10 = ((((r00) * (x93))) + (((r01) * (x89))) + (((IkReal(-1.00000000000000)) * (r02) * (sj4) * (x79))));
+      new_r11 = ((((r11) * (x89))) + (((r10) * (x93))) + (((IkReal(-1.00000000000000)) * (r12) * (sj4) * (x79))));
+      new_r12 = ((((r21) * (x89))) + (((IkReal(-1.00000000000000)) * (r22) * (sj4) * (x79))) + (((r20) * (x93))));
+      new_r20 = ((((r01) * (x96))) + (((r00) * (x95))) + (((r02) * (x91))));
+      new_r21 = ((((r12) * (x91))) + (((r11) * (x96))) + (((r10) * (x95))));
+      new_r22 = ((((r21) * (x96))) + (((r20) * (x95))) + (((r22) * (x91))));
+      {
+        IkReal j1array[2], cj1array[2], sj1array[2];
+        bool j1valid[2] = { false };
+        _nj1 = 2;
+        cj1array[0] = new_r22;
+        if (cj1array[0] >= -1 - IKFAST_SINCOS_THRESH && cj1array[0] <= 1 + IKFAST_SINCOS_THRESH)
+        {
+          j1valid[0] = j1valid[1] = true;
+          j1array[0] = IKacos(cj1array[0]);
+          sj1array[0] = IKsin(j1array[0]);
+          cj1array[1] = cj1array[0];
+          j1array[1] = -j1array[0];
+          sj1array[1] = -sj1array[0];
+        }
+        else if (isnan(cj1array[0]))
+        {
+          // probably any value will work
+          j1valid[0] = true;
+          cj1array[0] = 1;
+          sj1array[0] = 0;
+          j1array[0] = 0;
+        }
+        for (int ij1 = 0; ij1 < 2; ++ij1)
+        {
+          if (!j1valid[ij1])
+          {
+            continue;
+          }
+          _ij1[0] = ij1;
+          _ij1[1] = -1;
+          for (int iij1 = ij1 + 1; iij1 < 2; ++iij1)
+          {
+            if (j1valid[iij1] && IKabs(cj1array[ij1] - cj1array[iij1]) < IKFAST_SOLUTION_THRESH &&
+                IKabs(sj1array[ij1] - sj1array[iij1]) < IKFAST_SOLUTION_THRESH)
+            {
+              j1valid[iij1] = false;
+              _ij1[1] = iij1;
+              break;
+            }
+          }
+          j1 = j1array[ij1];
+          cj1 = cj1array[ij1];
+          sj1 = sj1array[ij1];
+
+          {
+            IkReal dummyeval[1];
+            IkReal gconst12;
+            gconst12 = IKsign(sj1);
+            dummyeval[0] = sj1;
+            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+            {
+              {
+                IkReal dummyeval[1];
+                IkReal gconst13;
+                gconst13 = IKsign((((new_r12) * (new_r12)) + ((new_r02) * (new_r02))));
+                dummyeval[0] = (((new_r12) * (new_r12)) + ((new_r02) * (new_r02)));
+                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                {
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst14;
+                    gconst14 = IKsign(((((cj1) * ((new_r12) * (new_r12)))) + (((cj1) * ((new_r02) * (new_r02))))));
+                    dummyeval[0] = ((((cj1) * ((new_r12) * (new_r12)))) + (((cj1) * ((new_r02) * (new_r02)))));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal evalcond[7];
+                        evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                       (IKfmod(((IkReal(1.57079632679490)) + (j1)), IkReal(6.28318530717959))));
+                        evalcond[1] = new_r22;
+                        evalcond[2] = new_r22;
+                        if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                            IKabs(evalcond[2]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal j0array[1], cj0array[1], sj0array[1];
+                            bool j0valid[1] = { false };
+                            _nj0 = 1;
+                            if (IKabs(new_r21) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r20) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(IKsqr(new_r21) + IKsqr(new_r20) - 1) <= IKFAST_SINCOS_THRESH)
+                              continue;
+                            j0array[0] = IKatan2(new_r21, new_r20);
+                            sj0array[0] = IKsin(j0array[0]);
+                            cj0array[0] = IKcos(j0array[0]);
+                            if (j0array[0] > IKPI)
+                            {
+                              j0array[0] -= IK2PI;
+                            }
+                            else if (j0array[0] < -IKPI)
+                            {
+                              j0array[0] += IK2PI;
+                            }
+                            j0valid[0] = true;
+                            for (int ij0 = 0; ij0 < 1; ++ij0)
+                            {
+                              if (!j0valid[ij0])
+                              {
+                                continue;
+                              }
+                              _ij0[0] = ij0;
+                              _ij0[1] = -1;
+                              for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                              {
+                                if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j0valid[iij0] = false;
+                                  _ij0[1] = iij0;
+                                  break;
+                                }
+                              }
+                              j0 = j0array[ij0];
+                              cj0 = cj0array[ij0];
+                              sj0 = sj0array[ij0];
+                              {
+                                IkReal evalcond[2];
+                                evalcond[0] = ((((IkReal(-1.00000000000000)) * (IKcos(j0)))) + (new_r20));
+                                evalcond[1] = ((((IkReal(-1.00000000000000)) * (IKsin(j0)))) + (new_r21));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                IkReal dummyeval[1];
+                                IkReal gconst21;
+                                gconst21 = IKsign((((new_r12) * (new_r12)) + ((new_r02) * (new_r02))));
+                                dummyeval[0] = (((new_r12) * (new_r12)) + ((new_r02) * (new_r02)));
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal dummyeval[1];
+                                    IkReal gconst20;
+                                    gconst20 = IKsign(((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) +
+                                                       (((new_r02) * (new_r10)))));
+                                    dummyeval[0] = ((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) +
+                                                    (((new_r02) * (new_r10))));
+                                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                    {
+                                      continue;
+                                    }
+                                    else
+                                    {
+                                      {
+                                        IkReal j2array[1], cj2array[1], sj2array[1];
+                                        bool j2valid[1] = { false };
+                                        _nj2 = 1;
+                                        IkReal x98 = ((gconst20) * (sj0));
+                                        if (IKabs(((new_r12) * (x98))) < IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x98))) <
+                                                IKFAST_ATAN2_MAGTHRESH)
+                                          continue;
+                                        j2array[0] = IKatan2(((new_r12) * (x98)),
+                                                             ((IkReal(-1.00000000000000)) * (new_r02) * (x98)));
+                                        sj2array[0] = IKsin(j2array[0]);
+                                        cj2array[0] = IKcos(j2array[0]);
+                                        if (j2array[0] > IKPI)
+                                        {
+                                          j2array[0] -= IK2PI;
+                                        }
+                                        else if (j2array[0] < -IKPI)
+                                        {
+                                          j2array[0] += IK2PI;
+                                        }
+                                        j2valid[0] = true;
+                                        for (int ij2 = 0; ij2 < 1; ++ij2)
+                                        {
+                                          if (!j2valid[ij2])
+                                          {
+                                            continue;
+                                          }
+                                          _ij2[0] = ij2;
+                                          _ij2[1] = -1;
+                                          for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                                          {
+                                            if (j2valid[iij2] &&
+                                                IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                                IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                            {
+                                              j2valid[iij2] = false;
+                                              _ij2[1] = iij2;
+                                              break;
+                                            }
+                                          }
+                                          j2 = j2array[ij2];
+                                          cj2 = cj2array[ij2];
+                                          sj2 = sj2array[ij2];
+                                          {
+                                            IkReal evalcond[6];
+                                            IkReal x99 = IKsin(j2);
+                                            IkReal x100 = IKcos(j2);
+                                            IkReal x101 = ((IkReal(1.00000000000000)) * (x99));
+                                            evalcond[0] = ((((new_r02) * (x99))) + (((new_r12) * (x100))));
+                                            evalcond[1] = ((((new_r10) * (x100))) + (sj0) + (((new_r00) * (x99))));
+                                            evalcond[2] = ((IkReal(1.00000000000000)) + (((new_r02) * (x100))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r12) * (x101))));
+                                            evalcond[3] =
+                                                ((((new_r01) * (x99))) + (((IkReal(-1.00000000000000)) * (cj0))) +
+                                                 (((new_r11) * (x100))));
+                                            evalcond[4] = ((((IkReal(-1.00000000000000)) * (new_r10) * (x101))) +
+                                                           (((new_r00) * (x100))));
+                                            evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x101))) +
+                                                           (((new_r01) * (x100))));
+                                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                            {
+                                              continue;
+                                            }
+                                          }
+
+                                          {
+                                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                            vinfos[0].jointtype = 1;
+                                            vinfos[0].foffset = j0;
+                                            vinfos[0].indices[0] = _ij0[0];
+                                            vinfos[0].indices[1] = _ij0[1];
+                                            vinfos[0].maxsolutions = _nj0;
+                                            vinfos[1].jointtype = 1;
+                                            vinfos[1].foffset = j1;
+                                            vinfos[1].indices[0] = _ij1[0];
+                                            vinfos[1].indices[1] = _ij1[1];
+                                            vinfos[1].maxsolutions = _nj1;
+                                            vinfos[2].jointtype = 1;
+                                            vinfos[2].foffset = j2;
+                                            vinfos[2].indices[0] = _ij2[0];
+                                            vinfos[2].indices[1] = _ij2[1];
+                                            vinfos[2].maxsolutions = _nj2;
+                                            vinfos[3].jointtype = 1;
+                                            vinfos[3].foffset = j3;
+                                            vinfos[3].indices[0] = _ij3[0];
+                                            vinfos[3].indices[1] = _ij3[1];
+                                            vinfos[3].maxsolutions = _nj3;
+                                            vinfos[4].jointtype = 1;
+                                            vinfos[4].foffset = j4;
+                                            vinfos[4].indices[0] = _ij4[0];
+                                            vinfos[4].indices[1] = _ij4[1];
+                                            vinfos[4].maxsolutions = _nj4;
+                                            vinfos[5].jointtype = 1;
+                                            vinfos[5].foffset = j5;
+                                            vinfos[5].indices[0] = _ij5[0];
+                                            vinfos[5].indices[1] = _ij5[1];
+                                            vinfos[5].maxsolutions = _nj5;
+                                            vinfos[6].jointtype = 1;
+                                            vinfos[6].foffset = j6;
+                                            vinfos[6].indices[0] = _ij6[0];
+                                            vinfos[6].indices[1] = _ij6[1];
+                                            vinfos[6].maxsolutions = _nj6;
+                                            std::vector<int> vfree(0);
+                                            solutions.AddSolution(vinfos, vfree);
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j2array[1], cj2array[1], sj2array[1];
+                                    bool j2valid[1] = { false };
+                                    _nj2 = 1;
+                                    if (IKabs(((gconst21) * (new_r12))) < IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((IkReal(-1.00000000000000)) * (gconst21) * (new_r02))) <
+                                            IKFAST_ATAN2_MAGTHRESH)
+                                      continue;
+                                    j2array[0] = IKatan2(((gconst21) * (new_r12)),
+                                                         ((IkReal(-1.00000000000000)) * (gconst21) * (new_r02)));
+                                    sj2array[0] = IKsin(j2array[0]);
+                                    cj2array[0] = IKcos(j2array[0]);
+                                    if (j2array[0] > IKPI)
+                                    {
+                                      j2array[0] -= IK2PI;
+                                    }
+                                    else if (j2array[0] < -IKPI)
+                                    {
+                                      j2array[0] += IK2PI;
+                                    }
+                                    j2valid[0] = true;
+                                    for (int ij2 = 0; ij2 < 1; ++ij2)
+                                    {
+                                      if (!j2valid[ij2])
+                                      {
+                                        continue;
+                                      }
+                                      _ij2[0] = ij2;
+                                      _ij2[1] = -1;
+                                      for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                                      {
+                                        if (j2valid[iij2] &&
+                                            IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j2valid[iij2] = false;
+                                          _ij2[1] = iij2;
+                                          break;
+                                        }
+                                      }
+                                      j2 = j2array[ij2];
+                                      cj2 = cj2array[ij2];
+                                      sj2 = sj2array[ij2];
+                                      {
+                                        IkReal evalcond[6];
+                                        IkReal x102 = IKsin(j2);
+                                        IkReal x103 = IKcos(j2);
+                                        IkReal x104 = ((IkReal(1.00000000000000)) * (x102));
+                                        evalcond[0] = ((((new_r02) * (x102))) + (((new_r12) * (x103))));
+                                        evalcond[1] = ((((new_r10) * (x103))) + (sj0) + (((new_r00) * (x102))));
+                                        evalcond[2] = ((IkReal(1.00000000000000)) + (((new_r02) * (x103))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r12) * (x104))));
+                                        evalcond[3] =
+                                            ((((new_r01) * (x102))) + (((IkReal(-1.00000000000000)) * (cj0))) +
+                                             (((new_r11) * (x103))));
+                                        evalcond[4] = ((((IkReal(-1.00000000000000)) * (new_r10) * (x104))) +
+                                                       (((new_r00) * (x103))));
+                                        evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x104))) +
+                                                       (((new_r01) * (x103))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        vinfos[6].jointtype = 1;
+                                        vinfos[6].foffset = j6;
+                                        vinfos[6].indices[0] = _ij6[0];
+                                        vinfos[6].indices[1] = _ij6[1];
+                                        vinfos[6].maxsolutions = _nj6;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                         (IKfmod(((IkReal(4.71238898038469)) + (j1)), IkReal(6.28318530717959))));
+                          evalcond[1] = new_r22;
+                          evalcond[2] = ((IkReal(-1.00000000000000)) * (new_r22));
+                          if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                              IKabs(evalcond[2]) < 0.0000010000000000)
+                          {
+                            {
+                              IkReal j0array[1], cj0array[1], sj0array[1];
+                              bool j0valid[1] = { false };
+                              _nj0 = 1;
+                              if (IKabs(((IkReal(-1.00000000000000)) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                                  IKabs(((IkReal(-1.00000000000000)) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH &&
+                                  IKabs(IKsqr(((IkReal(-1.00000000000000)) * (new_r21))) +
+                                        IKsqr(((IkReal(-1.00000000000000)) * (new_r20))) - 1) <= IKFAST_SINCOS_THRESH)
+                                continue;
+                              j0array[0] = IKatan2(((IkReal(-1.00000000000000)) * (new_r21)),
+                                                   ((IkReal(-1.00000000000000)) * (new_r20)));
+                              sj0array[0] = IKsin(j0array[0]);
+                              cj0array[0] = IKcos(j0array[0]);
+                              if (j0array[0] > IKPI)
+                              {
+                                j0array[0] -= IK2PI;
+                              }
+                              else if (j0array[0] < -IKPI)
+                              {
+                                j0array[0] += IK2PI;
+                              }
+                              j0valid[0] = true;
+                              for (int ij0 = 0; ij0 < 1; ++ij0)
+                              {
+                                if (!j0valid[ij0])
+                                {
+                                  continue;
+                                }
+                                _ij0[0] = ij0;
+                                _ij0[1] = -1;
+                                for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                {
+                                  if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                      IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                  {
+                                    j0valid[iij0] = false;
+                                    _ij0[1] = iij0;
+                                    break;
+                                  }
+                                }
+                                j0 = j0array[ij0];
+                                cj0 = cj0array[ij0];
+                                sj0 = sj0array[ij0];
+                                {
+                                  IkReal evalcond[2];
+                                  evalcond[0] = ((IKcos(j0)) + (new_r20));
+                                  evalcond[1] = ((IKsin(j0)) + (new_r21));
+                                  if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001)
+                                  {
+                                    continue;
+                                  }
+                                }
+
+                                {
+                                  IkReal dummyeval[1];
+                                  IkReal gconst24;
+                                  gconst24 = IKsign(((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) +
+                                                     (((new_r02) * (new_r10)))));
+                                  dummyeval[0] = ((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) +
+                                                  (((new_r02) * (new_r10))));
+                                  if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                  {
+                                    {
+                                      IkReal dummyeval[1];
+                                      IkReal gconst25;
+                                      gconst25 = IKsign(((((IkReal(-1.00000000000000)) * ((new_r02) * (new_r02)))) +
+                                                         (((IkReal(-1.00000000000000)) * ((new_r12) * (new_r12))))));
+                                      dummyeval[0] = ((((IkReal(-1.00000000000000)) * ((new_r02) * (new_r02)))) +
+                                                      (((IkReal(-1.00000000000000)) * ((new_r12) * (new_r12)))));
+                                      if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                      {
+                                        continue;
+                                      }
+                                      else
+                                      {
+                                        {
+                                          IkReal j2array[1], cj2array[1], sj2array[1];
+                                          bool j2valid[1] = { false };
+                                          _nj2 = 1;
+                                          if (IKabs(((gconst25) * (new_r12))) < IKFAST_ATAN2_MAGTHRESH &&
+                                              IKabs(((IkReal(-1.00000000000000)) * (gconst25) * (new_r02))) <
+                                                  IKFAST_ATAN2_MAGTHRESH)
+                                            continue;
+                                          j2array[0] = IKatan2(((gconst25) * (new_r12)),
+                                                               ((IkReal(-1.00000000000000)) * (gconst25) * (new_r02)));
+                                          sj2array[0] = IKsin(j2array[0]);
+                                          cj2array[0] = IKcos(j2array[0]);
+                                          if (j2array[0] > IKPI)
+                                          {
+                                            j2array[0] -= IK2PI;
+                                          }
+                                          else if (j2array[0] < -IKPI)
+                                          {
+                                            j2array[0] += IK2PI;
+                                          }
+                                          j2valid[0] = true;
+                                          for (int ij2 = 0; ij2 < 1; ++ij2)
+                                          {
+                                            if (!j2valid[ij2])
+                                            {
+                                              continue;
+                                            }
+                                            _ij2[0] = ij2;
+                                            _ij2[1] = -1;
+                                            for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                                            {
+                                              if (j2valid[iij2] &&
+                                                  IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                                  IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                              {
+                                                j2valid[iij2] = false;
+                                                _ij2[1] = iij2;
+                                                break;
+                                              }
+                                            }
+                                            j2 = j2array[ij2];
+                                            cj2 = cj2array[ij2];
+                                            sj2 = sj2array[ij2];
+                                            {
+                                              IkReal evalcond[6];
+                                              IkReal x105 = IKsin(j2);
+                                              IkReal x106 = IKcos(j2);
+                                              IkReal x107 = ((IkReal(1.00000000000000)) * (x105));
+                                              evalcond[0] = ((((new_r02) * (x105))) + (((new_r12) * (x106))));
+                                              evalcond[1] = ((((new_r10) * (x106))) + (sj0) + (((new_r00) * (x105))));
+                                              evalcond[2] = ((IkReal(-1.00000000000000)) + (((new_r02) * (x106))) +
+                                                             (((IkReal(-1.00000000000000)) * (new_r12) * (x107))));
+                                              evalcond[3] =
+                                                  ((((new_r01) * (x105))) + (((IkReal(-1.00000000000000)) * (cj0))) +
+                                                   (((new_r11) * (x106))));
+                                              evalcond[4] = ((((IkReal(-1.00000000000000)) * (new_r10) * (x107))) +
+                                                             (((new_r00) * (x106))));
+                                              evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x107))) +
+                                                             (((new_r01) * (x106))));
+                                              if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                  IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                                  IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                              {
+                                                continue;
+                                              }
+                                            }
+
+                                            {
+                                              std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                              vinfos[0].jointtype = 1;
+                                              vinfos[0].foffset = j0;
+                                              vinfos[0].indices[0] = _ij0[0];
+                                              vinfos[0].indices[1] = _ij0[1];
+                                              vinfos[0].maxsolutions = _nj0;
+                                              vinfos[1].jointtype = 1;
+                                              vinfos[1].foffset = j1;
+                                              vinfos[1].indices[0] = _ij1[0];
+                                              vinfos[1].indices[1] = _ij1[1];
+                                              vinfos[1].maxsolutions = _nj1;
+                                              vinfos[2].jointtype = 1;
+                                              vinfos[2].foffset = j2;
+                                              vinfos[2].indices[0] = _ij2[0];
+                                              vinfos[2].indices[1] = _ij2[1];
+                                              vinfos[2].maxsolutions = _nj2;
+                                              vinfos[3].jointtype = 1;
+                                              vinfos[3].foffset = j3;
+                                              vinfos[3].indices[0] = _ij3[0];
+                                              vinfos[3].indices[1] = _ij3[1];
+                                              vinfos[3].maxsolutions = _nj3;
+                                              vinfos[4].jointtype = 1;
+                                              vinfos[4].foffset = j4;
+                                              vinfos[4].indices[0] = _ij4[0];
+                                              vinfos[4].indices[1] = _ij4[1];
+                                              vinfos[4].maxsolutions = _nj4;
+                                              vinfos[5].jointtype = 1;
+                                              vinfos[5].foffset = j5;
+                                              vinfos[5].indices[0] = _ij5[0];
+                                              vinfos[5].indices[1] = _ij5[1];
+                                              vinfos[5].maxsolutions = _nj5;
+                                              vinfos[6].jointtype = 1;
+                                              vinfos[6].foffset = j6;
+                                              vinfos[6].indices[0] = _ij6[0];
+                                              vinfos[6].indices[1] = _ij6[1];
+                                              vinfos[6].maxsolutions = _nj6;
+                                              std::vector<int> vfree(0);
+                                              solutions.AddSolution(vinfos, vfree);
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                  else
+                                  {
+                                    {
+                                      IkReal j2array[1], cj2array[1], sj2array[1];
+                                      bool j2valid[1] = { false };
+                                      _nj2 = 1;
+                                      IkReal x108 = ((gconst24) * (sj0));
+                                      if (IKabs(((new_r12) * (x108))) < IKFAST_ATAN2_MAGTHRESH &&
+                                          IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x108))) <
+                                              IKFAST_ATAN2_MAGTHRESH)
+                                        continue;
+                                      j2array[0] = IKatan2(((new_r12) * (x108)),
+                                                           ((IkReal(-1.00000000000000)) * (new_r02) * (x108)));
+                                      sj2array[0] = IKsin(j2array[0]);
+                                      cj2array[0] = IKcos(j2array[0]);
+                                      if (j2array[0] > IKPI)
+                                      {
+                                        j2array[0] -= IK2PI;
+                                      }
+                                      else if (j2array[0] < -IKPI)
+                                      {
+                                        j2array[0] += IK2PI;
+                                      }
+                                      j2valid[0] = true;
+                                      for (int ij2 = 0; ij2 < 1; ++ij2)
+                                      {
+                                        if (!j2valid[ij2])
+                                        {
+                                          continue;
+                                        }
+                                        _ij2[0] = ij2;
+                                        _ij2[1] = -1;
+                                        for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                                        {
+                                          if (j2valid[iij2] &&
+                                              IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                              IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                          {
+                                            j2valid[iij2] = false;
+                                            _ij2[1] = iij2;
+                                            break;
+                                          }
+                                        }
+                                        j2 = j2array[ij2];
+                                        cj2 = cj2array[ij2];
+                                        sj2 = sj2array[ij2];
+                                        {
+                                          IkReal evalcond[6];
+                                          IkReal x109 = IKsin(j2);
+                                          IkReal x110 = IKcos(j2);
+                                          IkReal x111 = ((IkReal(1.00000000000000)) * (x109));
+                                          evalcond[0] = ((((new_r02) * (x109))) + (((new_r12) * (x110))));
+                                          evalcond[1] = ((((new_r10) * (x110))) + (sj0) + (((new_r00) * (x109))));
+                                          evalcond[2] = ((IkReal(-1.00000000000000)) + (((new_r02) * (x110))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r12) * (x111))));
+                                          evalcond[3] = ((((new_r11) * (x110))) + (((new_r01) * (x109))) +
+                                                         (((IkReal(-1.00000000000000)) * (cj0))));
+                                          evalcond[4] = ((((IkReal(-1.00000000000000)) * (new_r10) * (x111))) +
+                                                         (((new_r00) * (x110))));
+                                          evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x111))) +
+                                                         (((new_r01) * (x110))));
+                                          if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                              IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                              IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                                          {
+                                            continue;
+                                          }
+                                        }
+
+                                        {
+                                          std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                          vinfos[0].jointtype = 1;
+                                          vinfos[0].foffset = j0;
+                                          vinfos[0].indices[0] = _ij0[0];
+                                          vinfos[0].indices[1] = _ij0[1];
+                                          vinfos[0].maxsolutions = _nj0;
+                                          vinfos[1].jointtype = 1;
+                                          vinfos[1].foffset = j1;
+                                          vinfos[1].indices[0] = _ij1[0];
+                                          vinfos[1].indices[1] = _ij1[1];
+                                          vinfos[1].maxsolutions = _nj1;
+                                          vinfos[2].jointtype = 1;
+                                          vinfos[2].foffset = j2;
+                                          vinfos[2].indices[0] = _ij2[0];
+                                          vinfos[2].indices[1] = _ij2[1];
+                                          vinfos[2].maxsolutions = _nj2;
+                                          vinfos[3].jointtype = 1;
+                                          vinfos[3].foffset = j3;
+                                          vinfos[3].indices[0] = _ij3[0];
+                                          vinfos[3].indices[1] = _ij3[1];
+                                          vinfos[3].maxsolutions = _nj3;
+                                          vinfos[4].jointtype = 1;
+                                          vinfos[4].foffset = j4;
+                                          vinfos[4].indices[0] = _ij4[0];
+                                          vinfos[4].indices[1] = _ij4[1];
+                                          vinfos[4].maxsolutions = _nj4;
+                                          vinfos[5].jointtype = 1;
+                                          vinfos[5].foffset = j5;
+                                          vinfos[5].indices[0] = _ij5[0];
+                                          vinfos[5].indices[1] = _ij5[1];
+                                          vinfos[5].maxsolutions = _nj5;
+                                          vinfos[6].jointtype = 1;
+                                          vinfos[6].foffset = j6;
+                                          vinfos[6].indices[0] = _ij6[0];
+                                          vinfos[6].indices[1] = _ij6[1];
+                                          vinfos[6].maxsolutions = _nj6;
+                                          std::vector<int> vfree(0);
+                                          solutions.AddSolution(vinfos, vfree);
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                          else
+                          {
+                            evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                           (IKfmod(((IkReal(3.14159265358979)) + (j1)), IkReal(6.28318530717959))));
+                            evalcond[1] = ((IkReal(-1.00000000000000)) + (new_r22));
+                            evalcond[2] = new_r20;
+                            evalcond[3] = new_r21;
+                            evalcond[4] = ((IkReal(-1.00000000000000)) * (new_r20));
+                            evalcond[5] = ((IkReal(-1.00000000000000)) * (new_r21));
+                            evalcond[6] = ((IkReal(1.00000000000000)) + (((IkReal(-1.00000000000000)) * (new_r22))));
+                            if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                IKabs(evalcond[2]) < 0.0000010000000000 && IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                IKabs(evalcond[4]) < 0.0000010000000000 && IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                IKabs(evalcond[6]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal j2array[2], cj2array[2], sj2array[2];
+                                bool j2valid[2] = { false };
+                                _nj2 = 2;
+                                if (IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH && IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                IkReal x112 = IKatan2(new_r12, new_r02);
+                                j2array[0] = ((IkReal(-1.00000000000000)) * (x112));
+                                sj2array[0] = IKsin(j2array[0]);
+                                cj2array[0] = IKcos(j2array[0]);
+                                j2array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x112))));
+                                sj2array[1] = IKsin(j2array[1]);
+                                cj2array[1] = IKcos(j2array[1]);
+                                if (j2array[0] > IKPI)
+                                {
+                                  j2array[0] -= IK2PI;
+                                }
+                                else if (j2array[0] < -IKPI)
+                                {
+                                  j2array[0] += IK2PI;
+                                }
+                                j2valid[0] = true;
+                                if (j2array[1] > IKPI)
+                                {
+                                  j2array[1] -= IK2PI;
+                                }
+                                else if (j2array[1] < -IKPI)
+                                {
+                                  j2array[1] += IK2PI;
+                                }
+                                j2valid[1] = true;
+                                for (int ij2 = 0; ij2 < 2; ++ij2)
+                                {
+                                  if (!j2valid[ij2])
+                                  {
+                                    continue;
+                                  }
+                                  _ij2[0] = ij2;
+                                  _ij2[1] = -1;
+                                  for (int iij2 = ij2 + 1; iij2 < 2; ++iij2)
+                                  {
+                                    if (j2valid[iij2] &&
+                                        IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j2valid[iij2] = false;
+                                      _ij2[1] = iij2;
+                                      break;
+                                    }
+                                  }
+                                  j2 = j2array[ij2];
+                                  cj2 = cj2array[ij2];
+                                  sj2 = sj2array[ij2];
+                                  {
+                                    IkReal evalcond[1];
+                                    evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r12) * (IKsin(j2)))) +
+                                                   (((new_r02) * (IKcos(j2)))));
+                                    if (IKabs(evalcond[0]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    IkReal j0array[1], cj0array[1], sj0array[1];
+                                    bool j0valid[1] = { false };
+                                    _nj0 = 1;
+                                    if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                              IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                            IKFAST_SINCOS_THRESH)
+                                      continue;
+                                    j0array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                          (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                         ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                    sj0array[0] = IKsin(j0array[0]);
+                                    cj0array[0] = IKcos(j0array[0]);
+                                    if (j0array[0] > IKPI)
+                                    {
+                                      j0array[0] -= IK2PI;
+                                    }
+                                    else if (j0array[0] < -IKPI)
+                                    {
+                                      j0array[0] += IK2PI;
+                                    }
+                                    j0valid[0] = true;
+                                    for (int ij0 = 0; ij0 < 1; ++ij0)
+                                    {
+                                      if (!j0valid[ij0])
+                                      {
+                                        continue;
+                                      }
+                                      _ij0[0] = ij0;
+                                      _ij0[1] = -1;
+                                      for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                      {
+                                        if (j0valid[iij0] &&
+                                            IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j0valid[iij0] = false;
+                                          _ij0[1] = iij0;
+                                          break;
+                                        }
+                                      }
+                                      j0 = j0array[ij0];
+                                      cj0 = cj0array[ij0];
+                                      sj0 = sj0array[ij0];
+                                      {
+                                        IkReal evalcond[4];
+                                        IkReal x113 = IKsin(j0);
+                                        IkReal x114 = ((IkReal(1.00000000000000)) * (sj2));
+                                        IkReal x115 = ((IkReal(1.00000000000000)) * (IKcos(j0)));
+                                        evalcond[0] = ((((new_r00) * (sj2))) + (x113) + (((cj2) * (new_r10))));
+                                        evalcond[1] =
+                                            ((((new_r01) * (sj2))) + (((IkReal(-1.00000000000000)) * (x115))) +
+                                             (((cj2) * (new_r11))));
+                                        evalcond[2] =
+                                            ((((IkReal(-1.00000000000000)) * (new_r10) * (x114))) +
+                                             (((IkReal(-1.00000000000000)) * (x115))) + (((cj2) * (new_r00))));
+                                        evalcond[3] =
+                                            ((((IkReal(-1.00000000000000)) * (new_r11) * (x114))) +
+                                             (((cj2) * (new_r01))) + (((IkReal(-1.00000000000000)) * (x113))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        vinfos[6].jointtype = 1;
+                                        vinfos[6].foffset = j6;
+                                        vinfos[6].indices[0] = _ij6[0];
+                                        vinfos[6].indices[1] = _ij6[1];
+                                        vinfos[6].maxsolutions = _nj6;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              IkReal x116 = ((IkReal(1.00000000000000)) + (new_r22));
+                              evalcond[0] =
+                                  ((IkReal(-3.14159265358979)) +
+                                   (IKfmod(((IkReal(1.11022302462516e-16)) + (j1)), IkReal(6.28318530717959))));
+                              evalcond[1] = x116;
+                              evalcond[2] = new_r20;
+                              evalcond[3] = new_r21;
+                              evalcond[4] = new_r20;
+                              evalcond[5] = new_r21;
+                              evalcond[6] = x116;
+                              if (IKabs(evalcond[0]) < 0.0000010000000000 && IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                  IKabs(evalcond[2]) < 0.0000010000000000 && IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                  IKabs(evalcond[4]) < 0.0000010000000000 && IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                  IKabs(evalcond[6]) < 0.0000010000000000)
+                              {
+                                {
+                                  IkReal j2array[2], cj2array[2], sj2array[2];
+                                  bool j2valid[2] = { false };
+                                  _nj2 = 2;
+                                  if (IKabs(new_r12) < IKFAST_ATAN2_MAGTHRESH &&
+                                      IKabs(new_r02) < IKFAST_ATAN2_MAGTHRESH)
+                                    continue;
+                                  IkReal x117 = IKatan2(new_r12, new_r02);
+                                  j2array[0] = ((IkReal(-1.00000000000000)) * (x117));
+                                  sj2array[0] = IKsin(j2array[0]);
+                                  cj2array[0] = IKcos(j2array[0]);
+                                  j2array[1] = ((IkReal(3.14159265358979)) + (((IkReal(-1.00000000000000)) * (x117))));
+                                  sj2array[1] = IKsin(j2array[1]);
+                                  cj2array[1] = IKcos(j2array[1]);
+                                  if (j2array[0] > IKPI)
+                                  {
+                                    j2array[0] -= IK2PI;
+                                  }
+                                  else if (j2array[0] < -IKPI)
+                                  {
+                                    j2array[0] += IK2PI;
+                                  }
+                                  j2valid[0] = true;
+                                  if (j2array[1] > IKPI)
+                                  {
+                                    j2array[1] -= IK2PI;
+                                  }
+                                  else if (j2array[1] < -IKPI)
+                                  {
+                                    j2array[1] += IK2PI;
+                                  }
+                                  j2valid[1] = true;
+                                  for (int ij2 = 0; ij2 < 2; ++ij2)
+                                  {
+                                    if (!j2valid[ij2])
+                                    {
+                                      continue;
+                                    }
+                                    _ij2[0] = ij2;
+                                    _ij2[1] = -1;
+                                    for (int iij2 = ij2 + 1; iij2 < 2; ++iij2)
+                                    {
+                                      if (j2valid[iij2] &&
+                                          IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                          IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                      {
+                                        j2valid[iij2] = false;
+                                        _ij2[1] = iij2;
+                                        break;
+                                      }
+                                    }
+                                    j2 = j2array[ij2];
+                                    cj2 = cj2array[ij2];
+                                    sj2 = sj2array[ij2];
+                                    {
+                                      IkReal evalcond[1];
+                                      evalcond[0] = ((((IkReal(-1.00000000000000)) * (new_r12) * (IKsin(j2)))) +
+                                                     (((new_r02) * (IKcos(j2)))));
+                                      if (IKabs(evalcond[0]) > 0.000001)
+                                      {
+                                        continue;
+                                      }
+                                    }
+
+                                    {
+                                      IkReal j0array[1], cj0array[1], sj0array[1];
+                                      bool j0valid[1] = { false };
+                                      _nj0 = 1;
+                                      if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                 (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                              IKFAST_ATAN2_MAGTHRESH &&
+                                          IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                              IKFAST_ATAN2_MAGTHRESH &&
+                                          IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                              IKFAST_SINCOS_THRESH)
+                                        continue;
+                                      j0array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                            (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                           ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                      sj0array[0] = IKsin(j0array[0]);
+                                      cj0array[0] = IKcos(j0array[0]);
+                                      if (j0array[0] > IKPI)
+                                      {
+                                        j0array[0] -= IK2PI;
+                                      }
+                                      else if (j0array[0] < -IKPI)
+                                      {
+                                        j0array[0] += IK2PI;
+                                      }
+                                      j0valid[0] = true;
+                                      for (int ij0 = 0; ij0 < 1; ++ij0)
+                                      {
+                                        if (!j0valid[ij0])
+                                        {
+                                          continue;
+                                        }
+                                        _ij0[0] = ij0;
+                                        _ij0[1] = -1;
+                                        for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                        {
+                                          if (j0valid[iij0] &&
+                                              IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                              IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                          {
+                                            j0valid[iij0] = false;
+                                            _ij0[1] = iij0;
+                                            break;
+                                          }
+                                        }
+                                        j0 = j0array[ij0];
+                                        cj0 = cj0array[ij0];
+                                        sj0 = sj0array[ij0];
+                                        {
+                                          IkReal evalcond[4];
+                                          IkReal x118 = IKcos(j0);
+                                          IkReal x119 = IKsin(j0);
+                                          IkReal x120 = ((IkReal(1.00000000000000)) * (sj2));
+                                          evalcond[0] = ((((new_r00) * (sj2))) + (x119) + (((cj2) * (new_r10))));
+                                          evalcond[1] = ((((new_r01) * (sj2))) + (((cj2) * (new_r11))) +
+                                                         (((IkReal(-1.00000000000000)) * (x118))));
+                                          evalcond[2] = ((((IkReal(-1.00000000000000)) * (new_r10) * (x120))) + (x118) +
+                                                         (((cj2) * (new_r00))));
+                                          evalcond[3] = ((x119) + (((cj2) * (new_r01))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r11) * (x120))));
+                                          if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                              IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                          {
+                                            continue;
+                                          }
+                                        }
+
+                                        {
+                                          std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                          vinfos[0].jointtype = 1;
+                                          vinfos[0].foffset = j0;
+                                          vinfos[0].indices[0] = _ij0[0];
+                                          vinfos[0].indices[1] = _ij0[1];
+                                          vinfos[0].maxsolutions = _nj0;
+                                          vinfos[1].jointtype = 1;
+                                          vinfos[1].foffset = j1;
+                                          vinfos[1].indices[0] = _ij1[0];
+                                          vinfos[1].indices[1] = _ij1[1];
+                                          vinfos[1].maxsolutions = _nj1;
+                                          vinfos[2].jointtype = 1;
+                                          vinfos[2].foffset = j2;
+                                          vinfos[2].indices[0] = _ij2[0];
+                                          vinfos[2].indices[1] = _ij2[1];
+                                          vinfos[2].maxsolutions = _nj2;
+                                          vinfos[3].jointtype = 1;
+                                          vinfos[3].foffset = j3;
+                                          vinfos[3].indices[0] = _ij3[0];
+                                          vinfos[3].indices[1] = _ij3[1];
+                                          vinfos[3].maxsolutions = _nj3;
+                                          vinfos[4].jointtype = 1;
+                                          vinfos[4].foffset = j4;
+                                          vinfos[4].indices[0] = _ij4[0];
+                                          vinfos[4].indices[1] = _ij4[1];
+                                          vinfos[4].maxsolutions = _nj4;
+                                          vinfos[5].jointtype = 1;
+                                          vinfos[5].foffset = j5;
+                                          vinfos[5].indices[0] = _ij5[0];
+                                          vinfos[5].indices[1] = _ij5[1];
+                                          vinfos[5].maxsolutions = _nj5;
+                                          vinfos[6].jointtype = 1;
+                                          vinfos[6].foffset = j6;
+                                          vinfos[6].indices[0] = _ij6[0];
+                                          vinfos[6].indices[1] = _ij6[1];
+                                          vinfos[6].maxsolutions = _nj6;
+                                          std::vector<int> vfree(0);
+                                          solutions.AddSolution(vinfos, vfree);
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                              else
+                              {
+                                if (1)
+                                {
+                                  continue;
+                                }
+                                else
+                                {
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j2array[1], cj2array[1], sj2array[1];
+                        bool j2valid[1] = { false };
+                        _nj2 = 1;
+                        IkReal x121 = ((gconst14) * (new_r22) * (sj1));
+                        if (IKabs(((new_r12) * (x121))) < IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x121))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j2array[0] = IKatan2(((new_r12) * (x121)), ((IkReal(-1.00000000000000)) * (new_r02) * (x121)));
+                        sj2array[0] = IKsin(j2array[0]);
+                        cj2array[0] = IKcos(j2array[0]);
+                        if (j2array[0] > IKPI)
+                        {
+                          j2array[0] -= IK2PI;
+                        }
+                        else if (j2array[0] < -IKPI)
+                        {
+                          j2array[0] += IK2PI;
+                        }
+                        j2valid[0] = true;
+                        for (int ij2 = 0; ij2 < 1; ++ij2)
+                        {
+                          if (!j2valid[ij2])
+                          {
+                            continue;
+                          }
+                          _ij2[0] = ij2;
+                          _ij2[1] = -1;
+                          for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                          {
+                            if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j2valid[iij2] = false;
+                              _ij2[1] = iij2;
+                              break;
+                            }
+                          }
+                          j2 = j2array[ij2];
+                          cj2 = cj2array[ij2];
+                          sj2 = sj2array[ij2];
+                          {
+                            IkReal evalcond[6];
+                            IkReal x122 = IKcos(j2);
+                            IkReal x123 = IKsin(j2);
+                            IkReal x124 = ((IkReal(1.00000000000000)) * (cj1));
+                            IkReal x125 = ((sj1) * (x122));
+                            IkReal x126 = ((new_r12) * (x123));
+                            IkReal x127 = ((new_r02) * (x122));
+                            IkReal x128 = ((IkReal(1.00000000000000)) * (sj1) * (x123));
+                            evalcond[0] = ((((new_r02) * (x123))) + (((new_r12) * (x122))));
+                            evalcond[1] = ((sj1) + (x127) + (((IkReal(-1.00000000000000)) * (x126))));
+                            evalcond[2] = ((((cj1) * (x127))) + (((IkReal(-1.00000000000000)) * (x124) * (x126))) +
+                                           (((new_r22) * (sj1))));
+                            evalcond[3] =
+                                ((((IkReal(-1.00000000000000)) * (new_r10) * (x128))) + (((new_r00) * (x125))) +
+                                 (((IkReal(-1.00000000000000)) * (new_r20) * (x124))));
+                            evalcond[4] =
+                                ((((new_r01) * (x125))) + (((IkReal(-1.00000000000000)) * (new_r21) * (x124))) +
+                                 (((IkReal(-1.00000000000000)) * (new_r11) * (x128))));
+                            evalcond[5] =
+                                ((IkReal(1.00000000000000)) + (((IkReal(-1.00000000000000)) * (sj1) * (x126))) +
+                                 (((new_r02) * (x125))) + (((IkReal(-1.00000000000000)) * (new_r22) * (x124))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          {
+                            IkReal dummyeval[1];
+                            IkReal gconst15;
+                            gconst15 = IKsign(sj1);
+                            dummyeval[0] = sj1;
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal dummyeval[1];
+                                dummyeval[0] = sj1;
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal dummyeval[1];
+                                    dummyeval[0] = sj1;
+                                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                    {
+                                      {
+                                        IkReal evalcond[11];
+                                        IkReal x129 = ((((new_r02) * (sj2))) + (((cj2) * (new_r12))));
+                                        IkReal x130 = ((((cj2) * (new_r02))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r12) * (sj2))));
+                                        evalcond[0] =
+                                            ((IkReal(-3.14159265358979)) +
+                                             (IKfmod(((IkReal(3.14159265358979)) + (j1)), IkReal(6.28318530717959))));
+                                        evalcond[1] = ((IkReal(-1.00000000000000)) + (new_r22));
+                                        evalcond[2] = new_r20;
+                                        evalcond[3] = new_r21;
+                                        evalcond[4] = x129;
+                                        evalcond[5] = x129;
+                                        evalcond[6] = x130;
+                                        evalcond[7] = x130;
+                                        evalcond[8] = ((IkReal(-1.00000000000000)) * (new_r20));
+                                        evalcond[9] = ((IkReal(-1.00000000000000)) * (new_r21));
+                                        evalcond[10] =
+                                            ((IkReal(1.00000000000000)) + (((IkReal(-1.00000000000000)) * (new_r22))));
+                                        if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                            IKabs(evalcond[10]) < 0.0000010000000000)
+                                        {
+                                          {
+                                            IkReal j0array[1], cj0array[1], sj0array[1];
+                                            bool j0valid[1] = { false };
+                                            _nj0 = 1;
+                                            if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                       (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                                    IKFAST_ATAN2_MAGTHRESH &&
+                                                IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                             (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                      IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                                    IKFAST_SINCOS_THRESH)
+                                              continue;
+                                            j0array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                                  (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                                 ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                            sj0array[0] = IKsin(j0array[0]);
+                                            cj0array[0] = IKcos(j0array[0]);
+                                            if (j0array[0] > IKPI)
+                                            {
+                                              j0array[0] -= IK2PI;
+                                            }
+                                            else if (j0array[0] < -IKPI)
+                                            {
+                                              j0array[0] += IK2PI;
+                                            }
+                                            j0valid[0] = true;
+                                            for (int ij0 = 0; ij0 < 1; ++ij0)
+                                            {
+                                              if (!j0valid[ij0])
+                                              {
+                                                continue;
+                                              }
+                                              _ij0[0] = ij0;
+                                              _ij0[1] = -1;
+                                              for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                              {
+                                                if (j0valid[iij0] &&
+                                                    IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                                    IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                                {
+                                                  j0valid[iij0] = false;
+                                                  _ij0[1] = iij0;
+                                                  break;
+                                                }
+                                              }
+                                              j0 = j0array[ij0];
+                                              cj0 = cj0array[ij0];
+                                              sj0 = sj0array[ij0];
+                                              {
+                                                IkReal evalcond[4];
+                                                IkReal x131 = IKsin(j0);
+                                                IkReal x132 = ((IkReal(1.00000000000000)) * (sj2));
+                                                IkReal x133 = ((IkReal(1.00000000000000)) * (IKcos(j0)));
+                                                evalcond[0] = ((((new_r00) * (sj2))) + (x131) + (((cj2) * (new_r10))));
+                                                evalcond[1] =
+                                                    ((((new_r01) * (sj2))) + (((IkReal(-1.00000000000000)) * (x133))) +
+                                                     (((cj2) * (new_r11))));
+                                                evalcond[2] =
+                                                    ((((IkReal(-1.00000000000000)) * (new_r10) * (x132))) +
+                                                     (((IkReal(-1.00000000000000)) * (x133))) + (((cj2) * (new_r00))));
+                                                evalcond[3] =
+                                                    ((((IkReal(-1.00000000000000)) * (new_r11) * (x132))) +
+                                                     (((cj2) * (new_r01))) + (((IkReal(-1.00000000000000)) * (x131))));
+                                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                {
+                                                  continue;
+                                                }
+                                              }
+
+                                              {
+                                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                                vinfos[0].jointtype = 1;
+                                                vinfos[0].foffset = j0;
+                                                vinfos[0].indices[0] = _ij0[0];
+                                                vinfos[0].indices[1] = _ij0[1];
+                                                vinfos[0].maxsolutions = _nj0;
+                                                vinfos[1].jointtype = 1;
+                                                vinfos[1].foffset = j1;
+                                                vinfos[1].indices[0] = _ij1[0];
+                                                vinfos[1].indices[1] = _ij1[1];
+                                                vinfos[1].maxsolutions = _nj1;
+                                                vinfos[2].jointtype = 1;
+                                                vinfos[2].foffset = j2;
+                                                vinfos[2].indices[0] = _ij2[0];
+                                                vinfos[2].indices[1] = _ij2[1];
+                                                vinfos[2].maxsolutions = _nj2;
+                                                vinfos[3].jointtype = 1;
+                                                vinfos[3].foffset = j3;
+                                                vinfos[3].indices[0] = _ij3[0];
+                                                vinfos[3].indices[1] = _ij3[1];
+                                                vinfos[3].maxsolutions = _nj3;
+                                                vinfos[4].jointtype = 1;
+                                                vinfos[4].foffset = j4;
+                                                vinfos[4].indices[0] = _ij4[0];
+                                                vinfos[4].indices[1] = _ij4[1];
+                                                vinfos[4].maxsolutions = _nj4;
+                                                vinfos[5].jointtype = 1;
+                                                vinfos[5].foffset = j5;
+                                                vinfos[5].indices[0] = _ij5[0];
+                                                vinfos[5].indices[1] = _ij5[1];
+                                                vinfos[5].maxsolutions = _nj5;
+                                                vinfos[6].jointtype = 1;
+                                                vinfos[6].foffset = j6;
+                                                vinfos[6].indices[0] = _ij6[0];
+                                                vinfos[6].indices[1] = _ij6[1];
+                                                vinfos[6].maxsolutions = _nj6;
+                                                std::vector<int> vfree(0);
+                                                solutions.AddSolution(vinfos, vfree);
+                                              }
+                                            }
+                                          }
+                                        }
+                                        else
+                                        {
+                                          IkReal x134 = ((IkReal(1.00000000000000)) + (new_r22));
+                                          IkReal x135 = ((new_r12) * (sj2));
+                                          IkReal x136 = ((cj2) * (new_r02));
+                                          IkReal x137 = ((((new_r02) * (sj2))) + (((cj2) * (new_r12))));
+                                          evalcond[0] = ((IkReal(-3.14159265358979)) +
+                                                         (IKfmod(((IkReal(1.11022302462516e-16)) + (j1)),
+                                                                 IkReal(6.28318530717959))));
+                                          evalcond[1] = x134;
+                                          evalcond[2] = new_r20;
+                                          evalcond[3] = new_r21;
+                                          evalcond[4] = x137;
+                                          evalcond[5] = x137;
+                                          evalcond[6] = ((x136) + (((IkReal(-1.00000000000000)) * (x135))));
+                                          evalcond[7] = ((x135) + (((IkReal(-1.00000000000000)) * (x136))));
+                                          evalcond[8] = new_r20;
+                                          evalcond[9] = new_r21;
+                                          evalcond[10] = x134;
+                                          if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                              IKabs(evalcond[10]) < 0.0000010000000000)
+                                          {
+                                            {
+                                              IkReal j0array[1], cj0array[1], sj0array[1];
+                                              bool j0valid[1] = { false };
+                                              _nj0 = 1;
+                                              if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                                      IKFAST_ATAN2_MAGTHRESH &&
+                                                  IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                                      IKFAST_ATAN2_MAGTHRESH &&
+                                                  IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                               (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                        IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                                      IKFAST_SINCOS_THRESH)
+                                                continue;
+                                              j0array[0] =
+                                                  IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                          ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                              sj0array[0] = IKsin(j0array[0]);
+                                              cj0array[0] = IKcos(j0array[0]);
+                                              if (j0array[0] > IKPI)
+                                              {
+                                                j0array[0] -= IK2PI;
+                                              }
+                                              else if (j0array[0] < -IKPI)
+                                              {
+                                                j0array[0] += IK2PI;
+                                              }
+                                              j0valid[0] = true;
+                                              for (int ij0 = 0; ij0 < 1; ++ij0)
+                                              {
+                                                if (!j0valid[ij0])
+                                                {
+                                                  continue;
+                                                }
+                                                _ij0[0] = ij0;
+                                                _ij0[1] = -1;
+                                                for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                                {
+                                                  if (j0valid[iij0] &&
+                                                      IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                                      IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                                  {
+                                                    j0valid[iij0] = false;
+                                                    _ij0[1] = iij0;
+                                                    break;
+                                                  }
+                                                }
+                                                j0 = j0array[ij0];
+                                                cj0 = cj0array[ij0];
+                                                sj0 = sj0array[ij0];
+                                                {
+                                                  IkReal evalcond[4];
+                                                  IkReal x138 = IKcos(j0);
+                                                  IkReal x139 = IKsin(j0);
+                                                  IkReal x140 = ((IkReal(1.00000000000000)) * (sj2));
+                                                  evalcond[0] =
+                                                      ((((new_r00) * (sj2))) + (x139) + (((cj2) * (new_r10))));
+                                                  evalcond[1] = ((((new_r01) * (sj2))) + (((cj2) * (new_r11))) +
+                                                                 (((IkReal(-1.00000000000000)) * (x138))));
+                                                  evalcond[2] =
+                                                      ((x138) + (((IkReal(-1.00000000000000)) * (new_r10) * (x140))) +
+                                                       (((cj2) * (new_r00))));
+                                                  evalcond[3] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x140))) +
+                                                                 (x139) + (((cj2) * (new_r01))));
+                                                  if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                      IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                                  {
+                                                    continue;
+                                                  }
+                                                }
+
+                                                {
+                                                  std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                                  vinfos[0].jointtype = 1;
+                                                  vinfos[0].foffset = j0;
+                                                  vinfos[0].indices[0] = _ij0[0];
+                                                  vinfos[0].indices[1] = _ij0[1];
+                                                  vinfos[0].maxsolutions = _nj0;
+                                                  vinfos[1].jointtype = 1;
+                                                  vinfos[1].foffset = j1;
+                                                  vinfos[1].indices[0] = _ij1[0];
+                                                  vinfos[1].indices[1] = _ij1[1];
+                                                  vinfos[1].maxsolutions = _nj1;
+                                                  vinfos[2].jointtype = 1;
+                                                  vinfos[2].foffset = j2;
+                                                  vinfos[2].indices[0] = _ij2[0];
+                                                  vinfos[2].indices[1] = _ij2[1];
+                                                  vinfos[2].maxsolutions = _nj2;
+                                                  vinfos[3].jointtype = 1;
+                                                  vinfos[3].foffset = j3;
+                                                  vinfos[3].indices[0] = _ij3[0];
+                                                  vinfos[3].indices[1] = _ij3[1];
+                                                  vinfos[3].maxsolutions = _nj3;
+                                                  vinfos[4].jointtype = 1;
+                                                  vinfos[4].foffset = j4;
+                                                  vinfos[4].indices[0] = _ij4[0];
+                                                  vinfos[4].indices[1] = _ij4[1];
+                                                  vinfos[4].maxsolutions = _nj4;
+                                                  vinfos[5].jointtype = 1;
+                                                  vinfos[5].foffset = j5;
+                                                  vinfos[5].indices[0] = _ij5[0];
+                                                  vinfos[5].indices[1] = _ij5[1];
+                                                  vinfos[5].maxsolutions = _nj5;
+                                                  vinfos[6].jointtype = 1;
+                                                  vinfos[6].foffset = j6;
+                                                  vinfos[6].indices[0] = _ij6[0];
+                                                  vinfos[6].indices[1] = _ij6[1];
+                                                  vinfos[6].maxsolutions = _nj6;
+                                                  std::vector<int> vfree(0);
+                                                  solutions.AddSolution(vinfos, vfree);
+                                                }
+                                              }
+                                            }
+                                          }
+                                          else
+                                          {
+                                            if (1)
+                                            {
+                                              continue;
+                                            }
+                                            else
+                                            {
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                    else
+                                    {
+                                      {
+                                        IkReal j0array[1], cj0array[1], sj0array[1];
+                                        bool j0valid[1] = { false };
+                                        _nj0 = 1;
+                                        if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(((new_r20) *
+                                                   (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                  IKsqr(((new_r20) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) :
+                                                                                           (IkReal)1.0e30)))) -
+                                                  1) <= IKFAST_SINCOS_THRESH)
+                                          continue;
+                                        j0array[0] = IKatan2(
+                                            ((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                             (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                            ((new_r20) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30))));
+                                        sj0array[0] = IKsin(j0array[0]);
+                                        cj0array[0] = IKcos(j0array[0]);
+                                        if (j0array[0] > IKPI)
+                                        {
+                                          j0array[0] -= IK2PI;
+                                        }
+                                        else if (j0array[0] < -IKPI)
+                                        {
+                                          j0array[0] += IK2PI;
+                                        }
+                                        j0valid[0] = true;
+                                        for (int ij0 = 0; ij0 < 1; ++ij0)
+                                        {
+                                          if (!j0valid[ij0])
+                                          {
+                                            continue;
+                                          }
+                                          _ij0[0] = ij0;
+                                          _ij0[1] = -1;
+                                          for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                          {
+                                            if (j0valid[iij0] &&
+                                                IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                                IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                            {
+                                              j0valid[iij0] = false;
+                                              _ij0[1] = iij0;
+                                              break;
+                                            }
+                                          }
+                                          j0 = j0array[ij0];
+                                          cj0 = cj0array[ij0];
+                                          sj0 = sj0array[ij0];
+                                          {
+                                            IkReal evalcond[8];
+                                            IkReal x141 = IKsin(j0);
+                                            IkReal x142 = IKcos(j0);
+                                            IkReal x143 = ((cj2) * (new_r01));
+                                            IkReal x144 = ((IkReal(1.00000000000000)) * (cj1));
+                                            IkReal x145 = ((IkReal(1.00000000000000)) * (sj1));
+                                            IkReal x146 = ((new_r10) * (sj2));
+                                            IkReal x147 = ((new_r11) * (sj2));
+                                            IkReal x148 = ((cj2) * (new_r00));
+                                            IkReal x149 = ((IkReal(1.00000000000000)) * (x142));
+                                            evalcond[0] =
+                                                ((((IkReal(-1.00000000000000)) * (x142) * (x145))) + (new_r20));
+                                            evalcond[1] =
+                                                ((((IkReal(-1.00000000000000)) * (x141) * (x145))) + (new_r21));
+                                            evalcond[2] = ((((new_r00) * (sj2))) + (x141) + (((cj2) * (new_r10))));
+                                            evalcond[3] = ((((IkReal(-1.00000000000000)) * (x149))) +
+                                                           (((new_r01) * (sj2))) + (((cj2) * (new_r11))));
+                                            evalcond[4] = ((((IkReal(-1.00000000000000)) * (x142) * (x144))) + (x148) +
+                                                           (((IkReal(-1.00000000000000)) * (x146))));
+                                            evalcond[5] = ((x143) + (((IkReal(-1.00000000000000)) * (x147))) +
+                                                           (((IkReal(-1.00000000000000)) * (x141) * (x144))));
+                                            evalcond[6] =
+                                                ((((IkReal(-1.00000000000000)) * (x149))) + (((new_r20) * (sj1))) +
+                                                 (((IkReal(-1.00000000000000)) * (x144) * (x146))) +
+                                                 (((cj1) * (x148))));
+                                            evalcond[7] = ((((IkReal(-1.00000000000000)) * (x144) * (x147))) +
+                                                           (((IkReal(-1.00000000000000)) * (x141))) +
+                                                           (((new_r21) * (sj1))) + (((cj1) * (x143))));
+                                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                                IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                            {
+                                              continue;
+                                            }
+                                          }
+
+                                          {
+                                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                            vinfos[0].jointtype = 1;
+                                            vinfos[0].foffset = j0;
+                                            vinfos[0].indices[0] = _ij0[0];
+                                            vinfos[0].indices[1] = _ij0[1];
+                                            vinfos[0].maxsolutions = _nj0;
+                                            vinfos[1].jointtype = 1;
+                                            vinfos[1].foffset = j1;
+                                            vinfos[1].indices[0] = _ij1[0];
+                                            vinfos[1].indices[1] = _ij1[1];
+                                            vinfos[1].maxsolutions = _nj1;
+                                            vinfos[2].jointtype = 1;
+                                            vinfos[2].foffset = j2;
+                                            vinfos[2].indices[0] = _ij2[0];
+                                            vinfos[2].indices[1] = _ij2[1];
+                                            vinfos[2].maxsolutions = _nj2;
+                                            vinfos[3].jointtype = 1;
+                                            vinfos[3].foffset = j3;
+                                            vinfos[3].indices[0] = _ij3[0];
+                                            vinfos[3].indices[1] = _ij3[1];
+                                            vinfos[3].maxsolutions = _nj3;
+                                            vinfos[4].jointtype = 1;
+                                            vinfos[4].foffset = j4;
+                                            vinfos[4].indices[0] = _ij4[0];
+                                            vinfos[4].indices[1] = _ij4[1];
+                                            vinfos[4].maxsolutions = _nj4;
+                                            vinfos[5].jointtype = 1;
+                                            vinfos[5].foffset = j5;
+                                            vinfos[5].indices[0] = _ij5[0];
+                                            vinfos[5].indices[1] = _ij5[1];
+                                            vinfos[5].maxsolutions = _nj5;
+                                            vinfos[6].jointtype = 1;
+                                            vinfos[6].foffset = j6;
+                                            vinfos[6].indices[0] = _ij6[0];
+                                            vinfos[6].indices[1] = _ij6[1];
+                                            vinfos[6].maxsolutions = _nj6;
+                                            std::vector<int> vfree(0);
+                                            solutions.AddSolution(vinfos, vfree);
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j0array[1], cj0array[1], sj0array[1];
+                                    bool j0valid[1] = { false };
+                                    _nj0 = 1;
+                                    if (IKabs(((new_r21) *
+                                               (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(IKsqr(((new_r21) *
+                                                     (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) +
+                                              IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                            IKFAST_SINCOS_THRESH)
+                                      continue;
+                                    j0array[0] = IKatan2(
+                                        ((new_r21) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30))),
+                                        ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                    sj0array[0] = IKsin(j0array[0]);
+                                    cj0array[0] = IKcos(j0array[0]);
+                                    if (j0array[0] > IKPI)
+                                    {
+                                      j0array[0] -= IK2PI;
+                                    }
+                                    else if (j0array[0] < -IKPI)
+                                    {
+                                      j0array[0] += IK2PI;
+                                    }
+                                    j0valid[0] = true;
+                                    for (int ij0 = 0; ij0 < 1; ++ij0)
+                                    {
+                                      if (!j0valid[ij0])
+                                      {
+                                        continue;
+                                      }
+                                      _ij0[0] = ij0;
+                                      _ij0[1] = -1;
+                                      for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                      {
+                                        if (j0valid[iij0] &&
+                                            IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j0valid[iij0] = false;
+                                          _ij0[1] = iij0;
+                                          break;
+                                        }
+                                      }
+                                      j0 = j0array[ij0];
+                                      cj0 = cj0array[ij0];
+                                      sj0 = sj0array[ij0];
+                                      {
+                                        IkReal evalcond[8];
+                                        IkReal x150 = IKsin(j0);
+                                        IkReal x151 = IKcos(j0);
+                                        IkReal x152 = ((cj2) * (new_r01));
+                                        IkReal x153 = ((IkReal(1.00000000000000)) * (cj1));
+                                        IkReal x154 = ((IkReal(1.00000000000000)) * (sj1));
+                                        IkReal x155 = ((new_r10) * (sj2));
+                                        IkReal x156 = ((new_r11) * (sj2));
+                                        IkReal x157 = ((cj2) * (new_r00));
+                                        IkReal x158 = ((IkReal(1.00000000000000)) * (x151));
+                                        evalcond[0] = ((((IkReal(-1.00000000000000)) * (x151) * (x154))) + (new_r20));
+                                        evalcond[1] = ((((IkReal(-1.00000000000000)) * (x150) * (x154))) + (new_r21));
+                                        evalcond[2] = ((((new_r00) * (sj2))) + (x150) + (((cj2) * (new_r10))));
+                                        evalcond[3] = ((((IkReal(-1.00000000000000)) * (x158))) +
+                                                       (((new_r01) * (sj2))) + (((cj2) * (new_r11))));
+                                        evalcond[4] = ((((IkReal(-1.00000000000000)) * (x151) * (x153))) + (x157) +
+                                                       (((IkReal(-1.00000000000000)) * (x155))));
+                                        evalcond[5] = ((((IkReal(-1.00000000000000)) * (x150) * (x153))) + (x152) +
+                                                       (((IkReal(-1.00000000000000)) * (x156))));
+                                        evalcond[6] =
+                                            ((((IkReal(-1.00000000000000)) * (x158))) + (((new_r20) * (sj1))) +
+                                             (((IkReal(-1.00000000000000)) * (x153) * (x155))) + (((cj1) * (x157))));
+                                        evalcond[7] = ((((IkReal(-1.00000000000000)) * (x153) * (x156))) +
+                                                       (((IkReal(-1.00000000000000)) * (x150))) +
+                                                       (((new_r21) * (sj1))) + (((cj1) * (x152))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                            IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        vinfos[6].jointtype = 1;
+                                        vinfos[6].foffset = j6;
+                                        vinfos[6].indices[0] = _ij6[0];
+                                        vinfos[6].indices[1] = _ij6[1];
+                                        vinfos[6].maxsolutions = _nj6;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              {
+                                IkReal j0array[1], cj0array[1], sj0array[1];
+                                bool j0valid[1] = { false };
+                                _nj0 = 1;
+                                if (IKabs(((gconst15) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((gconst15) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH)
+                                  continue;
+                                j0array[0] = IKatan2(((gconst15) * (new_r21)), ((gconst15) * (new_r20)));
+                                sj0array[0] = IKsin(j0array[0]);
+                                cj0array[0] = IKcos(j0array[0]);
+                                if (j0array[0] > IKPI)
+                                {
+                                  j0array[0] -= IK2PI;
+                                }
+                                else if (j0array[0] < -IKPI)
+                                {
+                                  j0array[0] += IK2PI;
+                                }
+                                j0valid[0] = true;
+                                for (int ij0 = 0; ij0 < 1; ++ij0)
+                                {
+                                  if (!j0valid[ij0])
+                                  {
+                                    continue;
+                                  }
+                                  _ij0[0] = ij0;
+                                  _ij0[1] = -1;
+                                  for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                  {
+                                    if (j0valid[iij0] &&
+                                        IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j0valid[iij0] = false;
+                                      _ij0[1] = iij0;
+                                      break;
+                                    }
+                                  }
+                                  j0 = j0array[ij0];
+                                  cj0 = cj0array[ij0];
+                                  sj0 = sj0array[ij0];
+                                  {
+                                    IkReal evalcond[8];
+                                    IkReal x159 = IKsin(j0);
+                                    IkReal x160 = IKcos(j0);
+                                    IkReal x161 = ((cj2) * (new_r01));
+                                    IkReal x162 = ((IkReal(1.00000000000000)) * (cj1));
+                                    IkReal x163 = ((IkReal(1.00000000000000)) * (sj1));
+                                    IkReal x164 = ((new_r10) * (sj2));
+                                    IkReal x165 = ((new_r11) * (sj2));
+                                    IkReal x166 = ((cj2) * (new_r00));
+                                    IkReal x167 = ((IkReal(1.00000000000000)) * (x160));
+                                    evalcond[0] = ((((IkReal(-1.00000000000000)) * (x160) * (x163))) + (new_r20));
+                                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (x159) * (x163))) + (new_r21));
+                                    evalcond[2] = ((((new_r00) * (sj2))) + (x159) + (((cj2) * (new_r10))));
+                                    evalcond[3] = ((((IkReal(-1.00000000000000)) * (x167))) + (((new_r01) * (sj2))) +
+                                                   (((cj2) * (new_r11))));
+                                    evalcond[4] = ((((IkReal(-1.00000000000000)) * (x160) * (x162))) + (x166) +
+                                                   (((IkReal(-1.00000000000000)) * (x164))));
+                                    evalcond[5] = ((((IkReal(-1.00000000000000)) * (x159) * (x162))) + (x161) +
+                                                   (((IkReal(-1.00000000000000)) * (x165))));
+                                    evalcond[6] =
+                                        ((((new_r20) * (sj1))) + (((IkReal(-1.00000000000000)) * (x167))) +
+                                         (((IkReal(-1.00000000000000)) * (x162) * (x164))) + (((cj1) * (x166))));
+                                    evalcond[7] = ((((IkReal(-1.00000000000000)) * (x162) * (x165))) +
+                                                   (((IkReal(-1.00000000000000)) * (x159))) + (((cj1) * (x161))) +
+                                                   (((new_r21) * (sj1))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                        IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                    vinfos[0].jointtype = 1;
+                                    vinfos[0].foffset = j0;
+                                    vinfos[0].indices[0] = _ij0[0];
+                                    vinfos[0].indices[1] = _ij0[1];
+                                    vinfos[0].maxsolutions = _nj0;
+                                    vinfos[1].jointtype = 1;
+                                    vinfos[1].foffset = j1;
+                                    vinfos[1].indices[0] = _ij1[0];
+                                    vinfos[1].indices[1] = _ij1[1];
+                                    vinfos[1].maxsolutions = _nj1;
+                                    vinfos[2].jointtype = 1;
+                                    vinfos[2].foffset = j2;
+                                    vinfos[2].indices[0] = _ij2[0];
+                                    vinfos[2].indices[1] = _ij2[1];
+                                    vinfos[2].maxsolutions = _nj2;
+                                    vinfos[3].jointtype = 1;
+                                    vinfos[3].foffset = j3;
+                                    vinfos[3].indices[0] = _ij3[0];
+                                    vinfos[3].indices[1] = _ij3[1];
+                                    vinfos[3].maxsolutions = _nj3;
+                                    vinfos[4].jointtype = 1;
+                                    vinfos[4].foffset = j4;
+                                    vinfos[4].indices[0] = _ij4[0];
+                                    vinfos[4].indices[1] = _ij4[1];
+                                    vinfos[4].maxsolutions = _nj4;
+                                    vinfos[5].jointtype = 1;
+                                    vinfos[5].foffset = j5;
+                                    vinfos[5].indices[0] = _ij5[0];
+                                    vinfos[5].indices[1] = _ij5[1];
+                                    vinfos[5].maxsolutions = _nj5;
+                                    vinfos[6].jointtype = 1;
+                                    vinfos[6].foffset = j6;
+                                    vinfos[6].indices[0] = _ij6[0];
+                                    vinfos[6].indices[1] = _ij6[1];
+                                    vinfos[6].maxsolutions = _nj6;
+                                    std::vector<int> vfree(0);
+                                    solutions.AddSolution(vinfos, vfree);
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                else
+                {
+                  {
+                    IkReal j2array[1], cj2array[1], sj2array[1];
+                    bool j2valid[1] = { false };
+                    _nj2 = 1;
+                    IkReal x168 = ((gconst13) * (sj1));
+                    if (IKabs(((new_r12) * (x168))) < IKFAST_ATAN2_MAGTHRESH &&
+                        IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x168))) < IKFAST_ATAN2_MAGTHRESH)
+                      continue;
+                    j2array[0] = IKatan2(((new_r12) * (x168)), ((IkReal(-1.00000000000000)) * (new_r02) * (x168)));
+                    sj2array[0] = IKsin(j2array[0]);
+                    cj2array[0] = IKcos(j2array[0]);
+                    if (j2array[0] > IKPI)
+                    {
+                      j2array[0] -= IK2PI;
+                    }
+                    else if (j2array[0] < -IKPI)
+                    {
+                      j2array[0] += IK2PI;
+                    }
+                    j2valid[0] = true;
+                    for (int ij2 = 0; ij2 < 1; ++ij2)
+                    {
+                      if (!j2valid[ij2])
+                      {
+                        continue;
+                      }
+                      _ij2[0] = ij2;
+                      _ij2[1] = -1;
+                      for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                      {
+                        if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                            IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                        {
+                          j2valid[iij2] = false;
+                          _ij2[1] = iij2;
+                          break;
+                        }
+                      }
+                      j2 = j2array[ij2];
+                      cj2 = cj2array[ij2];
+                      sj2 = sj2array[ij2];
+                      {
+                        IkReal evalcond[6];
+                        IkReal x169 = IKcos(j2);
+                        IkReal x170 = IKsin(j2);
+                        IkReal x171 = ((IkReal(1.00000000000000)) * (cj1));
+                        IkReal x172 = ((sj1) * (x169));
+                        IkReal x173 = ((new_r12) * (x170));
+                        IkReal x174 = ((new_r02) * (x169));
+                        IkReal x175 = ((IkReal(1.00000000000000)) * (sj1) * (x170));
+                        evalcond[0] = ((((new_r02) * (x170))) + (((new_r12) * (x169))));
+                        evalcond[1] = ((sj1) + (((IkReal(-1.00000000000000)) * (x173))) + (x174));
+                        evalcond[2] = ((((new_r22) * (sj1))) + (((IkReal(-1.00000000000000)) * (x171) * (x173))) +
+                                       (((cj1) * (x174))));
+                        evalcond[3] = ((((new_r00) * (x172))) + (((IkReal(-1.00000000000000)) * (new_r20) * (x171))) +
+                                       (((IkReal(-1.00000000000000)) * (new_r10) * (x175))));
+                        evalcond[4] = ((((new_r01) * (x172))) + (((IkReal(-1.00000000000000)) * (new_r21) * (x171))) +
+                                       (((IkReal(-1.00000000000000)) * (new_r11) * (x175))));
+                        evalcond[5] = ((IkReal(1.00000000000000)) + (((new_r02) * (x172))) +
+                                       (((IkReal(-1.00000000000000)) * (sj1) * (x173))) +
+                                       (((IkReal(-1.00000000000000)) * (new_r22) * (x171))));
+                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001)
+                        {
+                          continue;
+                        }
+                      }
+
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst15;
+                        gconst15 = IKsign(sj1);
+                        dummyeval[0] = sj1;
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          {
+                            IkReal dummyeval[1];
+                            dummyeval[0] = sj1;
+                            if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                            {
+                              {
+                                IkReal dummyeval[1];
+                                dummyeval[0] = sj1;
+                                if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                                {
+                                  {
+                                    IkReal evalcond[11];
+                                    IkReal x176 = ((((new_r02) * (sj2))) + (((cj2) * (new_r12))));
+                                    IkReal x177 =
+                                        ((((cj2) * (new_r02))) + (((IkReal(-1.00000000000000)) * (new_r12) * (sj2))));
+                                    evalcond[0] =
+                                        ((IkReal(-3.14159265358979)) +
+                                         (IKfmod(((IkReal(3.14159265358979)) + (j1)), IkReal(6.28318530717959))));
+                                    evalcond[1] = ((IkReal(-1.00000000000000)) + (new_r22));
+                                    evalcond[2] = new_r20;
+                                    evalcond[3] = new_r21;
+                                    evalcond[4] = x176;
+                                    evalcond[5] = x176;
+                                    evalcond[6] = x177;
+                                    evalcond[7] = x177;
+                                    evalcond[8] = ((IkReal(-1.00000000000000)) * (new_r20));
+                                    evalcond[9] = ((IkReal(-1.00000000000000)) * (new_r21));
+                                    evalcond[10] =
+                                        ((IkReal(1.00000000000000)) + (((IkReal(-1.00000000000000)) * (new_r22))));
+                                    if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                        IKabs(evalcond[10]) < 0.0000010000000000)
+                                    {
+                                      {
+                                        IkReal j0array[1], cj0array[1], sj0array[1];
+                                        bool j0valid[1] = { false };
+                                        _nj0 = 1;
+                                        if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                   (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                                IKFAST_ATAN2_MAGTHRESH &&
+                                            IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                         (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                  IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                                IKFAST_SINCOS_THRESH)
+                                          continue;
+                                        j0array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                              (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                             ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                        sj0array[0] = IKsin(j0array[0]);
+                                        cj0array[0] = IKcos(j0array[0]);
+                                        if (j0array[0] > IKPI)
+                                        {
+                                          j0array[0] -= IK2PI;
+                                        }
+                                        else if (j0array[0] < -IKPI)
+                                        {
+                                          j0array[0] += IK2PI;
+                                        }
+                                        j0valid[0] = true;
+                                        for (int ij0 = 0; ij0 < 1; ++ij0)
+                                        {
+                                          if (!j0valid[ij0])
+                                          {
+                                            continue;
+                                          }
+                                          _ij0[0] = ij0;
+                                          _ij0[1] = -1;
+                                          for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                          {
+                                            if (j0valid[iij0] &&
+                                                IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                                IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                            {
+                                              j0valid[iij0] = false;
+                                              _ij0[1] = iij0;
+                                              break;
+                                            }
+                                          }
+                                          j0 = j0array[ij0];
+                                          cj0 = cj0array[ij0];
+                                          sj0 = sj0array[ij0];
+                                          {
+                                            IkReal evalcond[4];
+                                            IkReal x178 = IKsin(j0);
+                                            IkReal x179 = ((IkReal(1.00000000000000)) * (sj2));
+                                            IkReal x180 = ((IkReal(1.00000000000000)) * (IKcos(j0)));
+                                            evalcond[0] = ((((new_r00) * (sj2))) + (x178) + (((cj2) * (new_r10))));
+                                            evalcond[1] = ((((IkReal(-1.00000000000000)) * (x180))) +
+                                                           (((new_r01) * (sj2))) + (((cj2) * (new_r11))));
+                                            evalcond[2] =
+                                                ((((IkReal(-1.00000000000000)) * (new_r10) * (x179))) +
+                                                 (((IkReal(-1.00000000000000)) * (x180))) + (((cj2) * (new_r00))));
+                                            evalcond[3] = ((((IkReal(-1.00000000000000)) * (x178))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r11) * (x179))) +
+                                                           (((cj2) * (new_r01))));
+                                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                            {
+                                              continue;
+                                            }
+                                          }
+
+                                          {
+                                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                            vinfos[0].jointtype = 1;
+                                            vinfos[0].foffset = j0;
+                                            vinfos[0].indices[0] = _ij0[0];
+                                            vinfos[0].indices[1] = _ij0[1];
+                                            vinfos[0].maxsolutions = _nj0;
+                                            vinfos[1].jointtype = 1;
+                                            vinfos[1].foffset = j1;
+                                            vinfos[1].indices[0] = _ij1[0];
+                                            vinfos[1].indices[1] = _ij1[1];
+                                            vinfos[1].maxsolutions = _nj1;
+                                            vinfos[2].jointtype = 1;
+                                            vinfos[2].foffset = j2;
+                                            vinfos[2].indices[0] = _ij2[0];
+                                            vinfos[2].indices[1] = _ij2[1];
+                                            vinfos[2].maxsolutions = _nj2;
+                                            vinfos[3].jointtype = 1;
+                                            vinfos[3].foffset = j3;
+                                            vinfos[3].indices[0] = _ij3[0];
+                                            vinfos[3].indices[1] = _ij3[1];
+                                            vinfos[3].maxsolutions = _nj3;
+                                            vinfos[4].jointtype = 1;
+                                            vinfos[4].foffset = j4;
+                                            vinfos[4].indices[0] = _ij4[0];
+                                            vinfos[4].indices[1] = _ij4[1];
+                                            vinfos[4].maxsolutions = _nj4;
+                                            vinfos[5].jointtype = 1;
+                                            vinfos[5].foffset = j5;
+                                            vinfos[5].indices[0] = _ij5[0];
+                                            vinfos[5].indices[1] = _ij5[1];
+                                            vinfos[5].maxsolutions = _nj5;
+                                            vinfos[6].jointtype = 1;
+                                            vinfos[6].foffset = j6;
+                                            vinfos[6].indices[0] = _ij6[0];
+                                            vinfos[6].indices[1] = _ij6[1];
+                                            vinfos[6].maxsolutions = _nj6;
+                                            std::vector<int> vfree(0);
+                                            solutions.AddSolution(vinfos, vfree);
+                                          }
+                                        }
+                                      }
+                                    }
+                                    else
+                                    {
+                                      IkReal x181 = ((IkReal(1.00000000000000)) + (new_r22));
+                                      IkReal x182 = ((new_r12) * (sj2));
+                                      IkReal x183 = ((cj2) * (new_r02));
+                                      IkReal x184 = ((((new_r02) * (sj2))) + (((cj2) * (new_r12))));
+                                      evalcond[0] =
+                                          ((IkReal(-3.14159265358979)) +
+                                           (IKfmod(((IkReal(1.11022302462516e-16)) + (j1)), IkReal(6.28318530717959))));
+                                      evalcond[1] = x181;
+                                      evalcond[2] = new_r20;
+                                      evalcond[3] = new_r21;
+                                      evalcond[4] = x184;
+                                      evalcond[5] = x184;
+                                      evalcond[6] = ((((IkReal(-1.00000000000000)) * (x182))) + (x183));
+                                      evalcond[7] = ((((IkReal(-1.00000000000000)) * (x183))) + (x182));
+                                      evalcond[8] = new_r20;
+                                      evalcond[9] = new_r21;
+                                      evalcond[10] = x181;
+                                      if (IKabs(evalcond[0]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[1]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[2]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[3]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[4]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[5]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[6]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[7]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[8]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[9]) < 0.0000010000000000 &&
+                                          IKabs(evalcond[10]) < 0.0000010000000000)
+                                      {
+                                        {
+                                          IkReal j0array[1], cj0array[1], sj0array[1];
+                                          bool j0valid[1] = { false };
+                                          _nj0 = 1;
+                                          if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                              IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) <
+                                                  IKFAST_ATAN2_MAGTHRESH &&
+                                              IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                           (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                                    IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                                  IKFAST_SINCOS_THRESH)
+                                            continue;
+                                          j0array[0] = IKatan2(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                                (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                                               ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                          sj0array[0] = IKsin(j0array[0]);
+                                          cj0array[0] = IKcos(j0array[0]);
+                                          if (j0array[0] > IKPI)
+                                          {
+                                            j0array[0] -= IK2PI;
+                                          }
+                                          else if (j0array[0] < -IKPI)
+                                          {
+                                            j0array[0] += IK2PI;
+                                          }
+                                          j0valid[0] = true;
+                                          for (int ij0 = 0; ij0 < 1; ++ij0)
+                                          {
+                                            if (!j0valid[ij0])
+                                            {
+                                              continue;
+                                            }
+                                            _ij0[0] = ij0;
+                                            _ij0[1] = -1;
+                                            for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                            {
+                                              if (j0valid[iij0] &&
+                                                  IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                                  IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                              {
+                                                j0valid[iij0] = false;
+                                                _ij0[1] = iij0;
+                                                break;
+                                              }
+                                            }
+                                            j0 = j0array[ij0];
+                                            cj0 = cj0array[ij0];
+                                            sj0 = sj0array[ij0];
+                                            {
+                                              IkReal evalcond[4];
+                                              IkReal x185 = IKcos(j0);
+                                              IkReal x186 = IKsin(j0);
+                                              IkReal x187 = ((IkReal(1.00000000000000)) * (sj2));
+                                              evalcond[0] = ((((new_r00) * (sj2))) + (x186) + (((cj2) * (new_r10))));
+                                              evalcond[1] =
+                                                  ((((new_r01) * (sj2))) + (((IkReal(-1.00000000000000)) * (x185))) +
+                                                   (((cj2) * (new_r11))));
+                                              evalcond[2] =
+                                                  ((x185) + (((IkReal(-1.00000000000000)) * (new_r10) * (x187))) +
+                                                   (((cj2) * (new_r00))));
+                                              evalcond[3] =
+                                                  ((x186) + (((IkReal(-1.00000000000000)) * (new_r11) * (x187))) +
+                                                   (((cj2) * (new_r01))));
+                                              if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                                  IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001)
+                                              {
+                                                continue;
+                                              }
+                                            }
+
+                                            {
+                                              std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                              vinfos[0].jointtype = 1;
+                                              vinfos[0].foffset = j0;
+                                              vinfos[0].indices[0] = _ij0[0];
+                                              vinfos[0].indices[1] = _ij0[1];
+                                              vinfos[0].maxsolutions = _nj0;
+                                              vinfos[1].jointtype = 1;
+                                              vinfos[1].foffset = j1;
+                                              vinfos[1].indices[0] = _ij1[0];
+                                              vinfos[1].indices[1] = _ij1[1];
+                                              vinfos[1].maxsolutions = _nj1;
+                                              vinfos[2].jointtype = 1;
+                                              vinfos[2].foffset = j2;
+                                              vinfos[2].indices[0] = _ij2[0];
+                                              vinfos[2].indices[1] = _ij2[1];
+                                              vinfos[2].maxsolutions = _nj2;
+                                              vinfos[3].jointtype = 1;
+                                              vinfos[3].foffset = j3;
+                                              vinfos[3].indices[0] = _ij3[0];
+                                              vinfos[3].indices[1] = _ij3[1];
+                                              vinfos[3].maxsolutions = _nj3;
+                                              vinfos[4].jointtype = 1;
+                                              vinfos[4].foffset = j4;
+                                              vinfos[4].indices[0] = _ij4[0];
+                                              vinfos[4].indices[1] = _ij4[1];
+                                              vinfos[4].maxsolutions = _nj4;
+                                              vinfos[5].jointtype = 1;
+                                              vinfos[5].foffset = j5;
+                                              vinfos[5].indices[0] = _ij5[0];
+                                              vinfos[5].indices[1] = _ij5[1];
+                                              vinfos[5].maxsolutions = _nj5;
+                                              vinfos[6].jointtype = 1;
+                                              vinfos[6].foffset = j6;
+                                              vinfos[6].indices[0] = _ij6[0];
+                                              vinfos[6].indices[1] = _ij6[1];
+                                              vinfos[6].maxsolutions = _nj6;
+                                              std::vector<int> vfree(0);
+                                              solutions.AddSolution(vinfos, vfree);
+                                            }
+                                          }
+                                        }
+                                      }
+                                      else
+                                      {
+                                        if (1)
+                                        {
+                                          continue;
+                                        }
+                                        else
+                                        {
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                                else
+                                {
+                                  {
+                                    IkReal j0array[1], cj0array[1], sj0array[1];
+                                    bool j0valid[1] = { false };
+                                    _nj0 = 1;
+                                    if (IKabs(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(((new_r20) *
+                                               (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) <
+                                            IKFAST_ATAN2_MAGTHRESH &&
+                                        IKabs(IKsqr(((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                                     (((IkReal(-1.00000000000000)) * (new_r00) * (sj2))))) +
+                                              IKsqr(((new_r20) *
+                                                     (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) -
+                                              1) <= IKFAST_SINCOS_THRESH)
+                                      continue;
+                                    j0array[0] = IKatan2(
+                                        ((((IkReal(-1.00000000000000)) * (cj2) * (new_r10))) +
+                                         (((IkReal(-1.00000000000000)) * (new_r00) * (sj2)))),
+                                        ((new_r20) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30))));
+                                    sj0array[0] = IKsin(j0array[0]);
+                                    cj0array[0] = IKcos(j0array[0]);
+                                    if (j0array[0] > IKPI)
+                                    {
+                                      j0array[0] -= IK2PI;
+                                    }
+                                    else if (j0array[0] < -IKPI)
+                                    {
+                                      j0array[0] += IK2PI;
+                                    }
+                                    j0valid[0] = true;
+                                    for (int ij0 = 0; ij0 < 1; ++ij0)
+                                    {
+                                      if (!j0valid[ij0])
+                                      {
+                                        continue;
+                                      }
+                                      _ij0[0] = ij0;
+                                      _ij0[1] = -1;
+                                      for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                      {
+                                        if (j0valid[iij0] &&
+                                            IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                            IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                        {
+                                          j0valid[iij0] = false;
+                                          _ij0[1] = iij0;
+                                          break;
+                                        }
+                                      }
+                                      j0 = j0array[ij0];
+                                      cj0 = cj0array[ij0];
+                                      sj0 = sj0array[ij0];
+                                      {
+                                        IkReal evalcond[8];
+                                        IkReal x188 = IKsin(j0);
+                                        IkReal x189 = IKcos(j0);
+                                        IkReal x190 = ((cj2) * (new_r01));
+                                        IkReal x191 = ((IkReal(1.00000000000000)) * (cj1));
+                                        IkReal x192 = ((IkReal(1.00000000000000)) * (sj1));
+                                        IkReal x193 = ((new_r10) * (sj2));
+                                        IkReal x194 = ((new_r11) * (sj2));
+                                        IkReal x195 = ((cj2) * (new_r00));
+                                        IkReal x196 = ((IkReal(1.00000000000000)) * (x189));
+                                        evalcond[0] = ((((IkReal(-1.00000000000000)) * (x189) * (x192))) + (new_r20));
+                                        evalcond[1] = ((((IkReal(-1.00000000000000)) * (x188) * (x192))) + (new_r21));
+                                        evalcond[2] = ((((new_r00) * (sj2))) + (x188) + (((cj2) * (new_r10))));
+                                        evalcond[3] =
+                                            ((((new_r01) * (sj2))) + (((IkReal(-1.00000000000000)) * (x196))) +
+                                             (((cj2) * (new_r11))));
+                                        evalcond[4] = ((((IkReal(-1.00000000000000)) * (x189) * (x191))) +
+                                                       (((IkReal(-1.00000000000000)) * (x193))) + (x195));
+                                        evalcond[5] = ((((IkReal(-1.00000000000000)) * (x188) * (x191))) +
+                                                       (((IkReal(-1.00000000000000)) * (x194))) + (x190));
+                                        evalcond[6] =
+                                            ((((new_r20) * (sj1))) + (((IkReal(-1.00000000000000)) * (x191) * (x193))) +
+                                             (((IkReal(-1.00000000000000)) * (x196))) + (((cj1) * (x195))));
+                                        evalcond[7] = ((((IkReal(-1.00000000000000)) * (x191) * (x194))) +
+                                                       (((IkReal(-1.00000000000000)) * (x188))) + (((cj1) * (x190))) +
+                                                       (((new_r21) * (sj1))));
+                                        if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                            IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                            IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                            IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                        {
+                                          continue;
+                                        }
+                                      }
+
+                                      {
+                                        std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                        vinfos[0].jointtype = 1;
+                                        vinfos[0].foffset = j0;
+                                        vinfos[0].indices[0] = _ij0[0];
+                                        vinfos[0].indices[1] = _ij0[1];
+                                        vinfos[0].maxsolutions = _nj0;
+                                        vinfos[1].jointtype = 1;
+                                        vinfos[1].foffset = j1;
+                                        vinfos[1].indices[0] = _ij1[0];
+                                        vinfos[1].indices[1] = _ij1[1];
+                                        vinfos[1].maxsolutions = _nj1;
+                                        vinfos[2].jointtype = 1;
+                                        vinfos[2].foffset = j2;
+                                        vinfos[2].indices[0] = _ij2[0];
+                                        vinfos[2].indices[1] = _ij2[1];
+                                        vinfos[2].maxsolutions = _nj2;
+                                        vinfos[3].jointtype = 1;
+                                        vinfos[3].foffset = j3;
+                                        vinfos[3].indices[0] = _ij3[0];
+                                        vinfos[3].indices[1] = _ij3[1];
+                                        vinfos[3].maxsolutions = _nj3;
+                                        vinfos[4].jointtype = 1;
+                                        vinfos[4].foffset = j4;
+                                        vinfos[4].indices[0] = _ij4[0];
+                                        vinfos[4].indices[1] = _ij4[1];
+                                        vinfos[4].maxsolutions = _nj4;
+                                        vinfos[5].jointtype = 1;
+                                        vinfos[5].foffset = j5;
+                                        vinfos[5].indices[0] = _ij5[0];
+                                        vinfos[5].indices[1] = _ij5[1];
+                                        vinfos[5].maxsolutions = _nj5;
+                                        vinfos[6].jointtype = 1;
+                                        vinfos[6].foffset = j6;
+                                        vinfos[6].indices[0] = _ij6[0];
+                                        vinfos[6].indices[1] = _ij6[1];
+                                        vinfos[6].maxsolutions = _nj6;
+                                        std::vector<int> vfree(0);
+                                        solutions.AddSolution(vinfos, vfree);
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            else
+                            {
+                              {
+                                IkReal j0array[1], cj0array[1], sj0array[1];
+                                bool j0valid[1] = { false };
+                                _nj0 = 1;
+                                if (IKabs(((new_r21) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) <
+                                        IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) < IKFAST_ATAN2_MAGTHRESH &&
+                                    IKabs(IKsqr(((new_r21) *
+                                                 (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30)))) +
+                                          IKsqr(((((new_r01) * (sj2))) + (((cj2) * (new_r11))))) - 1) <=
+                                        IKFAST_SINCOS_THRESH)
+                                  continue;
+                                j0array[0] =
+                                    IKatan2(((new_r21) * (((IKabs(sj1) != 0) ? ((IkReal)1 / (sj1)) : (IkReal)1.0e30))),
+                                            ((((new_r01) * (sj2))) + (((cj2) * (new_r11)))));
+                                sj0array[0] = IKsin(j0array[0]);
+                                cj0array[0] = IKcos(j0array[0]);
+                                if (j0array[0] > IKPI)
+                                {
+                                  j0array[0] -= IK2PI;
+                                }
+                                else if (j0array[0] < -IKPI)
+                                {
+                                  j0array[0] += IK2PI;
+                                }
+                                j0valid[0] = true;
+                                for (int ij0 = 0; ij0 < 1; ++ij0)
+                                {
+                                  if (!j0valid[ij0])
+                                  {
+                                    continue;
+                                  }
+                                  _ij0[0] = ij0;
+                                  _ij0[1] = -1;
+                                  for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                                  {
+                                    if (j0valid[iij0] &&
+                                        IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                        IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                    {
+                                      j0valid[iij0] = false;
+                                      _ij0[1] = iij0;
+                                      break;
+                                    }
+                                  }
+                                  j0 = j0array[ij0];
+                                  cj0 = cj0array[ij0];
+                                  sj0 = sj0array[ij0];
+                                  {
+                                    IkReal evalcond[8];
+                                    IkReal x197 = IKsin(j0);
+                                    IkReal x198 = IKcos(j0);
+                                    IkReal x199 = ((cj2) * (new_r01));
+                                    IkReal x200 = ((IkReal(1.00000000000000)) * (cj1));
+                                    IkReal x201 = ((IkReal(1.00000000000000)) * (sj1));
+                                    IkReal x202 = ((new_r10) * (sj2));
+                                    IkReal x203 = ((new_r11) * (sj2));
+                                    IkReal x204 = ((cj2) * (new_r00));
+                                    IkReal x205 = ((IkReal(1.00000000000000)) * (x198));
+                                    evalcond[0] = ((((IkReal(-1.00000000000000)) * (x198) * (x201))) + (new_r20));
+                                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (x197) * (x201))) + (new_r21));
+                                    evalcond[2] = ((((new_r00) * (sj2))) + (x197) + (((cj2) * (new_r10))));
+                                    evalcond[3] = ((((new_r01) * (sj2))) + (((IkReal(-1.00000000000000)) * (x205))) +
+                                                   (((cj2) * (new_r11))));
+                                    evalcond[4] = ((x204) + (((IkReal(-1.00000000000000)) * (x198) * (x200))) +
+                                                   (((IkReal(-1.00000000000000)) * (x202))));
+                                    evalcond[5] = ((((IkReal(-1.00000000000000)) * (x197) * (x200))) + (x199) +
+                                                   (((IkReal(-1.00000000000000)) * (x203))));
+                                    evalcond[6] =
+                                        ((((IkReal(-1.00000000000000)) * (x200) * (x202))) + (((cj1) * (x204))) +
+                                         (((new_r20) * (sj1))) + (((IkReal(-1.00000000000000)) * (x205))));
+                                    evalcond[7] = ((((IkReal(-1.00000000000000)) * (x200) * (x203))) +
+                                                   (((IkReal(-1.00000000000000)) * (x197))) + (((cj1) * (x199))) +
+                                                   (((new_r21) * (sj1))));
+                                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                        IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                        IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                        IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                    {
+                                      continue;
+                                    }
+                                  }
+
+                                  {
+                                    std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                    vinfos[0].jointtype = 1;
+                                    vinfos[0].foffset = j0;
+                                    vinfos[0].indices[0] = _ij0[0];
+                                    vinfos[0].indices[1] = _ij0[1];
+                                    vinfos[0].maxsolutions = _nj0;
+                                    vinfos[1].jointtype = 1;
+                                    vinfos[1].foffset = j1;
+                                    vinfos[1].indices[0] = _ij1[0];
+                                    vinfos[1].indices[1] = _ij1[1];
+                                    vinfos[1].maxsolutions = _nj1;
+                                    vinfos[2].jointtype = 1;
+                                    vinfos[2].foffset = j2;
+                                    vinfos[2].indices[0] = _ij2[0];
+                                    vinfos[2].indices[1] = _ij2[1];
+                                    vinfos[2].maxsolutions = _nj2;
+                                    vinfos[3].jointtype = 1;
+                                    vinfos[3].foffset = j3;
+                                    vinfos[3].indices[0] = _ij3[0];
+                                    vinfos[3].indices[1] = _ij3[1];
+                                    vinfos[3].maxsolutions = _nj3;
+                                    vinfos[4].jointtype = 1;
+                                    vinfos[4].foffset = j4;
+                                    vinfos[4].indices[0] = _ij4[0];
+                                    vinfos[4].indices[1] = _ij4[1];
+                                    vinfos[4].maxsolutions = _nj4;
+                                    vinfos[5].jointtype = 1;
+                                    vinfos[5].foffset = j5;
+                                    vinfos[5].indices[0] = _ij5[0];
+                                    vinfos[5].indices[1] = _ij5[1];
+                                    vinfos[5].maxsolutions = _nj5;
+                                    vinfos[6].jointtype = 1;
+                                    vinfos[6].foffset = j6;
+                                    vinfos[6].indices[0] = _ij6[0];
+                                    vinfos[6].indices[1] = _ij6[1];
+                                    vinfos[6].maxsolutions = _nj6;
+                                    std::vector<int> vfree(0);
+                                    solutions.AddSolution(vinfos, vfree);
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                        else
+                        {
+                          {
+                            IkReal j0array[1], cj0array[1], sj0array[1];
+                            bool j0valid[1] = { false };
+                            _nj0 = 1;
+                            if (IKabs(((gconst15) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((gconst15) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j0array[0] = IKatan2(((gconst15) * (new_r21)), ((gconst15) * (new_r20)));
+                            sj0array[0] = IKsin(j0array[0]);
+                            cj0array[0] = IKcos(j0array[0]);
+                            if (j0array[0] > IKPI)
+                            {
+                              j0array[0] -= IK2PI;
+                            }
+                            else if (j0array[0] < -IKPI)
+                            {
+                              j0array[0] += IK2PI;
+                            }
+                            j0valid[0] = true;
+                            for (int ij0 = 0; ij0 < 1; ++ij0)
+                            {
+                              if (!j0valid[ij0])
+                              {
+                                continue;
+                              }
+                              _ij0[0] = ij0;
+                              _ij0[1] = -1;
+                              for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                              {
+                                if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j0valid[iij0] = false;
+                                  _ij0[1] = iij0;
+                                  break;
+                                }
+                              }
+                              j0 = j0array[ij0];
+                              cj0 = cj0array[ij0];
+                              sj0 = sj0array[ij0];
+                              {
+                                IkReal evalcond[8];
+                                IkReal x206 = IKsin(j0);
+                                IkReal x207 = IKcos(j0);
+                                IkReal x208 = ((cj2) * (new_r01));
+                                IkReal x209 = ((IkReal(1.00000000000000)) * (cj1));
+                                IkReal x210 = ((IkReal(1.00000000000000)) * (sj1));
+                                IkReal x211 = ((new_r10) * (sj2));
+                                IkReal x212 = ((new_r11) * (sj2));
+                                IkReal x213 = ((cj2) * (new_r00));
+                                IkReal x214 = ((IkReal(1.00000000000000)) * (x207));
+                                evalcond[0] = ((((IkReal(-1.00000000000000)) * (x207) * (x210))) + (new_r20));
+                                evalcond[1] = ((((IkReal(-1.00000000000000)) * (x206) * (x210))) + (new_r21));
+                                evalcond[2] = ((((new_r00) * (sj2))) + (x206) + (((cj2) * (new_r10))));
+                                evalcond[3] = ((((new_r01) * (sj2))) + (((cj2) * (new_r11))) +
+                                               (((IkReal(-1.00000000000000)) * (x214))));
+                                evalcond[4] = ((((IkReal(-1.00000000000000)) * (x207) * (x209))) + (x213) +
+                                               (((IkReal(-1.00000000000000)) * (x211))));
+                                evalcond[5] = ((((IkReal(-1.00000000000000)) * (x206) * (x209))) + (x208) +
+                                               (((IkReal(-1.00000000000000)) * (x212))));
+                                evalcond[6] = ((((new_r20) * (sj1))) + (((cj1) * (x213))) +
+                                               (((IkReal(-1.00000000000000)) * (x214))) +
+                                               (((IkReal(-1.00000000000000)) * (x209) * (x211))));
+                                evalcond[7] = ((((cj1) * (x208))) + (((new_r21) * (sj1))) +
+                                               (((IkReal(-1.00000000000000)) * (x206))) +
+                                               (((IkReal(-1.00000000000000)) * (x209) * (x212))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                    IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                vinfos[0].jointtype = 1;
+                                vinfos[0].foffset = j0;
+                                vinfos[0].indices[0] = _ij0[0];
+                                vinfos[0].indices[1] = _ij0[1];
+                                vinfos[0].maxsolutions = _nj0;
+                                vinfos[1].jointtype = 1;
+                                vinfos[1].foffset = j1;
+                                vinfos[1].indices[0] = _ij1[0];
+                                vinfos[1].indices[1] = _ij1[1];
+                                vinfos[1].maxsolutions = _nj1;
+                                vinfos[2].jointtype = 1;
+                                vinfos[2].foffset = j2;
+                                vinfos[2].indices[0] = _ij2[0];
+                                vinfos[2].indices[1] = _ij2[1];
+                                vinfos[2].maxsolutions = _nj2;
+                                vinfos[3].jointtype = 1;
+                                vinfos[3].foffset = j3;
+                                vinfos[3].indices[0] = _ij3[0];
+                                vinfos[3].indices[1] = _ij3[1];
+                                vinfos[3].maxsolutions = _nj3;
+                                vinfos[4].jointtype = 1;
+                                vinfos[4].foffset = j4;
+                                vinfos[4].indices[0] = _ij4[0];
+                                vinfos[4].indices[1] = _ij4[1];
+                                vinfos[4].maxsolutions = _nj4;
+                                vinfos[5].jointtype = 1;
+                                vinfos[5].foffset = j5;
+                                vinfos[5].indices[0] = _ij5[0];
+                                vinfos[5].indices[1] = _ij5[1];
+                                vinfos[5].maxsolutions = _nj5;
+                                vinfos[6].jointtype = 1;
+                                vinfos[6].foffset = j6;
+                                vinfos[6].indices[0] = _ij6[0];
+                                vinfos[6].indices[1] = _ij6[1];
+                                vinfos[6].maxsolutions = _nj6;
+                                std::vector<int> vfree(0);
+                                solutions.AddSolution(vinfos, vfree);
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            else
+            {
+              {
+                IkReal j0array[1], cj0array[1], sj0array[1];
+                bool j0valid[1] = { false };
+                _nj0 = 1;
+                if (IKabs(((gconst12) * (new_r21))) < IKFAST_ATAN2_MAGTHRESH &&
+                    IKabs(((gconst12) * (new_r20))) < IKFAST_ATAN2_MAGTHRESH)
+                  continue;
+                j0array[0] = IKatan2(((gconst12) * (new_r21)), ((gconst12) * (new_r20)));
+                sj0array[0] = IKsin(j0array[0]);
+                cj0array[0] = IKcos(j0array[0]);
+                if (j0array[0] > IKPI)
+                {
+                  j0array[0] -= IK2PI;
+                }
+                else if (j0array[0] < -IKPI)
+                {
+                  j0array[0] += IK2PI;
+                }
+                j0valid[0] = true;
+                for (int ij0 = 0; ij0 < 1; ++ij0)
+                {
+                  if (!j0valid[ij0])
+                  {
+                    continue;
+                  }
+                  _ij0[0] = ij0;
+                  _ij0[1] = -1;
+                  for (int iij0 = ij0 + 1; iij0 < 1; ++iij0)
+                  {
+                    if (j0valid[iij0] && IKabs(cj0array[ij0] - cj0array[iij0]) < IKFAST_SOLUTION_THRESH &&
+                        IKabs(sj0array[ij0] - sj0array[iij0]) < IKFAST_SOLUTION_THRESH)
+                    {
+                      j0valid[iij0] = false;
+                      _ij0[1] = iij0;
+                      break;
+                    }
+                  }
+                  j0 = j0array[ij0];
+                  cj0 = cj0array[ij0];
+                  sj0 = sj0array[ij0];
+                  {
+                    IkReal evalcond[2];
+                    IkReal x215 = ((IkReal(1.00000000000000)) * (sj1));
+                    evalcond[0] = ((new_r20) + (((IkReal(-1.00000000000000)) * (x215) * (IKcos(j0)))));
+                    evalcond[1] = ((((IkReal(-1.00000000000000)) * (x215) * (IKsin(j0)))) + (new_r21));
+                    if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001)
+                    {
+                      continue;
+                    }
+                  }
+
+                  {
+                    IkReal dummyeval[1];
+                    IkReal gconst17;
+                    gconst17 = IKsign((((new_r12) * (new_r12)) + ((new_r02) * (new_r02))));
+                    dummyeval[0] = (((new_r12) * (new_r12)) + ((new_r02) * (new_r02)));
+                    if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                    {
+                      {
+                        IkReal dummyeval[1];
+                        IkReal gconst16;
+                        gconst16 = IKsign(
+                            ((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) + (((new_r02) * (new_r10)))));
+                        dummyeval[0] =
+                            ((((IkReal(-1.00000000000000)) * (new_r00) * (new_r12))) + (((new_r02) * (new_r10))));
+                        if (IKabs(dummyeval[0]) < 0.0000010000000000)
+                        {
+                          continue;
+                        }
+                        else
+                        {
+                          {
+                            IkReal j2array[1], cj2array[1], sj2array[1];
+                            bool j2valid[1] = { false };
+                            _nj2 = 1;
+                            IkReal x216 = ((gconst16) * (sj0));
+                            if (IKabs(((new_r12) * (x216))) < IKFAST_ATAN2_MAGTHRESH &&
+                                IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x216))) < IKFAST_ATAN2_MAGTHRESH)
+                              continue;
+                            j2array[0] =
+                                IKatan2(((new_r12) * (x216)), ((IkReal(-1.00000000000000)) * (new_r02) * (x216)));
+                            sj2array[0] = IKsin(j2array[0]);
+                            cj2array[0] = IKcos(j2array[0]);
+                            if (j2array[0] > IKPI)
+                            {
+                              j2array[0] -= IK2PI;
+                            }
+                            else if (j2array[0] < -IKPI)
+                            {
+                              j2array[0] += IK2PI;
+                            }
+                            j2valid[0] = true;
+                            for (int ij2 = 0; ij2 < 1; ++ij2)
+                            {
+                              if (!j2valid[ij2])
+                              {
+                                continue;
+                              }
+                              _ij2[0] = ij2;
+                              _ij2[1] = -1;
+                              for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                              {
+                                if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                    IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                                {
+                                  j2valid[iij2] = false;
+                                  _ij2[1] = iij2;
+                                  break;
+                                }
+                              }
+                              j2 = j2array[ij2];
+                              cj2 = cj2array[ij2];
+                              sj2 = sj2array[ij2];
+                              {
+                                IkReal evalcond[12];
+                                IkReal x217 = IKsin(j2);
+                                IkReal x218 = IKcos(j2);
+                                IkReal x219 = ((IkReal(1.00000000000000)) * (cj0));
+                                IkReal x220 = ((IkReal(1.00000000000000)) * (cj1));
+                                IkReal x221 = ((IkReal(1.00000000000000)) * (x217));
+                                IkReal x222 = ((new_r01) * (x218));
+                                IkReal x223 = ((new_r00) * (x218));
+                                IkReal x224 = ((new_r02) * (x218));
+                                evalcond[0] = ((((new_r02) * (x217))) + (((new_r12) * (x218))));
+                                evalcond[1] = ((sj0) + (((new_r00) * (x217))) + (((new_r10) * (x218))));
+                                evalcond[2] = ((sj1) + (x224) + (((IkReal(-1.00000000000000)) * (new_r12) * (x221))));
+                                evalcond[3] = ((((new_r01) * (x217))) + (((IkReal(-1.00000000000000)) * (x219))) +
+                                               (((new_r11) * (x218))));
+                                evalcond[4] = ((((IkReal(-1.00000000000000)) * (cj1) * (x219))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r10) * (x221))) + (x223));
+                                evalcond[5] = ((((IkReal(-1.00000000000000)) * (new_r11) * (x221))) +
+                                               (((IkReal(-1.00000000000000)) * (sj0) * (x220))) + (x222));
+                                evalcond[6] = ((((IkReal(-1.00000000000000)) * (new_r12) * (x217) * (x220))) +
+                                               (((cj1) * (x224))) + (((new_r22) * (sj1))));
+                                evalcond[7] =
+                                    ((((IkReal(-1.00000000000000)) * (new_r10) * (sj1) * (x221))) + (((sj1) * (x223))) +
+                                     (((IkReal(-1.00000000000000)) * (new_r20) * (x220))));
+                                evalcond[8] =
+                                    ((((sj1) * (x222))) + (((IkReal(-1.00000000000000)) * (new_r11) * (sj1) * (x221))) +
+                                     (((IkReal(-1.00000000000000)) * (new_r21) * (x220))));
+                                evalcond[9] = ((IkReal(1.00000000000000)) + (((sj1) * (x224))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r22) * (x220))) +
+                                               (((IkReal(-1.00000000000000)) * (new_r12) * (sj1) * (x221))));
+                                evalcond[10] = ((((new_r20) * (sj1))) + (((cj1) * (x223))) +
+                                                (((IkReal(-1.00000000000000)) * (new_r10) * (x217) * (x220))) +
+                                                (((IkReal(-1.00000000000000)) * (x219))));
+                                evalcond[11] = ((((IkReal(-1.00000000000000)) * (sj0))) + (((cj1) * (x222))) +
+                                                (((IkReal(-1.00000000000000)) * (new_r11) * (x217) * (x220))) +
+                                                (((new_r21) * (sj1))));
+                                if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                    IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                    IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                    IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001 ||
+                                    IKabs(evalcond[8]) > 0.000001 || IKabs(evalcond[9]) > 0.000001 ||
+                                    IKabs(evalcond[10]) > 0.000001 || IKabs(evalcond[11]) > 0.000001)
+                                {
+                                  continue;
+                                }
+                              }
+
+                              {
+                                std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                                vinfos[0].jointtype = 1;
+                                vinfos[0].foffset = j0;
+                                vinfos[0].indices[0] = _ij0[0];
+                                vinfos[0].indices[1] = _ij0[1];
+                                vinfos[0].maxsolutions = _nj0;
+                                vinfos[1].jointtype = 1;
+                                vinfos[1].foffset = j1;
+                                vinfos[1].indices[0] = _ij1[0];
+                                vinfos[1].indices[1] = _ij1[1];
+                                vinfos[1].maxsolutions = _nj1;
+                                vinfos[2].jointtype = 1;
+                                vinfos[2].foffset = j2;
+                                vinfos[2].indices[0] = _ij2[0];
+                                vinfos[2].indices[1] = _ij2[1];
+                                vinfos[2].maxsolutions = _nj2;
+                                vinfos[3].jointtype = 1;
+                                vinfos[3].foffset = j3;
+                                vinfos[3].indices[0] = _ij3[0];
+                                vinfos[3].indices[1] = _ij3[1];
+                                vinfos[3].maxsolutions = _nj3;
+                                vinfos[4].jointtype = 1;
+                                vinfos[4].foffset = j4;
+                                vinfos[4].indices[0] = _ij4[0];
+                                vinfos[4].indices[1] = _ij4[1];
+                                vinfos[4].maxsolutions = _nj4;
+                                vinfos[5].jointtype = 1;
+                                vinfos[5].foffset = j5;
+                                vinfos[5].indices[0] = _ij5[0];
+                                vinfos[5].indices[1] = _ij5[1];
+                                vinfos[5].maxsolutions = _nj5;
+                                vinfos[6].jointtype = 1;
+                                vinfos[6].foffset = j6;
+                                vinfos[6].indices[0] = _ij6[0];
+                                vinfos[6].indices[1] = _ij6[1];
+                                vinfos[6].maxsolutions = _nj6;
+                                std::vector<int> vfree(0);
+                                solutions.AddSolution(vinfos, vfree);
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    else
+                    {
+                      {
+                        IkReal j2array[1], cj2array[1], sj2array[1];
+                        bool j2valid[1] = { false };
+                        _nj2 = 1;
+                        IkReal x225 = ((gconst17) * (sj1));
+                        if (IKabs(((new_r12) * (x225))) < IKFAST_ATAN2_MAGTHRESH &&
+                            IKabs(((IkReal(-1.00000000000000)) * (new_r02) * (x225))) < IKFAST_ATAN2_MAGTHRESH)
+                          continue;
+                        j2array[0] = IKatan2(((new_r12) * (x225)), ((IkReal(-1.00000000000000)) * (new_r02) * (x225)));
+                        sj2array[0] = IKsin(j2array[0]);
+                        cj2array[0] = IKcos(j2array[0]);
+                        if (j2array[0] > IKPI)
+                        {
+                          j2array[0] -= IK2PI;
+                        }
+                        else if (j2array[0] < -IKPI)
+                        {
+                          j2array[0] += IK2PI;
+                        }
+                        j2valid[0] = true;
+                        for (int ij2 = 0; ij2 < 1; ++ij2)
+                        {
+                          if (!j2valid[ij2])
+                          {
+                            continue;
+                          }
+                          _ij2[0] = ij2;
+                          _ij2[1] = -1;
+                          for (int iij2 = ij2 + 1; iij2 < 1; ++iij2)
+                          {
+                            if (j2valid[iij2] && IKabs(cj2array[ij2] - cj2array[iij2]) < IKFAST_SOLUTION_THRESH &&
+                                IKabs(sj2array[ij2] - sj2array[iij2]) < IKFAST_SOLUTION_THRESH)
+                            {
+                              j2valid[iij2] = false;
+                              _ij2[1] = iij2;
+                              break;
+                            }
+                          }
+                          j2 = j2array[ij2];
+                          cj2 = cj2array[ij2];
+                          sj2 = sj2array[ij2];
+                          {
+                            IkReal evalcond[12];
+                            IkReal x226 = IKsin(j2);
+                            IkReal x227 = IKcos(j2);
+                            IkReal x228 = ((IkReal(1.00000000000000)) * (cj0));
+                            IkReal x229 = ((IkReal(1.00000000000000)) * (cj1));
+                            IkReal x230 = ((IkReal(1.00000000000000)) * (x226));
+                            IkReal x231 = ((new_r01) * (x227));
+                            IkReal x232 = ((new_r00) * (x227));
+                            IkReal x233 = ((new_r02) * (x227));
+                            evalcond[0] = ((((new_r02) * (x226))) + (((new_r12) * (x227))));
+                            evalcond[1] = ((((new_r00) * (x226))) + (sj0) + (((new_r10) * (x227))));
+                            evalcond[2] = ((sj1) + (((IkReal(-1.00000000000000)) * (new_r12) * (x230))) + (x233));
+                            evalcond[3] = ((((new_r01) * (x226))) + (((new_r11) * (x227))) +
+                                           (((IkReal(-1.00000000000000)) * (x228))));
+                            evalcond[4] = ((x232) + (((IkReal(-1.00000000000000)) * (cj1) * (x228))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r10) * (x230))));
+                            evalcond[5] = ((((IkReal(-1.00000000000000)) * (sj0) * (x229))) + (x231) +
+                                           (((IkReal(-1.00000000000000)) * (new_r11) * (x230))));
+                            evalcond[6] = ((((IkReal(-1.00000000000000)) * (new_r12) * (x226) * (x229))) +
+                                           (((cj1) * (x233))) + (((new_r22) * (sj1))));
+                            evalcond[7] = ((((sj1) * (x232))) + (((IkReal(-1.00000000000000)) * (new_r20) * (x229))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r10) * (sj1) * (x230))));
+                            evalcond[8] =
+                                ((((sj1) * (x231))) + (((IkReal(-1.00000000000000)) * (new_r11) * (sj1) * (x230))) +
+                                 (((IkReal(-1.00000000000000)) * (new_r21) * (x229))));
+                            evalcond[9] = ((IkReal(1.00000000000000)) + (((sj1) * (x233))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r22) * (x229))) +
+                                           (((IkReal(-1.00000000000000)) * (new_r12) * (sj1) * (x230))));
+                            evalcond[10] = ((((cj1) * (x232))) + (((new_r20) * (sj1))) +
+                                            (((IkReal(-1.00000000000000)) * (new_r10) * (x226) * (x229))) +
+                                            (((IkReal(-1.00000000000000)) * (x228))));
+                            evalcond[11] =
+                                ((((cj1) * (x231))) + (((IkReal(-1.00000000000000)) * (sj0))) +
+                                 (((IkReal(-1.00000000000000)) * (new_r11) * (x226) * (x229))) + (((new_r21) * (sj1))));
+                            if (IKabs(evalcond[0]) > 0.000001 || IKabs(evalcond[1]) > 0.000001 ||
+                                IKabs(evalcond[2]) > 0.000001 || IKabs(evalcond[3]) > 0.000001 ||
+                                IKabs(evalcond[4]) > 0.000001 || IKabs(evalcond[5]) > 0.000001 ||
+                                IKabs(evalcond[6]) > 0.000001 || IKabs(evalcond[7]) > 0.000001 ||
+                                IKabs(evalcond[8]) > 0.000001 || IKabs(evalcond[9]) > 0.000001 ||
+                                IKabs(evalcond[10]) > 0.000001 || IKabs(evalcond[11]) > 0.000001)
+                            {
+                              continue;
+                            }
+                          }
+
+                          {
+                            std::vector<IkSingleDOFSolutionBase<IkReal> > vinfos(7);
+                            vinfos[0].jointtype = 1;
+                            vinfos[0].foffset = j0;
+                            vinfos[0].indices[0] = _ij0[0];
+                            vinfos[0].indices[1] = _ij0[1];
+                            vinfos[0].maxsolutions = _nj0;
+                            vinfos[1].jointtype = 1;
+                            vinfos[1].foffset = j1;
+                            vinfos[1].indices[0] = _ij1[0];
+                            vinfos[1].indices[1] = _ij1[1];
+                            vinfos[1].maxsolutions = _nj1;
+                            vinfos[2].jointtype = 1;
+                            vinfos[2].foffset = j2;
+                            vinfos[2].indices[0] = _ij2[0];
+                            vinfos[2].indices[1] = _ij2[1];
+                            vinfos[2].maxsolutions = _nj2;
+                            vinfos[3].jointtype = 1;
+                            vinfos[3].foffset = j3;
+                            vinfos[3].indices[0] = _ij3[0];
+                            vinfos[3].indices[1] = _ij3[1];
+                            vinfos[3].maxsolutions = _nj3;
+                            vinfos[4].jointtype = 1;
+                            vinfos[4].foffset = j4;
+                            vinfos[4].indices[0] = _ij4[0];
+                            vinfos[4].indices[1] = _ij4[1];
+                            vinfos[4].maxsolutions = _nj4;
+                            vinfos[5].jointtype = 1;
+                            vinfos[5].foffset = j5;
+                            vinfos[5].indices[0] = _ij5[0];
+                            vinfos[5].indices[1] = _ij5[1];
+                            vinfos[5].maxsolutions = _nj5;
+                            vinfos[6].jointtype = 1;
+                            vinfos[6].foffset = j6;
+                            vinfos[6].indices[0] = _ij6[0];
+                            vinfos[6].indices[1] = _ij6[1];
+                            vinfos[6].maxsolutions = _nj6;
+                            std::vector<int> vfree(0);
+                            solutions.AddSolution(vinfos, vfree);
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
 
 /// solves the inverse kinematics equations.
 /// \param pfree is an array specifying the free joints of the chain.
-IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree, IkSolutionListBase<IkReal>& solutions) {
-IKSolver solver;
-return solver.ComputeIk(eetrans,eerot,pfree,solutions);
+IKFAST_API bool ComputeIk(const IkReal* eetrans, const IkReal* eerot, const IkReal* pfree,
+                          IkSolutionListBase<IkReal>& solutions)
+{
+  IKSolver solver;
+  return solver.ComputeIk(eetrans, eerot, pfree, solutions);
 }
 
-IKFAST_API const char* GetKinematicsHash() { return "<robot:genericrobot - motoman_sia20d (72a5dabf099b6c11c75f8620052123af)>"; }
+IKFAST_API const char* GetKinematicsHash()
+{
+  return "<robot:genericrobot - motoman_sia20d (72a5dabf099b6c11c75f8620052123af)>";
+}
 
-IKFAST_API const char* GetIkFastVersion() { return IKFAST_STRINGIZE(IKFAST_VERSION); }
+IKFAST_API const char* GetIkFastVersion()
+{
+  return IKFAST_STRINGIZE(IKFAST_VERSION);
+}
 
 #ifdef IKFAST_NAMESPACE
-} // end namespace
+}  // end namespace
 #endif
 
 #ifndef IKFAST_NO_MAIN
@@ -4253,41 +5595,54 @@ using namespace IKFAST_NAMESPACE;
 #endif
 int main(int argc, char** argv)
 {
-    if( argc != 12+GetNumFreeParameters()+1 ) {
-        printf("\nUsage: ./ik r00 r01 r02 t0 r10 r11 r12 t1 r20 r21 r22 t2 free0 ...\n\n"
-               "Returns the ik solutions given the transformation of the end effector specified by\n"
-               "a 3x3 rotation R (rXX), and a 3x1 translation (tX).\n"
-               "There are %d free parameters that have to be specified.\n\n",GetNumFreeParameters());
-        return 1;
-    }
+  if (argc != 12 + GetNumFreeParameters() + 1)
+  {
+    printf("\nUsage: ./ik r00 r01 r02 t0 r10 r11 r12 t1 r20 r21 r22 t2 free0 ...\n\n"
+           "Returns the ik solutions given the transformation of the end effector specified by\n"
+           "a 3x3 rotation R (rXX), and a 3x1 translation (tX).\n"
+           "There are %d free parameters that have to be specified.\n\n",
+           GetNumFreeParameters());
+    return 1;
+  }
 
-    IkSolutionList<IkReal> solutions;
-    std::vector<IkReal> vfree(GetNumFreeParameters());
-    IkReal eerot[9],eetrans[3];
-    eerot[0] = atof(argv[1]); eerot[1] = atof(argv[2]); eerot[2] = atof(argv[3]); eetrans[0] = atof(argv[4]);
-    eerot[3] = atof(argv[5]); eerot[4] = atof(argv[6]); eerot[5] = atof(argv[7]); eetrans[1] = atof(argv[8]);
-    eerot[6] = atof(argv[9]); eerot[7] = atof(argv[10]); eerot[8] = atof(argv[11]); eetrans[2] = atof(argv[12]);
-    for(std::size_t i = 0; i < vfree.size(); ++i)
-        vfree[i] = atof(argv[13+i]);
-    bool bSuccess = ComputeIk(eetrans, eerot, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
+  IkSolutionList<IkReal> solutions;
+  std::vector<IkReal> vfree(GetNumFreeParameters());
+  IkReal eerot[9], eetrans[3];
+  eerot[0] = atof(argv[1]);
+  eerot[1] = atof(argv[2]);
+  eerot[2] = atof(argv[3]);
+  eetrans[0] = atof(argv[4]);
+  eerot[3] = atof(argv[5]);
+  eerot[4] = atof(argv[6]);
+  eerot[5] = atof(argv[7]);
+  eetrans[1] = atof(argv[8]);
+  eerot[6] = atof(argv[9]);
+  eerot[7] = atof(argv[10]);
+  eerot[8] = atof(argv[11]);
+  eetrans[2] = atof(argv[12]);
+  for (std::size_t i = 0; i < vfree.size(); ++i)
+    vfree[i] = atof(argv[13 + i]);
+  bool bSuccess = ComputeIk(eetrans, eerot, vfree.size() > 0 ? &vfree[0] : NULL, solutions);
 
-    if( !bSuccess ) {
-        fprintf(stderr,"Failed to get ik solution\n");
-        return -1;
-    }
+  if (!bSuccess)
+  {
+    fprintf(stderr, "Failed to get ik solution\n");
+    return -1;
+  }
 
-    printf("Found %d ik solutions:\n", (int)solutions.GetNumSolutions());
-    std::vector<IkReal> solvalues(GetNumJoints());
-    for(std::size_t i = 0; i < solutions.GetNumSolutions(); ++i) {
-        const IkSolutionBase<IkReal>& sol = solutions.GetSolution(i);
-        printf("sol%d (free=%d): ", (int)i, (int)sol.GetFree().size());
-        std::vector<IkReal> vsolfree(sol.GetFree().size());
-        sol.GetSolution(&solvalues[0],vsolfree.size()>0?&vsolfree[0]:NULL);
-        for( std::size_t j = 0; j < solvalues.size(); ++j)
-            printf("%.15f, ", solvalues[j]);
-        printf("\n");
-    }
-    return 0;
+  printf("Found %d ik solutions:\n", (int)solutions.GetNumSolutions());
+  std::vector<IkReal> solvalues(GetNumJoints());
+  for (std::size_t i = 0; i < solutions.GetNumSolutions(); ++i)
+  {
+    const IkSolutionBase<IkReal>& sol = solutions.GetSolution(i);
+    printf("sol%d (free=%d): ", (int)i, (int)sol.GetFree().size());
+    std::vector<IkReal> vsolfree(sol.GetFree().size());
+    sol.GetSolution(&solvalues[0], vsolfree.size() > 0 ? &vsolfree[0] : NULL);
+    for (std::size_t j = 0; j < solvalues.size(); ++j)
+      printf("%.15f, ", solvalues[j]);
+    printf("\n");
+  }
+  return 0;
 }
 
 #endif


### PR DESCRIPTION
In reviewing https://github.com/ros-planning/moveit_kinematics_tests/pull/10 I realized this repo has not been clang-formatted as the rest of moveit has, so I ran the script here in a separate PR so that my request [here](https://github.com/ros-planning/moveit_kinematics_tests/pull/10#discussion_r123886929) doesn't cause too many changes in the same PR. This should be merged first, and @nsnitish should run clang-format on his PR also